### PR TITLE
fix: CSP img-src and camera permissions policy

### DIFF
--- a/internal/server/security.go
+++ b/internal/server/security.go
@@ -28,11 +28,11 @@ func securityHeaders(cfg SecurityConfig) func(http.Handler) http.Handler {
 			w.Header().Set("Referrer-Policy", "no-referrer")
 			w.Header().Set("X-Content-Type-Options", "nosniff")
 			w.Header().Set("X-Frame-Options", "SAMEORIGIN")
-			w.Header().Set("Permissions-Policy", "camera=(), microphone=(self), geolocation=(), screen-wake-lock=(), display-capture=(self)")
+			w.Header().Set("Permissions-Policy", "camera=(self), microphone=(self), geolocation=(), screen-wake-lock=(), display-capture=(self)")
 
 			csp := fmt.Sprintf(
-				"default-src 'self'; img-src 'self' data:; media-src 'self' data:%s; script-src 'self' 'nonce-%s'; style-src 'self' 'nonce-%s'; connect-src 'self'%s;",
-				storageSuffix, nonce, nonce, storageSuffix,
+				"default-src 'self'; img-src 'self' data:%s; media-src 'self' data:%s; script-src 'self' 'nonce-%s'; style-src 'self' 'nonce-%s'; connect-src 'self'%s;",
+				storageSuffix, storageSuffix, nonce, nonce, storageSuffix,
 			)
 			w.Header().Set("Content-Security-Policy", csp)
 

--- a/internal/server/security_test.go
+++ b/internal/server/security_test.go
@@ -61,6 +61,9 @@ func TestSecurityHeaders_CSPIncludesStorageEndpoint(t *testing.T) {
 	if !strings.Contains(csp, "media-src 'self' data: https://storage.example.com") {
 		t.Errorf("CSP media-src should include storage endpoint, got: %s", csp)
 	}
+	if !strings.Contains(csp, "img-src 'self' data: https://storage.example.com") {
+		t.Errorf("CSP img-src should include storage endpoint, got: %s", csp)
+	}
 }
 
 func TestSecurityHeaders_CSPOmitsStorageWhenEmpty(t *testing.T) {
@@ -122,6 +125,9 @@ func TestSecurityHeaders_PermissionsPolicyAllowsMicrophone(t *testing.T) {
 	pp := rec.Header().Get("Permissions-Policy")
 	if !strings.Contains(pp, "microphone=(self)") {
 		t.Errorf("Permissions-Policy should allow microphone=(self), got: %s", pp)
+	}
+	if !strings.Contains(pp, "camera=(self)") {
+		t.Errorf("Permissions-Policy should allow camera=(self), got: %s", pp)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Add storage endpoint to CSP `img-src` directive so thumbnails from `storage.sendrec.eu` load
- Change `camera=()` to `camera=(self)` in Permissions-Policy so `getDisplayMedia` works in Chrome

## Test plan

- [x] Library page loads thumbnails without CSP violation
- [x] Screen recording works without Permissions-Policy violation