### PR TITLE
Add emoji reaction bar to watch page

### DIFF
--- a/internal/video/watch_page.go
+++ b/internal/video/watch_page.go
@@ -925,26 +925,6 @@ var watchPageTemplate = template.Must(template.New("watch").Funcs(watchFuncs).Pa
                     var btn = e.target.closest('.reaction-btn');
                     if (!btn || btn.disabled) return;
                     var emoji = btn.getAttribute('data-emoji');
-                    var authorName = nameEl ? nameEl.value.trim() : '';
-                    var authorEmail = emailEl ? emailEl.value.trim() : '';
-                    if ((commentMode === 'name_required' || commentMode === 'name_email_required') && !authorName) {
-                        if (nameEl) {
-                            nameEl.focus();
-                            nameEl.style.borderColor = '#ef4444';
-                            setTimeout(function() { nameEl.style.borderColor = ''; }, 2000);
-                            nameEl.scrollIntoView({ behavior: 'smooth', block: 'center' });
-                        }
-                        return;
-                    }
-                    if (commentMode === 'name_email_required' && !authorEmail) {
-                        if (emailEl) {
-                            emailEl.focus();
-                            emailEl.style.borderColor = '#ef4444';
-                            setTimeout(function() { emailEl.style.borderColor = ''; }, 2000);
-                            emailEl.scrollIntoView({ behavior: 'smooth', block: 'center' });
-                        }
-                        return;
-                    }
                     var timestamp = clampReactionTimestamp(player.currentTime);
                     btn.disabled = true;
                     var rect = btn.getBoundingClientRect();
@@ -960,7 +940,7 @@ var watchPageTemplate = template.Must(template.New("watch").Funcs(watchFuncs).Pa
                     fetch('/api/watch/' + shareToken + '/comments', {
                         method: 'POST',
                         headers: headers,
-                        body: JSON.stringify({authorName: authorName, authorEmail: authorEmail, body: emoji, isPrivate: false, videoTimestamp: timestamp})
+                        body: JSON.stringify({authorName: '', authorEmail: '', body: emoji, isPrivate: false, videoTimestamp: timestamp})
                     }).then(function(r) {
                         if (!r.ok) return r.json().then(function(d) { throw new Error(d.error); });
                         return r.json();

--- a/internal/video/watch_page_test.go
+++ b/internal/video/watch_page_test.go
@@ -352,6 +352,9 @@ func TestWatchPage_CommentsEnabled_RendersCommentForm(t *testing.T) {
 	if strings.Contains(body, "if (!markersBar || !videoDuration) return;") {
 		t.Error("expected markers rendering to handle videos with unknown duration instead of hard-stopping")
 	}
+	if !strings.Contains(body, "body: JSON.stringify({authorName: '', authorEmail: '', body: emoji, isPrivate: false, videoTimestamp: timestamp})") {
+		t.Error("expected reaction payload to use anonymous author name/email")
+	}
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Errorf("unmet expectations: %v", err)
 	}


### PR DESCRIPTION
## Summary
- Adds a persistent 6-emoji reaction bar (👍 👎 ❤️ 😂 😮 🎉) below the video on the watch page
- Clicking an emoji posts it as a timestamped reaction comment and renders it as a compact inline reaction badge
- Restores marker bar behavior for videos with unknown/Infinity duration by using a timeline fallback from comment timestamps
- Allows quick reactions to be anonymous even when comment mode is `name_required` or `name_email_required` (regular text comments keep existing requirements)

## Test Plan
- [x] `go test ./internal/video -count=1`
- [x] Regression: marker rendering no longer hard-stops on unknown duration (`TestWatchPage_CommentsEnabled_RendersCommentForm` assertion)
- [x] Regression: anonymous reactions allowed in strict modes (`TestPostWatchComment_NameRequired_ReactionAllowsAnonymous`, `TestPostWatchComment_NameEmailRequired_ReactionAllowsAnonymous`)
- [x] Manual: reaction click creates a compact badge and marker dot
- [x] Manual: markers bar appears and click-to-seek works on WebM recordings where duration is initially unknown
