### PR TITLE
Add deploy workflows for preview, staging, and production

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -1,0 +1,78 @@
+name: Deploy Preview
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, closed]
+
+permissions:
+  pull-requests: write
+
+concurrency:
+  group: preview-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    if: github.event.pull_request.author_association != 'NONE' && github.event.pull_request.author_association != 'FIRST_TIMER' && github.event.pull_request.author_association != 'FIRST_TIME_CONTRIBUTOR'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup SSH
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.DEPLOY_SSH_KEY }}" > ~/.ssh/deploy_key
+          chmod 600 ~/.ssh/deploy_key
+          echo "${{ secrets.DEPLOY_KNOWN_HOSTS }}" >> ~/.ssh/known_hosts
+
+      - name: Deploy preview
+        if: github.event.action != 'closed'
+        run: |
+          ssh -i ~/.ssh/deploy_key ${{ secrets.DEPLOY_USER }}@${{ secrets.DEPLOY_HOST }} \
+            "/opt/sendrec/deploy.sh preview up ${{ github.event.pull_request.number }} ${{ github.event.pull_request.head.ref }}"
+
+      - name: Teardown preview
+        if: github.event.action == 'closed'
+        run: |
+          ssh -i ~/.ssh/deploy_key ${{ secrets.DEPLOY_USER }}@${{ secrets.DEPLOY_HOST }} \
+            "/opt/sendrec/deploy.sh preview down ${{ github.event.pull_request.number }}"
+
+      - name: Comment PR with preview URL
+        if: github.event.action != 'closed'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const prNumber = context.payload.pull_request.number;
+            const url = `https://pr-${prNumber}.app.sendrec.eu`;
+            const body = `Preview deployed: ${url}`;
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+            });
+            const existing = comments.find(c => c.body.startsWith('Preview deployed:'));
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+                body,
+              });
+            }
+
+      - name: Comment PR cleanup
+        if: github.event.action == 'closed'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              body: 'Preview environment cleaned up.',
+            });

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -1,0 +1,25 @@
+name: Deploy Production
+
+on:
+  push:
+    tags: ['v*']
+
+concurrency:
+  group: deploy-production
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment: production
+    steps:
+      - name: Setup SSH
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.DEPLOY_SSH_KEY }}" > ~/.ssh/deploy_key
+          chmod 600 ~/.ssh/deploy_key
+          echo "${{ secrets.DEPLOY_KNOWN_HOSTS }}" >> ~/.ssh/known_hosts
+
+      - name: Deploy production
+        run: |
+          ssh -i ~/.ssh/deploy_key ${{ secrets.DEPLOY_USER }}@${{ secrets.DEPLOY_HOST }} \
+            "/opt/sendrec/deploy.sh production ${{ github.ref_name }}"

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -1,0 +1,26 @@
+name: Deploy Staging
+
+on:
+  push:
+    branches: [main]
+
+concurrency:
+  group: deploy-staging
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment: staging
+    steps:
+      - name: Setup SSH
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.DEPLOY_SSH_KEY }}" > ~/.ssh/deploy_key
+          chmod 600 ~/.ssh/deploy_key
+          echo "${{ secrets.DEPLOY_KNOWN_HOSTS }}" >> ~/.ssh/known_hosts
+
+      - name: Deploy staging
+        run: |
+          ssh -i ~/.ssh/deploy_key ${{ secrets.DEPLOY_USER }}@${{ secrets.DEPLOY_HOST }} \
+            "/opt/sendrec/deploy.sh staging"

--- a/README.md
+++ b/README.md
@@ -53,8 +53,10 @@ make test
 - `DATABASE_URL` – required
 - `JWT_SECRET` – required
 - `S3_ENDPOINT`, `S3_BUCKET`, `S3_ACCESS_KEY`, `S3_SECRET_KEY`, `S3_REGION` (defaults to EU region)
+- `S3_PUBLIC_ENDPOINT` – public URL for S3 (used for presigned URLs)
 - `BASE_URL` – used for CORS and share links
 - `MAX_UPLOAD_BYTES` – max allowed upload size (bytes), defaults to 500MB
+- `LISTMONK_BASE_URL`, `LISTMONK_USERNAME`, `LISTMONK_PASSWORD`, `LISTMONK_TEMPLATE_ID` – email (optional)
 
 ## Architecture
 
@@ -65,6 +67,28 @@ Single Go binary that:
 - Runs database migrations on startup
 
 Video recordings happen entirely in the browser using `getDisplayMedia` + `MediaRecorder`. Files upload directly to S3 via presigned URLs — the server never touches video bytes.
+
+## Deployment
+
+Deployments are automated via GitHub Actions. Three environments are available:
+
+| Environment | URL | Trigger |
+|-------------|-----|---------|
+| **Preview** | `pr-{N}.app.sendrec.eu` | PR opened/updated (write-access authors only, max 3 concurrent) |
+| **Staging** | `staging.app.sendrec.eu` | Push to `main` |
+| **Production** | `app.sendrec.eu` | Push a git tag (`v*`) |
+
+### Deploying to production
+
+1. Merge your PR to `main` — staging deploys automatically
+2. Verify on `staging.app.sendrec.eu`
+3. Tag and push:
+   ```bash
+   git tag v1.0.0
+   git push origin v1.0.0
+   ```
+
+Preview environments are cleaned up automatically when the PR is closed.
 
 ## License
 


### PR DESCRIPTION
## Summary

- Adds three GitHub Actions deploy workflows (preview, staging, production)
- Preview environments deploy per-PR at `pr-{N}.app.sendrec.eu` (write-access authors only, max 3 concurrent)
- Staging auto-deploys on push to `main` at `staging.app.sendrec.eu`
- Production deploys on git tag (`v*`) with required reviewer approval
- Updates README with deployment docs and missing env vars

## Server-side setup (already done)

- Staging DB added to docker-compose
- Caddy admin API enabled for dynamic preview routes
- Staging route configured in Caddyfile
- Deploy script created at `/opt/sendrec/deploy.sh`
- GitHub secrets configured (DEPLOY_SSH_KEY, DEPLOY_HOST, DEPLOY_USER, DEPLOY_KNOWN_HOSTS)
- GitHub environments created (preview, staging, production with reviewer)

## Manual step required

Add wildcard DNS A record in Cloudflare: `*.app.sendrec.eu` → server IP (DNS only, grey cloud)

## Test plan

- [x] Merge this PR — staging deploy workflow should trigger
- [x] Verify `staging.app.sendrec.eu` loads
- [x] Create test PR — preview deploy should trigger
- [x] Verify preview URL loads
- [x] Close test PR — preview cleanup should trigger
- [x] Tag `v1.0.0` — production deploy should trigger (requires approval)