### PR TITLE
feat: add video search to library

### DIFF
--- a/web/src/pages/Library.test.tsx
+++ b/web/src/pages/Library.test.tsx
@@ -619,4 +619,32 @@ describe("Library", () => {
 
     expect(await screen.findByText("Retry transcript")).toBeInTheDocument();
   });
+
+  it("renders search input", async () => {
+    mockFetch([makeVideo()]);
+    renderLibrary();
+
+    await screen.findByText("My Recording");
+    expect(screen.getByPlaceholderText("Search videos...")).toBeInTheDocument();
+  });
+
+  it("fetches with query param when typing in search", async () => {
+    mockFetch([makeVideo()]);
+    renderLibrary();
+
+    await screen.findByText("My Recording");
+    mockApiFetch.mockClear();
+
+    // Mock the search response
+    mockApiFetch
+      .mockResolvedValueOnce([makeVideo({ title: "Deploy walkthrough" })])
+      .mockResolvedValueOnce(unlimitedLimits);
+
+    const input = screen.getByPlaceholderText("Search videos...");
+    await userEvent.type(input, "deploy");
+
+    await waitFor(() => {
+      expect(mockApiFetch).toHaveBeenCalledWith("/api/videos?q=deploy");
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- Adds search input to the Library page header
- Backend: `GET /api/videos?q=term` filters by title and transcript text (ILIKE)
- Frontend: 300ms debounced search input, passes `?q=` to API
- Empty query behaves as before (no filter)

## Test plan
- [x] Type in search box, verify results filter after 300ms
- [x] Search by video title — matching videos shown
- [x] Search by transcript content — videos with matching transcript shown
- [x] Clear search — all videos shown again
- [x] Empty library shows no search input issues