### PR TITLE
feat: add password-protected share links

### DIFF
--- a/internal/video/watch_auth.go
+++ b/internal/video/watch_auth.go
@@ -1,0 +1,107 @@
+package video
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"net/http"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/sendrec/sendrec/internal/httputil"
+	"golang.org/x/crypto/bcrypt"
+)
+
+func hashSharePassword(password string) (string, error) {
+	hash, err := bcrypt.GenerateFromPassword([]byte(password), bcrypt.DefaultCost)
+	if err != nil {
+		return "", err
+	}
+	return string(hash), nil
+}
+
+func checkSharePassword(hash, password string) bool {
+	return bcrypt.CompareHashAndPassword([]byte(hash), []byte(password)) == nil
+}
+
+func watchCookieName(shareToken string) string {
+	prefix := shareToken
+	if len(prefix) > 8 {
+		prefix = prefix[:8]
+	}
+	return "wa_" + prefix
+}
+
+func signWatchCookie(hmacSecret, shareToken, passwordHash string) string {
+	hashPrefix := passwordHash
+	if len(hashPrefix) > 16 {
+		hashPrefix = hashPrefix[:16]
+	}
+	mac := hmac.New(sha256.New, []byte(hmacSecret))
+	mac.Write([]byte(shareToken + "|" + hashPrefix))
+	return hex.EncodeToString(mac.Sum(nil))
+}
+
+func verifyWatchCookie(hmacSecret, shareToken, passwordHash, cookieValue string) bool {
+	expected := signWatchCookie(hmacSecret, shareToken, passwordHash)
+	return hmac.Equal([]byte(expected), []byte(cookieValue))
+}
+
+func setWatchCookie(w http.ResponseWriter, shareToken, cookieValue string, secure bool) {
+	http.SetCookie(w, &http.Cookie{
+		Name:     watchCookieName(shareToken),
+		Value:    cookieValue,
+		Path:     "/",
+		HttpOnly: true,
+		Secure:   secure,
+		SameSite: http.SameSiteStrictMode,
+		MaxAge:   int(7 * 24 * time.Hour / time.Second),
+	})
+}
+
+func hasValidWatchCookie(r *http.Request, hmacSecret, shareToken, passwordHash string) bool {
+	cookie, err := r.Cookie(watchCookieName(shareToken))
+	if err != nil {
+		return false
+	}
+	return verifyWatchCookie(hmacSecret, shareToken, passwordHash, cookie.Value)
+}
+
+type verifyPasswordRequest struct {
+	Password string `json:"password"`
+}
+
+func (h *Handler) VerifyWatchPassword(w http.ResponseWriter, r *http.Request) {
+	shareToken := chi.URLParam(r, "shareToken")
+
+	var req verifyPasswordRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		httputil.WriteError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+
+	var sharePassword *string
+	err := h.db.QueryRow(r.Context(),
+		`SELECT share_password FROM videos WHERE share_token = $1 AND status = 'ready'`,
+		shareToken,
+	).Scan(&sharePassword)
+	if err != nil {
+		httputil.WriteError(w, http.StatusNotFound, "video not found")
+		return
+	}
+
+	if sharePassword == nil {
+		w.WriteHeader(http.StatusOK)
+		return
+	}
+
+	if !checkSharePassword(*sharePassword, req.Password) {
+		httputil.WriteError(w, http.StatusForbidden, "incorrect password")
+		return
+	}
+
+	sig := signWatchCookie(h.hmacSecret, shareToken, *sharePassword)
+	setWatchCookie(w, shareToken, sig, h.secureCookies)
+	w.WriteHeader(http.StatusOK)
+}

--- a/internal/video/watch_auth_test.go
+++ b/internal/video/watch_auth_test.go
@@ -1,0 +1,491 @@
+package video
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/pashagolub/pgxmock/v4"
+)
+
+const testHMACSecret = "test-hmac-secret-for-watch-auth"
+
+func TestHashSharePassword_ReturnsBcryptHash(t *testing.T) {
+	hash, err := hashSharePassword("mysecret")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if hash == "" {
+		t.Error("expected non-empty hash")
+	}
+	if hash == "mysecret" {
+		t.Error("hash should not equal plaintext password")
+	}
+}
+
+func TestCheckSharePassword_CorrectPassword(t *testing.T) {
+	hash, err := hashSharePassword("mysecret")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !checkSharePassword(hash, "mysecret") {
+		t.Error("expected correct password to match")
+	}
+}
+
+func TestCheckSharePassword_WrongPassword(t *testing.T) {
+	hash, err := hashSharePassword("mysecret")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if checkSharePassword(hash, "wrongpassword") {
+		t.Error("expected wrong password to not match")
+	}
+}
+
+func TestWatchCookieName_UsesTokenPrefix(t *testing.T) {
+	name := watchCookieName("abcdefghijkl")
+	if name != "wa_abcdefgh" {
+		t.Errorf("expected wa_abcdefgh, got %s", name)
+	}
+}
+
+func TestWatchCookieName_ShortToken(t *testing.T) {
+	name := watchCookieName("abc")
+	if name != "wa_abc" {
+		t.Errorf("expected wa_abc, got %s", name)
+	}
+}
+
+func TestSignWatchCookie_ReturnsNonEmpty(t *testing.T) {
+	sig := signWatchCookie(testHMACSecret, "sharetoken", "$2a$10$abcdefghij1234567890ab")
+	if sig == "" {
+		t.Error("expected non-empty signature")
+	}
+}
+
+func TestSignWatchCookie_DeterministicForSameInput(t *testing.T) {
+	sig1 := signWatchCookie(testHMACSecret, "sharetoken", "$2a$10$abcdefghij1234567890ab")
+	sig2 := signWatchCookie(testHMACSecret, "sharetoken", "$2a$10$abcdefghij1234567890ab")
+	if sig1 != sig2 {
+		t.Error("expected same signature for same input")
+	}
+}
+
+func TestSignWatchCookie_DifferentForDifferentPasswordHash(t *testing.T) {
+	sig1 := signWatchCookie(testHMACSecret, "sharetoken", "$2a$10$aaaaaaaaaaaaaaaaaaaaa")
+	sig2 := signWatchCookie(testHMACSecret, "sharetoken", "$2a$10$bbbbbbbbbbbbbbbbbbbbb")
+	if sig1 == sig2 {
+		t.Error("expected different signatures for different password hashes")
+	}
+}
+
+func TestVerifyWatchCookie_ValidSignature(t *testing.T) {
+	sig := signWatchCookie(testHMACSecret, "sharetoken", "$2a$10$abcdefghij1234567890ab")
+	if !verifyWatchCookie(testHMACSecret, "sharetoken", "$2a$10$abcdefghij1234567890ab", sig) {
+		t.Error("expected valid signature to verify")
+	}
+}
+
+func TestVerifyWatchCookie_InvalidSignature(t *testing.T) {
+	if verifyWatchCookie(testHMACSecret, "sharetoken", "$2a$10$abcdefghij1234567890ab", "invalidsig") {
+		t.Error("expected invalid signature to fail verification")
+	}
+}
+
+func TestVerifyWatchCookie_WrongSecret(t *testing.T) {
+	sig := signWatchCookie(testHMACSecret, "sharetoken", "$2a$10$abcdefghij1234567890ab")
+	if verifyWatchCookie("wrong-secret", "sharetoken", "$2a$10$abcdefghij1234567890ab", sig) {
+		t.Error("expected verification to fail with wrong secret")
+	}
+}
+
+func TestSetWatchCookie_SetsCookieOnResponse(t *testing.T) {
+	rec := httptest.NewRecorder()
+	setWatchCookie(rec, "abcdefghijkl", "sigvalue", false)
+
+	cookies := rec.Result().Cookies()
+	if len(cookies) != 1 {
+		t.Fatalf("expected 1 cookie, got %d", len(cookies))
+	}
+	c := cookies[0]
+	if c.Name != "wa_abcdefgh" {
+		t.Errorf("expected cookie name wa_abcdefgh, got %s", c.Name)
+	}
+	if c.Value != "sigvalue" {
+		t.Errorf("expected cookie value sigvalue, got %s", c.Value)
+	}
+	if !c.HttpOnly {
+		t.Error("expected HttpOnly cookie")
+	}
+	if c.SameSite != http.SameSiteStrictMode {
+		t.Errorf("expected SameSiteStrict, got %v", c.SameSite)
+	}
+	if c.Secure {
+		t.Error("expected non-secure cookie when secure=false")
+	}
+}
+
+func TestSetWatchCookie_SecureFlag(t *testing.T) {
+	rec := httptest.NewRecorder()
+	setWatchCookie(rec, "abcdefghijkl", "sigvalue", true)
+
+	cookies := rec.Result().Cookies()
+	if len(cookies) != 1 {
+		t.Fatalf("expected 1 cookie, got %d", len(cookies))
+	}
+	if !cookies[0].Secure {
+		t.Error("expected secure cookie when secure=true")
+	}
+}
+
+func TestHasValidWatchCookie_ValidCookie(t *testing.T) {
+	passwordHash := "$2a$10$abcdefghij1234567890ab"
+	sig := signWatchCookie(testHMACSecret, "sharetoken12", passwordHash)
+
+	req := httptest.NewRequest(http.MethodGet, "/watch/sharetoken12", nil)
+	req.AddCookie(&http.Cookie{
+		Name:  watchCookieName("sharetoken12"),
+		Value: sig,
+	})
+
+	if !hasValidWatchCookie(req, testHMACSecret, "sharetoken12", passwordHash) {
+		t.Error("expected valid cookie to pass verification")
+	}
+}
+
+func TestHasValidWatchCookie_NoCookie(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/watch/sharetoken12", nil)
+	if hasValidWatchCookie(req, testHMACSecret, "sharetoken12", "$2a$10$abcdefghij1234567890ab") {
+		t.Error("expected no cookie to fail verification")
+	}
+}
+
+func TestHasValidWatchCookie_InvalidCookie(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/watch/sharetoken12", nil)
+	req.AddCookie(&http.Cookie{
+		Name:  watchCookieName("sharetoken12"),
+		Value: "garbage",
+	})
+
+	if hasValidWatchCookie(req, testHMACSecret, "sharetoken12", "$2a$10$abcdefghij1234567890ab") {
+		t.Error("expected invalid cookie to fail verification")
+	}
+}
+
+// --- VerifyWatchPassword Handler Tests ---
+
+func TestVerifyWatchPassword_CorrectPassword(t *testing.T) {
+	mock, err := pgxmock.NewPool()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer mock.Close()
+
+	passwordHash, _ := hashSharePassword("secret123")
+	storage := &mockStorage{}
+	handler := NewHandler(mock, storage, testBaseURL, 0, 0, 0, testHMACSecret, false)
+	shareToken := "abc123defghi"
+
+	mock.ExpectQuery(`SELECT share_password FROM videos WHERE share_token = \$1 AND status = 'ready'`).
+		WithArgs(shareToken).
+		WillReturnRows(pgxmock.NewRows([]string{"share_password"}).AddRow(&passwordHash))
+
+	body, _ := json.Marshal(map[string]string{"password": "secret123"})
+	r := chi.NewRouter()
+	r.Post("/api/watch/{shareToken}/verify", handler.VerifyWatchPassword)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/watch/"+shareToken+"/verify", bytes.NewReader(body))
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d: %s", http.StatusOK, rec.Code, rec.Body.String())
+	}
+
+	cookies := rec.Result().Cookies()
+	if len(cookies) != 1 {
+		t.Fatalf("expected 1 cookie, got %d", len(cookies))
+	}
+	if cookies[0].Name != watchCookieName(shareToken) {
+		t.Errorf("expected cookie name %s, got %s", watchCookieName(shareToken), cookies[0].Name)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet pgxmock expectations: %v", err)
+	}
+}
+
+func TestVerifyWatchPassword_WrongPassword(t *testing.T) {
+	mock, err := pgxmock.NewPool()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer mock.Close()
+
+	passwordHash, _ := hashSharePassword("secret123")
+	storage := &mockStorage{}
+	handler := NewHandler(mock, storage, testBaseURL, 0, 0, 0, testHMACSecret, false)
+	shareToken := "abc123defghi"
+
+	mock.ExpectQuery(`SELECT share_password FROM videos WHERE share_token = \$1 AND status = 'ready'`).
+		WithArgs(shareToken).
+		WillReturnRows(pgxmock.NewRows([]string{"share_password"}).AddRow(&passwordHash))
+
+	body, _ := json.Marshal(map[string]string{"password": "wrongpassword"})
+	r := chi.NewRouter()
+	r.Post("/api/watch/{shareToken}/verify", handler.VerifyWatchPassword)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/watch/"+shareToken+"/verify", bytes.NewReader(body))
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("expected status %d, got %d: %s", http.StatusForbidden, rec.Code, rec.Body.String())
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet pgxmock expectations: %v", err)
+	}
+}
+
+func TestVerifyWatchPassword_NoPasswordSet(t *testing.T) {
+	mock, err := pgxmock.NewPool()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer mock.Close()
+
+	storage := &mockStorage{}
+	handler := NewHandler(mock, storage, testBaseURL, 0, 0, 0, testHMACSecret, false)
+	shareToken := "abc123defghi"
+
+	mock.ExpectQuery(`SELECT share_password FROM videos WHERE share_token = \$1 AND status = 'ready'`).
+		WithArgs(shareToken).
+		WillReturnRows(pgxmock.NewRows([]string{"share_password"}).AddRow((*string)(nil)))
+
+	body, _ := json.Marshal(map[string]string{"password": "anything"})
+	r := chi.NewRouter()
+	r.Post("/api/watch/{shareToken}/verify", handler.VerifyWatchPassword)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/watch/"+shareToken+"/verify", bytes.NewReader(body))
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d: %s", http.StatusOK, rec.Code, rec.Body.String())
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet pgxmock expectations: %v", err)
+	}
+}
+
+func TestVerifyWatchPassword_VideoNotFound(t *testing.T) {
+	mock, err := pgxmock.NewPool()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer mock.Close()
+
+	storage := &mockStorage{}
+	handler := NewHandler(mock, storage, testBaseURL, 0, 0, 0, testHMACSecret, false)
+	shareToken := "abc123defghi"
+
+	mock.ExpectQuery(`SELECT share_password FROM videos WHERE share_token = \$1 AND status = 'ready'`).
+		WithArgs(shareToken).
+		WillReturnError(errors.New("no rows"))
+
+	body, _ := json.Marshal(map[string]string{"password": "secret123"})
+	r := chi.NewRouter()
+	r.Post("/api/watch/{shareToken}/verify", handler.VerifyWatchPassword)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/watch/"+shareToken+"/verify", bytes.NewReader(body))
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("expected status %d, got %d: %s", http.StatusNotFound, rec.Code, rec.Body.String())
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet pgxmock expectations: %v", err)
+	}
+}
+
+// --- Password-Protected Watch Handler Tests ---
+
+func TestWatch_PasswordProtected_NoCookie(t *testing.T) {
+	mock, err := pgxmock.NewPool()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer mock.Close()
+
+	passwordHash, _ := hashSharePassword("secret123")
+	storage := &mockStorage{downloadURL: "https://s3.example.com/download"}
+	handler := NewHandler(mock, storage, testBaseURL, 0, 0, 0, testHMACSecret, false)
+	shareToken := "abc123defghi"
+	createdAt := time.Date(2026, 2, 5, 14, 0, 0, 0, time.UTC)
+	shareExpiresAt := time.Now().Add(7 * 24 * time.Hour)
+
+	mock.ExpectQuery(`SELECT v.id, v.title, v.duration, v.file_key, u.name, v.created_at, v.share_expires_at`).
+		WithArgs(shareToken).
+		WillReturnRows(
+			pgxmock.NewRows([]string{"id", "title", "duration", "file_key", "name", "created_at", "share_expires_at", "thumbnail_key", "share_password"}).
+				AddRow("video-001", "Demo Recording", 180, "recordings/user-1/abc.webm", "Alex Neamtu", createdAt, shareExpiresAt, (*string)(nil), &passwordHash),
+		)
+
+	r := chi.NewRouter()
+	r.Get("/watch/{shareToken}", handler.Watch)
+
+	req := httptest.NewRequest(http.MethodGet, "/watch/"+shareToken, nil)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("expected status %d, got %d: %s", http.StatusForbidden, rec.Code, rec.Body.String())
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet pgxmock expectations: %v", err)
+	}
+}
+
+func TestWatch_PasswordProtected_ValidCookie(t *testing.T) {
+	mock, err := pgxmock.NewPool()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer mock.Close()
+
+	passwordHash, _ := hashSharePassword("secret123")
+	storage := &mockStorage{downloadURL: "https://s3.example.com/download"}
+	handler := NewHandler(mock, storage, testBaseURL, 0, 0, 0, testHMACSecret, false)
+	shareToken := "abc123defghi"
+	createdAt := time.Date(2026, 2, 5, 14, 0, 0, 0, time.UTC)
+	shareExpiresAt := time.Now().Add(7 * 24 * time.Hour)
+	videoID := "video-001"
+
+	mock.ExpectQuery(`SELECT v.id, v.title, v.duration, v.file_key, u.name, v.created_at, v.share_expires_at`).
+		WithArgs(shareToken).
+		WillReturnRows(
+			pgxmock.NewRows([]string{"id", "title", "duration", "file_key", "name", "created_at", "share_expires_at", "thumbnail_key", "share_password"}).
+				AddRow(videoID, "Demo Recording", 180, "recordings/user-1/abc.webm", "Alex Neamtu", createdAt, shareExpiresAt, (*string)(nil), &passwordHash),
+		)
+
+	mock.ExpectExec(`INSERT INTO video_views`).
+		WithArgs(videoID, pgxmock.AnyArg()).
+		WillReturnResult(pgxmock.NewResult("INSERT", 1))
+
+	sig := signWatchCookie(testHMACSecret, shareToken, passwordHash)
+
+	r := chi.NewRouter()
+	r.Get("/watch/{shareToken}", handler.Watch)
+
+	req := httptest.NewRequest(http.MethodGet, "/watch/"+shareToken, nil)
+	req.AddCookie(&http.Cookie{
+		Name:  watchCookieName(shareToken),
+		Value: sig,
+	})
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d: %s", http.StatusOK, rec.Code, rec.Body.String())
+	}
+
+	time.Sleep(100 * time.Millisecond)
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet pgxmock expectations: %v", err)
+	}
+}
+
+func TestWatchDownload_PasswordProtected_NoCookie(t *testing.T) {
+	mock, err := pgxmock.NewPool()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer mock.Close()
+
+	passwordHash, _ := hashSharePassword("secret123")
+	storage := &mockStorage{downloadDispositionURL: "https://s3.example.com/download"}
+	handler := NewHandler(mock, storage, testBaseURL, 0, 0, 0, testHMACSecret, false)
+	shareToken := "abc123defghi"
+	shareExpiresAt := time.Now().Add(7 * 24 * time.Hour)
+
+	mock.ExpectQuery(`SELECT title, file_key, share_expires_at, share_password FROM videos WHERE share_token = \$1 AND status = 'ready'`).
+		WithArgs(shareToken).
+		WillReturnRows(pgxmock.NewRows([]string{"title", "file_key", "share_expires_at", "share_password"}).
+			AddRow("Demo Recording", "recordings/user-1/abc.webm", shareExpiresAt, &passwordHash))
+
+	r := chi.NewRouter()
+	r.Get("/api/watch/{shareToken}/download", handler.WatchDownload)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/watch/"+shareToken+"/download", nil)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("expected status %d, got %d: %s", http.StatusForbidden, rec.Code, rec.Body.String())
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet pgxmock expectations: %v", err)
+	}
+}
+
+func TestWatchPage_PasswordProtected_ShowsPasswordForm(t *testing.T) {
+	mock, err := pgxmock.NewPool()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer mock.Close()
+
+	passwordHash, _ := hashSharePassword("secret123")
+	storage := &mockStorage{downloadURL: "https://s3.example.com/download"}
+	handler := NewHandler(mock, storage, testBaseURL, 0, 0, 0, testHMACSecret, false)
+	shareToken := "abc123defghi"
+	createdAt := time.Date(2026, 2, 5, 14, 0, 0, 0, time.UTC)
+	shareExpiresAt := time.Now().Add(7 * 24 * time.Hour)
+
+	mock.ExpectQuery(`SELECT v.title, v.file_key, u.name, v.created_at, v.share_expires_at, v.thumbnail_key`).
+		WithArgs(shareToken).
+		WillReturnRows(
+			pgxmock.NewRows([]string{"title", "file_key", "name", "created_at", "share_expires_at", "thumbnail_key", "share_password"}).
+				AddRow("Demo Recording", "recordings/user-1/abc.webm", "Alex Neamtu", createdAt, shareExpiresAt, (*string)(nil), &passwordHash),
+		)
+
+	r := chi.NewRouter()
+	r.Get("/watch/{shareToken}", handler.WatchPage)
+
+	req := httptest.NewRequest(http.MethodGet, "/watch/"+shareToken, nil)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d: %s", http.StatusOK, rec.Code, rec.Body.String())
+	}
+
+	body := rec.Body.String()
+	if !strings.Contains(body, "password protected") {
+		t.Error("expected password page to contain 'password protected'")
+	}
+	if !strings.Contains(body, "password-form") {
+		t.Error("expected password page to contain password form")
+	}
+	if strings.Contains(body, "<video") {
+		t.Error("expected password page to NOT contain video player")
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet pgxmock expectations: %v", err)
+	}
+}

--- a/internal/video/watch_page.go
+++ b/internal/video/watch_page.go
@@ -167,6 +167,93 @@ type expiredPageData struct {
 	Nonce string
 }
 
+type passwordPageData struct {
+	Title      string
+	ShareToken string
+	Nonce      string
+}
+
+var passwordPageTemplate = template.Must(template.New("password").Parse(`<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>{{.Title}} — SendRec</title>
+    <style nonce="{{.Nonce}}">
+        * { margin: 0; padding: 0; box-sizing: border-box; }
+        body {
+            background: #0a1628;
+            color: #ffffff;
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+            min-height: 100vh;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+        }
+        .container { text-align: center; padding: 2rem; max-width: 400px; width: 100%; }
+        h1 { font-size: 1.5rem; margin-bottom: 0.75rem; }
+        p { color: #94a3b8; margin-bottom: 1.5rem; }
+        .error { color: #ef4444; font-size: 0.875rem; margin-bottom: 1rem; display: none; }
+        input[type="password"] {
+            width: 100%;
+            padding: 0.75rem 1rem;
+            border-radius: 8px;
+            border: 1px solid #334155;
+            background: #1e293b;
+            color: #fff;
+            font-size: 1rem;
+            margin-bottom: 1rem;
+            outline: none;
+        }
+        input[type="password"]:focus { border-color: #00b67a; }
+        button {
+            width: 100%;
+            background: #00b67a;
+            color: #fff;
+            padding: 0.75rem 1.5rem;
+            border: none;
+            border-radius: 8px;
+            font-size: 1rem;
+            font-weight: 600;
+            cursor: pointer;
+        }
+        button:hover { opacity: 0.9; }
+        button:disabled { opacity: 0.5; cursor: not-allowed; }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <h1>This video is password protected</h1>
+        <p>Enter the password to watch this video.</p>
+        <p class="error" id="error-msg"></p>
+        <form id="password-form">
+            <input type="password" id="password-input" placeholder="Password" required autofocus>
+            <button type="submit" id="submit-btn">Watch Video</button>
+        </form>
+    </div>
+    <script nonce="{{.Nonce}}">
+        document.getElementById('password-form').addEventListener('submit', function(e) {
+            e.preventDefault();
+            var btn = document.getElementById('submit-btn');
+            var errEl = document.getElementById('error-msg');
+            var pw = document.getElementById('password-input').value;
+            btn.disabled = true;
+            errEl.style.display = 'none';
+            fetch('/api/watch/{{.ShareToken}}/verify', {
+                method: 'POST',
+                headers: {'Content-Type': 'application/json'},
+                body: JSON.stringify({password: pw})
+            }).then(function(r) {
+                if (r.ok) { window.location.reload(); }
+                else { errEl.textContent = 'Incorrect password'; errEl.style.display = 'block'; btn.disabled = false; }
+            }).catch(function() {
+                errEl.textContent = 'Something went wrong'; errEl.style.display = 'block'; btn.disabled = false;
+            });
+        });
+    </script>
+</body>
+</html>`))
+
 func (h *Handler) WatchPage(w http.ResponseWriter, r *http.Request) {
 	shareToken := chi.URLParam(r, "shareToken")
 
@@ -176,14 +263,15 @@ func (h *Handler) WatchPage(w http.ResponseWriter, r *http.Request) {
 	var createdAt time.Time
 	var shareExpiresAt time.Time
 	var thumbnailKey *string
+	var sharePassword *string
 
 	err := h.db.QueryRow(r.Context(),
-		`SELECT v.title, v.file_key, u.name, v.created_at, v.share_expires_at, v.thumbnail_key
+		`SELECT v.title, v.file_key, u.name, v.created_at, v.share_expires_at, v.thumbnail_key, v.share_password
 		 FROM videos v
 		 JOIN users u ON u.id = v.user_id
 		 WHERE v.share_token = $1 AND v.status = 'ready'`,
 		shareToken,
-	).Scan(&title, &fileKey, &creator, &createdAt, &shareExpiresAt, &thumbnailKey)
+	).Scan(&title, &fileKey, &creator, &createdAt, &shareExpiresAt, &thumbnailKey, &sharePassword)
 	if err != nil {
 		http.NotFound(w, r)
 		return
@@ -198,6 +286,20 @@ func (h *Handler) WatchPage(w http.ResponseWriter, r *http.Request) {
 			log.Printf("failed to render expired page: %v", err)
 		}
 		return
+	}
+
+	if sharePassword != nil {
+		if !hasValidWatchCookie(r, h.hmacSecret, shareToken, *sharePassword) {
+			w.Header().Set("Content-Type", "text/html; charset=utf-8")
+			if err := passwordPageTemplate.Execute(w, passwordPageData{
+				Title:      title,
+				ShareToken: shareToken,
+				Nonce:      nonce,
+			}); err != nil {
+				log.Printf("failed to render password page: %v", err)
+			}
+			return
+		}
 	}
 
 	videoURL, err := h.storage.GenerateDownloadURL(r.Context(), fileKey, 1*time.Hour)

--- a/migrations/000009_add_share_password.down.sql
+++ b/migrations/000009_add_share_password.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE videos DROP COLUMN share_password;

--- a/migrations/000009_add_share_password.up.sql
+++ b/migrations/000009_add_share_password.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE videos ADD COLUMN share_password TEXT;


### PR DESCRIPTION
## Summary

- Add optional password protection for video share links using bcrypt-hashed passwords
- Stateless per-video authentication via HMAC-SHA256 cookies (no sessions table needed)
- Watch page renders a password form when password is set and no valid cookie exists
- Password check enforced on Watch API, WatchDownload, and WatchPage handlers
- Library UI shows "Add password" / "Remove password" buttons per video

## Changes

- **Migration 000009**: `share_password` nullable TEXT column on `videos` table
- **`PUT /api/videos/{id}/password`**: Set or remove password (authenticated, owner only)
- **`POST /api/watch/{shareToken}/verify`**: Verify password and set auth cookie (rate-limited)
- **Watch/WatchDownload/WatchPage**: Return 403 or render password page when password required
- **List API**: Includes `hasPassword` boolean field
- **Library UI**: Password management buttons with prompt/confirm UX

## Test plan

- [x] 22 Go tests in `watch_auth_test.go` (helpers + verify handler + protected watch/download/page)
- [x] 3 Go tests for `SetPassword` handler (set, remove, not found)
- [x] All existing Watch/WatchDownload/WatchPage tests updated for new column
- [x] 2 server route registration tests
- [x] 5 frontend tests for password UI (show label, add, remove, cancel prompt)
- [x] `go test ./...` — all pass
- [x] `go vet ./...` — clean
- [x] `pnpm typecheck` — clean
- [x] `pnpm test` — 73 tests pass
- [x] `pnpm build` — builds successfully