### PR TITLE
Security hardening from comprehensive audit

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -25,15 +25,24 @@ jobs:
 
       - name: Deploy preview
         if: github.event.action != 'closed'
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          BRANCH_REF: ${{ github.event.pull_request.head.ref }}
         run: |
+          if ! echo "$BRANCH_REF" | grep -qE '^[a-zA-Z0-9._/-]+$'; then
+            echo "::error::Invalid branch name: $BRANCH_REF"
+            exit 1
+          fi
           ssh -i ~/.ssh/deploy_key ${{ secrets.DEPLOY_USER }}@${{ secrets.DEPLOY_HOST }} \
-            "/opt/sendrec/deploy.sh preview up ${{ github.event.pull_request.number }} ${{ github.event.pull_request.head.ref }}"
+            "/opt/sendrec/deploy.sh preview up ${PR_NUMBER} ${BRANCH_REF}"
 
       - name: Teardown preview
         if: github.event.action == 'closed'
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           ssh -i ~/.ssh/deploy_key ${{ secrets.DEPLOY_USER }}@${{ secrets.DEPLOY_HOST }} \
-            "/opt/sendrec/deploy.sh preview down ${{ github.event.pull_request.number }}"
+            "/opt/sendrec/deploy.sh preview down ${PR_NUMBER}"
 
       - name: Comment PR with preview URL
         if: github.event.action != 'closed'

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -23,15 +23,22 @@ jobs:
           echo "${{ secrets.DEPLOY_KNOWN_HOSTS }}" >> ~/.ssh/known_hosts
 
       - name: Deploy production
+        env:
+          TAG_NAME: ${{ github.ref_name }}
         run: |
+          if ! echo "$TAG_NAME" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+'; then
+            echo "::error::Invalid tag name: $TAG_NAME"
+            exit 1
+          fi
           ssh -i ~/.ssh/deploy_key ${{ secrets.DEPLOY_USER }}@${{ secrets.DEPLOY_HOST }} \
-            "/opt/sendrec/deploy.sh production ${{ github.ref_name }}"
+            "/opt/sendrec/deploy.sh production ${TAG_NAME}"
 
       - name: Create GitHub Release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG_NAME: ${{ github.ref_name }}
         run: |
-          gh release create "${{ github.ref_name }}" \
+          gh release create "$TAG_NAME" \
             --repo "${{ github.repository }}" \
-            --title "${{ github.ref_name }}" \
+            --title "$TAG_NAME" \
             --generate-notes

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN pnpm build
 FROM alpine:3.21 AS whisper
 RUN apk add --no-cache build-base cmake git
 WORKDIR /build
-RUN git clone --depth 1 https://github.com/ggerganov/whisper.cpp.git . && \
+RUN git clone --depth 1 --branch v1.8.3 https://github.com/ggerganov/whisper.cpp.git . && \
     cmake -B build -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=OFF && \
     cmake --build build --target whisper-cli -j$(nproc)
 

--- a/cmd/sendrec/main.go
+++ b/cmd/sendrec/main.go
@@ -115,8 +115,12 @@ func main() {
 	video.StartCleanupLoop(cleanupCtx, db.Pool, store, 10*time.Minute)
 
 	httpServer := &http.Server{
-		Addr:    fmt.Sprintf(":%s", port),
-		Handler: srv,
+		Addr:              fmt.Sprintf(":%s", port),
+		Handler:           srv,
+		ReadHeaderTimeout: 10 * time.Second,
+		ReadTimeout:       60 * time.Second,
+		WriteTimeout:      120 * time.Second,
+		IdleTimeout:       120 * time.Second,
 	}
 
 	shutdownCh := make(chan os.Signal, 1)

--- a/internal/email/email.go
+++ b/internal/email/email.go
@@ -39,7 +39,7 @@ type txRequest struct {
 
 func (c *Client) SendPasswordReset(ctx context.Context, toEmail, toName, resetLink string) error {
 	if c.config.BaseURL == "" {
-		log.Printf("email not configured — reset link for %s: %s", toEmail, resetLink)
+		log.Printf("email not configured — password reset requested for %s (link not logged for security)", toEmail)
 		return nil
 	}
 

--- a/internal/server/security.go
+++ b/internal/server/security.go
@@ -31,7 +31,7 @@ func securityHeaders(cfg SecurityConfig) func(http.Handler) http.Handler {
 			w.Header().Set("Permissions-Policy", "camera=(self), microphone=(self), geolocation=(), screen-wake-lock=(), display-capture=(self)")
 
 			csp := fmt.Sprintf(
-				"default-src 'self'; img-src 'self' data:%s; media-src 'self' data:%s; script-src 'self' 'nonce-%s'; style-src 'self' 'nonce-%s'; connect-src 'self'%s;",
+				"default-src 'self'; img-src 'self' data:%s; media-src 'self' data:%s; script-src 'self' 'nonce-%s'; style-src 'self' 'nonce-%s'; connect-src 'self'%s; frame-ancestors 'self';",
 				storageSuffix, storageSuffix, nonce, nonce, storageSuffix,
 			)
 			w.Header().Set("Content-Security-Policy", csp)

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -327,7 +327,7 @@ func TestWatchRouteRegisteredWithDB(t *testing.T) {
 func TestWatchPageRouteRegisteredWithDB(t *testing.T) {
 	srv, mock := newServerWithDB(t)
 
-	mock.ExpectQuery("SELECT v.title, v.file_key").
+	mock.ExpectQuery("SELECT v.id, v.title, v.file_key").
 		WithArgs("some-token").
 		WillReturnError(errors.New("no rows"))
 

--- a/internal/video/comment.go
+++ b/internal/video/comment.go
@@ -331,7 +331,7 @@ func (h *Handler) ListWatchComments(w http.ResponseWriter, r *http.Request) {
 	}
 
 	callerUserID := h.optionalUserID(r)
-	includePrivate := callerUserID != ""
+	includePrivate := callerUserID != "" && callerUserID == ownerID
 
 	comments, err := h.queryComments(r.Context(), videoID, ownerID, includePrivate)
 	if err != nil {

--- a/internal/video/video.go
+++ b/internal/video/video.go
@@ -167,6 +167,10 @@ func (h *Handler) Create(w http.ResponseWriter, r *http.Request) {
 	if title == "" {
 		title = "Untitled Recording"
 	}
+	if len(title) > 500 {
+		httputil.WriteError(w, http.StatusBadRequest, "title is too long")
+		return
+	}
 
 	shareToken, err := generateShareToken()
 	if err != nil {
@@ -342,6 +346,10 @@ func (h *Handler) Update(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if req.Title != "" {
+		if len(req.Title) > 500 {
+			httputil.WriteError(w, http.StatusBadRequest, "title is too long")
+			return
+		}
 		tag, err := h.db.Exec(r.Context(),
 			`UPDATE videos SET title = $1, updated_at = now()
 			 WHERE id = $2 AND user_id = $3 AND status != 'deleted'`,
@@ -676,6 +684,11 @@ func (h *Handler) SetPassword(w http.ResponseWriter, r *http.Request) {
 	var req setPasswordRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		httputil.WriteError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+
+	if len(req.Password) > 128 {
+		httputil.WriteError(w, http.StatusBadRequest, "password is too long")
 		return
 	}
 

--- a/internal/video/watch_auth.go
+++ b/internal/video/watch_auth.go
@@ -81,6 +81,11 @@ func (h *Handler) VerifyWatchPassword(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if len(req.Password) > 128 {
+		httputil.WriteError(w, http.StatusBadRequest, "password is too long")
+		return
+	}
+
 	var sharePassword *string
 	err := h.db.QueryRow(r.Context(),
 		`SELECT share_password FROM videos WHERE share_token = $1 AND status IN ('ready', 'processing')`,


### PR DESCRIPTION
## Summary

- Fix SSH script injection in deploy workflows by using env vars with input validation
- Stop logging password reset tokens; fix private comments authorization (owner-only)
- Add HTTP server timeouts, request body size limits (64KB), and input length validation
- Sanitize Content-Disposition filenames, add CSP frame-ancestors, pin whisper.cpp to v1.8.3

## Changes by severity

**HIGH (3):**
- Prevent script injection via branch name in deploy-preview.yml SSH command
- Remove password reset token from server logs when email is not configured
- Private comments on watch page now only visible to video owner (was: any authenticated user)

**MEDIUM (6):**
- HTTP server timeouts: ReadHeader 10s, Read 60s, Write 120s, Idle 120s
- 64KB max body size on all JSON API routes (auth, user, videos, watch)
- Sanitize video title in Content-Disposition header (strip quotes, backslashes, control chars)
- Video title max 500 characters (Create + Update handlers)
- Share password max 128 characters (Set + Verify handlers)
- Pin whisper.cpp Docker build to v1.8.3 (was: unpinned HEAD)

**LOW (2):**
- Add `frame-ancestors 'self'` to Content-Security-Policy
- Deploy-production uses env vars for tag name with semver validation

## Test plan

- [x] All Go tests pass (`go test ./...`)
- [x] `go vet` clean
- [x] Verify deploy-preview still works on PR open
- [x] Verify deploy-production still works on tag push
- [x] Test video title > 500 chars is rejected
- [x] Test share password > 128 chars is rejected