### PR TITLE
fix: show usage indicator in Library empty state

### DIFF
--- a/web/src/pages/Library.test.tsx
+++ b/web/src/pages/Library.test.tsx
@@ -208,6 +208,20 @@ describe("Library", () => {
     });
   });
 
+  it("shows usage indicator in empty state when limits are active", async () => {
+    mockFetch([], {
+      maxVideosPerMonth: 25,
+      maxVideoDurationSeconds: 300,
+      videosUsedThisMonth: 10,
+    });
+    renderLibrary();
+
+    await waitFor(() => {
+      expect(screen.getByText("No recordings yet.")).toBeInTheDocument();
+    });
+    expect(screen.getByText(/10 \/ 25 videos this month/i)).toBeInTheDocument();
+  });
+
   it("hides usage indicator when limits are unlimited", async () => {
     mockFetch([makeVideo()]);
     renderLibrary();

--- a/web/src/pages/Library.tsx
+++ b/web/src/pages/Library.tsx
@@ -143,6 +143,11 @@ export function Library() {
         >
           Create your first recording
         </Link>
+        {limits && limits.maxVideosPerMonth > 0 && (
+          <p style={{ color: "var(--color-text-secondary)", fontSize: 13, marginTop: 16 }}>
+            {limits.videosUsedThisMonth} / {limits.maxVideosPerMonth} videos this month
+          </p>
+        )}
       </div>
     );
   }


### PR DESCRIPTION
## Summary

- Show video usage count (X / 25 videos this month) in Library empty state, not just when videos exist

## Test plan

- [x] New test: "shows usage indicator in empty state when limits are active"
- [x] All 66 frontend tests pass