### PR TITLE
feat: add video download with Content-Disposition attachment

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -114,8 +114,10 @@ func (s *Server) routes() {
 			r.Patch("/{id}", s.videoHandler.Update)
 			r.Delete("/{id}", s.videoHandler.Delete)
 			r.Post("/{id}/extend", s.videoHandler.Extend)
+			r.Get("/{id}/download", s.videoHandler.Download)
 		})
 		s.router.Get("/api/watch/{shareToken}", s.videoHandler.Watch)
+		s.router.Get("/api/watch/{shareToken}/download", s.videoHandler.WatchDownload)
 		s.router.Get("/watch/{shareToken}", s.videoHandler.WatchPage)
 	}
 

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -30,6 +30,10 @@ func (m *mockStorage) GenerateDownloadURL(ctx context.Context, key string, expir
 	return "https://example.com/download", nil
 }
 
+func (m *mockStorage) GenerateDownloadURLWithDisposition(ctx context.Context, key string, filename string, expiry time.Duration) (string, error) {
+	return "https://example.com/download?disposition=attachment", nil
+}
+
 func (m *mockStorage) DeleteObject(ctx context.Context, key string) error {
 	return nil
 }

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -104,6 +104,20 @@ func (s *Storage) GenerateDownloadURL(ctx context.Context, key string, expiry ti
 	return req.URL, nil
 }
 
+func (s *Storage) GenerateDownloadURLWithDisposition(ctx context.Context, key string, filename string, expiry time.Duration) (string, error) {
+	disposition := fmt.Sprintf(`attachment; filename="%s"`, filename)
+	req, err := s.presigner.PresignGetObject(ctx, &s3.GetObjectInput{
+		Bucket:                     aws.String(s.bucket),
+		Key:                        aws.String(key),
+		ResponseContentDisposition: aws.String(disposition),
+	}, s3.WithPresignExpires(expiry))
+	if err != nil {
+		return "", fmt.Errorf("presign download: %w", err)
+	}
+
+	return req.URL, nil
+}
+
 func (s *Storage) DeleteObject(ctx context.Context, key string) error {
 	_, err := s.client.DeleteObject(ctx, &s3.DeleteObjectInput{
 		Bucket: aws.String(s.bucket),

--- a/internal/video/watch_page.go
+++ b/internal/video/watch_page.go
@@ -65,6 +65,24 @@ var watchPageTemplate = template.Must(template.New("watch").Parse(`<!DOCTYPE htm
         .branding a:hover {
             text-decoration: underline;
         }
+        .actions {
+            margin-top: 1rem;
+        }
+        .download-btn {
+            display: inline-block;
+            background: transparent;
+            color: #00b67a;
+            border: 1px solid #00b67a;
+            padding: 0.5rem 1.25rem;
+            border-radius: 6px;
+            font-size: 0.875rem;
+            font-weight: 600;
+            cursor: pointer;
+            text-decoration: none;
+        }
+        .download-btn:hover {
+            background: rgba(0, 182, 122, 0.1);
+        }
     </style>
 </head>
 <body>
@@ -79,6 +97,16 @@ var watchPageTemplate = template.Must(template.New("watch").Parse(`<!DOCTYPE htm
         </script>
         <h1>{{.Title}}</h1>
         <p class="meta">{{.Creator}} · {{.Date}}</p>
+        <div class="actions">
+            <button class="download-btn" id="download-btn">Download</button>
+        </div>
+        <script nonce="{{.Nonce}}">
+            document.getElementById('download-btn').addEventListener('click', function() {
+                fetch('/api/watch/{{.ShareToken}}/download')
+                    .then(function(r) { return r.json(); })
+                    .then(function(data) { if (data.downloadUrl) window.location.href = data.downloadUrl; });
+            });
+        </script>
         <p class="branding">Shared via <a href="https://sendrec.eu">SendRec</a> — open-source video messaging</p>
     </div>
 </body>
@@ -132,6 +160,7 @@ type watchPageData struct {
 	Date         string
 	Nonce        string
 	ThumbnailURL string
+	ShareToken   string
 }
 
 type expiredPageData struct {
@@ -192,6 +221,7 @@ func (h *Handler) WatchPage(w http.ResponseWriter, r *http.Request) {
 		Date:         createdAt.Format("Jan 2, 2006"),
 		Nonce:        nonce,
 		ThumbnailURL: thumbnailURL,
+		ShareToken:   shareToken,
 	}); err != nil {
 		log.Printf("failed to render watch page: %v", err)
 	}

--- a/web/src/pages/Library.test.tsx
+++ b/web/src/pages/Library.test.tsx
@@ -231,4 +231,30 @@ describe("Library", () => {
     });
     expect(screen.queryByText(/videos this month/i)).not.toBeInTheDocument();
   });
+
+  it("renders download button for ready videos", async () => {
+    mockFetch([makeVideo()]);
+    renderLibrary();
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Download" })).toBeInTheDocument();
+    });
+  });
+
+  it("triggers download API call on click", async () => {
+    const user = userEvent.setup();
+    mockFetch([makeVideo()]);
+    mockApiFetch.mockResolvedValueOnce({ downloadUrl: "https://s3.example.com/download" });
+    renderLibrary();
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Download" })).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole("button", { name: "Download" }));
+
+    await waitFor(() => {
+      expect(mockApiFetch).toHaveBeenCalledWith("/api/videos/v1/download");
+    });
+  });
 });

--- a/web/src/pages/Library.tsx
+++ b/web/src/pages/Library.tsx
@@ -52,6 +52,7 @@ export function Library() {
   const [deletingId, setDeletingId] = useState<string | null>(null);
   const [extendingId, setExtendingId] = useState<string | null>(null);
   const [copiedId, setCopiedId] = useState<string | null>(null);
+  const [downloadingId, setDownloadingId] = useState<string | null>(null);
   const [limits, setLimits] = useState<LimitsResponse | null>(null);
 
   useEffect(() => {
@@ -103,6 +104,18 @@ export function Library() {
       document.body.removeChild(textArea);
       setCopiedId(videoId);
       setTimeout(() => setCopiedId(null), 2000);
+    }
+  }
+
+  async function downloadVideo(id: string) {
+    setDownloadingId(id);
+    try {
+      const resp = await apiFetch<{ downloadUrl: string }>(`/api/videos/${id}/download`);
+      if (resp?.downloadUrl) {
+        window.location.href = resp.downloadUrl;
+      }
+    } finally {
+      setDownloadingId(null);
     }
   }
 
@@ -278,6 +291,22 @@ export function Library() {
                     }}
                   >
                     {copiedId === video.id ? "Copied!" : "Copy link"}
+                  </button>
+                  <button
+                    onClick={() => downloadVideo(video.id)}
+                    disabled={downloadingId === video.id}
+                    style={{
+                      background: "transparent",
+                      color: "var(--color-accent)",
+                      border: "1px solid var(--color-accent)",
+                      borderRadius: 4,
+                      padding: "6px 14px",
+                      fontSize: 13,
+                      fontWeight: 600,
+                      opacity: downloadingId === video.id ? 0.7 : 1,
+                    }}
+                  >
+                    {downloadingId === video.id ? "Downloading..." : "Download"}
                   </button>
                   <button
                     onClick={() => extendVideo(video.id)}


### PR DESCRIPTION
## Summary
- Add authenticated download endpoint (`GET /api/videos/{id}/download`) for video owners
- Add public download endpoint (`GET /api/watch/{shareToken}/download`) for anyone with a valid share link
- Both return presigned S3 URLs with `Content-Disposition: attachment` header to trigger browser downloads
- Download buttons added to Library page and Watch page HTML template

## Test plan
- [x] 7 new Go tests (Download success/not found/storage error, WatchDownload success/not found/expired, WatchPage download button)
- [x] 2 new frontend tests (download button renders, triggers API call)
- [x] All existing tests pass (`go test ./...`, `pnpm test`)
- [x] TypeScript typecheck and build pass
- [x] Manual: record a video, verify download from Library and Watch page