### PR TITLE
Remove SetCORS from Go app

### DIFF
--- a/cmd/sendrec/main.go
+++ b/cmd/sendrec/main.go
@@ -68,15 +68,6 @@ func main() {
 
 	baseURL := getEnv("BASE_URL", "http://localhost:8080")
 
-	corsOrigins := []string{baseURL}
-	// Allow Vite dev server uploads during local development.
-	if baseURL == "http://localhost:8080" {
-		corsOrigins = append(corsOrigins, "http://localhost:5173")
-	}
-
-	if err := store.SetCORS(ctx, corsOrigins); err != nil {
-		log.Printf("warning: failed to set storage CORS: %v", err)
-	}
 	log.Println("storage bucket ready")
 
 	var webFS fs.FS

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -12,7 +12,6 @@ import (
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
-	"github.com/aws/aws-sdk-go-v2/service/s3/types"
 )
 
 type Storage struct {
@@ -164,26 +163,6 @@ func (s *Storage) HeadObject(ctx context.Context, key string) (int64, string, er
 		ct = *out.ContentType
 	}
 	return size, ct, nil
-}
-
-func (s *Storage) SetCORS(ctx context.Context, allowedOrigins []string) error {
-	_, err := s.client.PutBucketCors(ctx, &s3.PutBucketCorsInput{
-		Bucket: aws.String(s.bucket),
-		CORSConfiguration: &types.CORSConfiguration{
-			CORSRules: []types.CORSRule{
-				{
-					AllowedOrigins: allowedOrigins,
-					AllowedMethods: []string{"GET", "PUT"},
-					AllowedHeaders: []string{"*"},
-					MaxAgeSeconds:  aws.Int32(3600),
-				},
-			},
-		},
-	})
-	if err != nil {
-		return fmt.Errorf("set bucket CORS: %w", err)
-	}
-	return nil
 }
 
 func (s *Storage) EnsureBucket(ctx context.Context) error {

--- a/internal/storage/storage_test.go
+++ b/internal/storage/storage_test.go
@@ -270,55 +270,6 @@ func TestDeleteObjectError(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// SetCORS
-// ---------------------------------------------------------------------------
-
-func TestSetCORSSuccess(t *testing.T) {
-	var mu sync.Mutex
-	var calledMethod string
-	var hadCorsQuery bool
-
-	ts, store := newFakeS3Server(t, func(w http.ResponseWriter, r *http.Request) {
-		mu.Lock()
-		calledMethod = r.Method
-		hadCorsQuery = r.URL.Query().Has("cors")
-		mu.Unlock()
-		w.WriteHeader(http.StatusOK)
-	})
-	defer ts.Close()
-
-	err := store.SetCORS(context.Background(), []string{"https://sendrec.eu"})
-	if err != nil {
-		t.Fatalf("expected no error, got: %v", err)
-	}
-
-	mu.Lock()
-	defer mu.Unlock()
-	if calledMethod != http.MethodPut {
-		t.Fatalf("expected PUT method, got: %s", calledMethod)
-	}
-	if !hadCorsQuery {
-		t.Fatal("expected request to have ?cors query parameter")
-	}
-}
-
-func TestSetCORSError(t *testing.T) {
-	ts, store := newFakeS3Server(t, func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusInternalServerError)
-		_, _ = fmt.Fprint(w, s3ErrorResponse("InternalError", "Internal Server Error"))
-	})
-	defer ts.Close()
-
-	err := store.SetCORS(context.Background(), []string{"https://sendrec.eu"})
-	if err == nil {
-		t.Fatal("expected an error, got nil")
-	}
-	if !strings.Contains(err.Error(), "set bucket CORS") {
-		t.Fatalf("expected error to contain 'set bucket CORS', got: %v", err)
-	}
-}
-
-// ---------------------------------------------------------------------------
 // EnsureBucket
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- Remove `Storage.SetCORS()` method and its call in `main.go` — CORS on the Garage bucket is already managed by `garage-init.sh` via the Garage admin API
- Remove associated tests (`TestSetCORSSuccess`, `TestSetCORSError`)
- Remove unused `s3/types` import from `storage.go`