### PR TITLE
feat: enforce free tier limits (25 videos/month, 5 min max)

### DIFF
--- a/cmd/sendrec/main.go
+++ b/cmd/sendrec/main.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/sendrec/sendrec/internal/database"
 	"github.com/sendrec/sendrec/internal/email"
+	"github.com/sendrec/sendrec/internal/plans"
 	"github.com/sendrec/sendrec/internal/server"
 	"github.com/sendrec/sendrec/internal/storage"
 	"github.com/sendrec/sendrec/internal/video"
@@ -94,15 +95,17 @@ func main() {
 	})
 
 	srv := server.New(server.Config{
-		DB:              db.Pool,
-		Pinger:          db,
-		Storage:         store,
-		WebFS:           webFS,
-		JWTSecret:       jwtSecret,
-		BaseURL:         baseURL,
-		MaxUploadBytes:  getEnvInt64("MAX_UPLOAD_BYTES", 500*1024*1024),
-		S3PublicEndpoint: os.Getenv("S3_PUBLIC_ENDPOINT"),
-		EmailSender:     emailClient,
+		DB:                      db.Pool,
+		Pinger:                  db,
+		Storage:                 store,
+		WebFS:                   webFS,
+		JWTSecret:               jwtSecret,
+		BaseURL:                 baseURL,
+		MaxUploadBytes:          getEnvInt64("MAX_UPLOAD_BYTES", 500*1024*1024),
+		MaxVideosPerMonth:       int(getEnvInt64("MAX_VIDEOS_PER_MONTH", int64(plans.Free.MaxVideosPerMonth))),
+		MaxVideoDurationSeconds: int(getEnvInt64("MAX_VIDEO_DURATION_SECONDS", int64(plans.Free.MaxVideoDurationSeconds))),
+		S3PublicEndpoint:        os.Getenv("S3_PUBLIC_ENDPOINT"),
+		EmailSender:             emailClient,
 	})
 
 	cleanupCtx, cleanupCancel := context.WithCancel(context.Background())

--- a/internal/plans/free.json
+++ b/internal/plans/free.json
@@ -1,0 +1,4 @@
+{
+  "maxVideosPerMonth": 25,
+  "maxVideoDurationSeconds": 300
+}

--- a/internal/plans/plans.go
+++ b/internal/plans/plans.go
@@ -1,0 +1,23 @@
+package plans
+
+import (
+	_ "embed"
+	"encoding/json"
+	"log"
+)
+
+//go:embed free.json
+var freeJSON []byte
+
+type FreePlan struct {
+	MaxVideosPerMonth       int `json:"maxVideosPerMonth"`
+	MaxVideoDurationSeconds int `json:"maxVideoDurationSeconds"`
+}
+
+var Free FreePlan
+
+func init() {
+	if err := json.Unmarshal(freeJSON, &Free); err != nil {
+		log.Fatalf("failed to parse free.json: %v", err)
+	}
+}

--- a/web/src/pages/Record.test.tsx
+++ b/web/src/pages/Record.test.tsx
@@ -1,0 +1,104 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { Record } from "./Record";
+
+const mockApiFetch = vi.fn();
+
+vi.mock("../api/client", () => ({
+  apiFetch: (...args: unknown[]) => mockApiFetch(...args),
+}));
+
+// Mock Recorder to avoid browser API dependencies
+vi.mock("../components/Recorder", () => ({
+  Recorder: ({ maxDurationSeconds }: { maxDurationSeconds?: number }) => (
+    <div data-testid="recorder" data-max-duration={maxDurationSeconds ?? ""}>
+      Mock Recorder
+    </div>
+  ),
+}));
+
+function renderRecord() {
+  return render(
+    <MemoryRouter>
+      <Record />
+    </MemoryRouter>
+  );
+}
+
+describe("Record", () => {
+  beforeEach(() => {
+    mockApiFetch.mockReset();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("shows limit reached message when monthly quota is full", async () => {
+    mockApiFetch.mockResolvedValueOnce({
+      maxVideosPerMonth: 25,
+      maxVideoDurationSeconds: 300,
+      videosUsedThisMonth: 25,
+    });
+    renderRecord();
+
+    await waitFor(() => {
+      expect(screen.getByText(/reached your limit of 25 videos/i)).toBeInTheDocument();
+    });
+    expect(screen.queryByTestId("recorder")).not.toBeInTheDocument();
+  });
+
+  it("shows recorder when below monthly limit", async () => {
+    mockApiFetch.mockResolvedValueOnce({
+      maxVideosPerMonth: 25,
+      maxVideoDurationSeconds: 300,
+      videosUsedThisMonth: 10,
+    });
+    renderRecord();
+
+    await waitFor(() => {
+      expect(screen.getByTestId("recorder")).toBeInTheDocument();
+    });
+  });
+
+  it("passes maxDurationSeconds to Recorder", async () => {
+    mockApiFetch.mockResolvedValueOnce({
+      maxVideosPerMonth: 25,
+      maxVideoDurationSeconds: 300,
+      videosUsedThisMonth: 10,
+    });
+    renderRecord();
+
+    await waitFor(() => {
+      expect(screen.getByTestId("recorder")).toHaveAttribute("data-max-duration", "300");
+    });
+  });
+
+  it("shows recorder without duration limit when unlimited", async () => {
+    mockApiFetch.mockResolvedValueOnce({
+      maxVideosPerMonth: 0,
+      maxVideoDurationSeconds: 0,
+      videosUsedThisMonth: 0,
+    });
+    renderRecord();
+
+    await waitFor(() => {
+      expect(screen.getByTestId("recorder")).toBeInTheDocument();
+      expect(screen.getByTestId("recorder")).toHaveAttribute("data-max-duration", "0");
+    });
+  });
+
+  it("shows remaining videos count when limits active", async () => {
+    mockApiFetch.mockResolvedValueOnce({
+      maxVideosPerMonth: 25,
+      maxVideoDurationSeconds: 300,
+      videosUsedThisMonth: 20,
+    });
+    renderRecord();
+
+    await waitFor(() => {
+      expect(screen.getByText(/5 videos remaining/i)).toBeInTheDocument();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Add backend enforcement of monthly video quota (25/month) and max duration (5 min) with configurable env var overrides (0 = unlimited for self-hosted)
- New `GET /api/videos/limits` endpoint serves limits and current usage to the frontend
- Single source of truth: `internal/plans/free.json` defines defaults, embedded at compile time
- Frontend: Record page blocks when quota reached, Recorder auto-stops at max duration, Library shows usage indicator
- 11 new backend tests, 7 new frontend tests (TDD)

## Test plan

- [x] `make test` — all Go tests pass (including 11 new limit tests)
- [x] `cd web && pnpm test` — 65 frontend tests pass (7 new)
- [x] `cd web && pnpm typecheck && pnpm build` — clean
- [x] CI passes on this PR
- [x] Manual: verify limits enforce on Record page with env vars set
- [x] Manual: verify Library shows usage count
- [x] Manual: verify self-hosted (env vars = 0) has no limits