### PR TITLE
feat: unify notification settings for views and comments

### DIFF
--- a/internal/docs/openapi.yaml
+++ b/internal/docs/openapi.yaml
@@ -251,24 +251,24 @@ components:
         viewNotification:
           type: string
           nullable: true
-          enum: [null, "off", "every", "first", "digest"]
+          enum: [null, "off", "every", "digest"]
           description: Per-video notification override. Null means use account default.
 
     NotificationPreferencesResponse:
       type: object
-      required: [viewNotification]
+      required: [notificationMode]
       properties:
-        viewNotification:
+        notificationMode:
           type: string
-          enum: [off, every, first, digest]
+          enum: [off, views_only, comments_only, views_and_comments, digest]
 
     UpdateNotificationPreferencesRequest:
       type: object
-      required: [viewNotification]
+      required: [notificationMode]
       properties:
-        viewNotification:
+        notificationMode:
           type: string
-          enum: [off, every, first, digest]
+          enum: [off, views_only, comments_only, views_and_comments, digest]
 
     SetVideoNotificationRequest:
       type: object
@@ -277,7 +277,7 @@ components:
         viewNotification:
           type: string
           nullable: true
-          enum: [null, "off", "every", "first", "digest"]
+          enum: [null, "off", "every", "digest"]
           description: Set to null to clear the per-video override and use account default.
 
     BrandingSettingsResponse:
@@ -1012,7 +1012,7 @@ paths:
     put:
       tags: [Settings]
       summary: Update notification preferences
-      description: Sets the account-wide notification preference for view notifications.
+      description: Sets the account-wide notification preference for view and comment notifications.
       operationId: updateNotificationPreferences
       security:
         - bearerAuth: []

--- a/internal/email/email.go
+++ b/internal/email/email.go
@@ -13,14 +13,14 @@ import (
 )
 
 type Config struct {
-	BaseURL            string
-	Username           string
-	Password           string
-	TemplateID         int
-	CommentTemplateID  int
-	ViewTemplateID     int
-	ConfirmTemplateID  int
-	Allowlist          []string
+	BaseURL           string
+	Username          string
+	Password          string
+	TemplateID        int
+	CommentTemplateID int
+	ViewTemplateID    int
+	ConfirmTemplateID int
+	Allowlist         []string
 }
 
 type Client struct {
@@ -44,9 +44,10 @@ type txRequest struct {
 
 // DigestVideoSummary represents a single video in a digest email.
 type DigestVideoSummary struct {
-	Title     string `json:"title"`
-	ViewCount int    `json:"viewCount"`
-	WatchURL  string `json:"watchURL"`
+	Title        string `json:"title"`
+	ViewCount    int    `json:"viewCount"`
+	CommentCount int    `json:"commentCount"`
+	WatchURL     string `json:"watchURL"`
 }
 
 type subscriberRequest struct {
@@ -274,18 +275,21 @@ func (c *Client) SendDigestNotification(ctx context.Context, toEmail, toName str
 	c.ensureSubscriber(ctx, toEmail, toName)
 
 	totalViews := 0
+	totalComments := 0
 	for _, v := range videos {
 		totalViews += v.ViewCount
+		totalComments += v.CommentCount
 	}
 
 	body := txRequest{
 		SubscriberEmail: toEmail,
 		TemplateID:      c.config.ViewTemplateID,
 		Data: map[string]any{
-			"name":       toName,
-			"isDigest":   "true",
-			"totalViews": strconv.Itoa(totalViews),
-			"videos":     videos,
+			"name":          toName,
+			"isDigest":      "true",
+			"totalViews":    strconv.Itoa(totalViews),
+			"totalComments": strconv.Itoa(totalComments),
+			"videos":        videos,
 		},
 		ContentType: "html",
 	}

--- a/internal/email/email_test.go
+++ b/internal/email/email_test.go
@@ -287,8 +287,8 @@ func TestSendDigestNotification_Success(t *testing.T) {
 	})
 
 	videos := []DigestVideoSummary{
-		{Title: "Video One", ViewCount: 10, WatchURL: "https://example.com/watch/abc"},
-		{Title: "Video Two", ViewCount: 3, WatchURL: "https://example.com/watch/def"},
+		{Title: "Video One", ViewCount: 10, CommentCount: 2, WatchURL: "https://example.com/watch/abc"},
+		{Title: "Video Two", ViewCount: 3, CommentCount: 1, WatchURL: "https://example.com/watch/def"},
 	}
 
 	err := client.SendDigestNotification(context.Background(), "alice@example.com", "Alice", videos)
@@ -299,9 +299,10 @@ func TestSendDigestNotification_Success(t *testing.T) {
 	var parsed struct {
 		TemplateID int `json:"template_id"`
 		Data       struct {
-			IsDigest   string                `json:"isDigest"`
-			TotalViews string                `json:"totalViews"`
-			Videos     []DigestVideoSummary  `json:"videos"`
+			IsDigest      string               `json:"isDigest"`
+			TotalViews    string               `json:"totalViews"`
+			TotalComments string               `json:"totalComments"`
+			Videos        []DigestVideoSummary `json:"videos"`
 		} `json:"data"`
 	}
 	if err := json.Unmarshal(receivedRaw, &parsed); err != nil {
@@ -317,6 +318,9 @@ func TestSendDigestNotification_Success(t *testing.T) {
 	if parsed.Data.TotalViews != "13" {
 		t.Errorf("expected totalViews=13, got %s", parsed.Data.TotalViews)
 	}
+	if parsed.Data.TotalComments != "3" {
+		t.Errorf("expected totalComments=3, got %s", parsed.Data.TotalComments)
+	}
 	if len(parsed.Data.Videos) != 2 {
 		t.Fatalf("expected 2 videos, got %d", len(parsed.Data.Videos))
 	}
@@ -325,6 +329,9 @@ func TestSendDigestNotification_Success(t *testing.T) {
 	}
 	if parsed.Data.Videos[0].ViewCount != 10 {
 		t.Errorf("expected first video 10 views, got %d", parsed.Data.Videos[0].ViewCount)
+	}
+	if parsed.Data.Videos[0].CommentCount != 2 {
+		t.Errorf("expected first video 2 comments, got %d", parsed.Data.Videos[0].CommentCount)
 	}
 }
 
@@ -606,4 +613,3 @@ func TestParseAllowlist(t *testing.T) {
 		}
 	}
 }
-

--- a/internal/video/comment.go
+++ b/internal/video/comment.go
@@ -22,13 +22,15 @@ var validCommentModes = map[string]bool{
 	"name_email_required": true,
 }
 
-var quickReactionBodies = map[string]bool{
-	"👍":  true,
-	"👎":  true,
-	"❤️": true,
-	"😂":  true,
-	"😮":  true,
-	"🎉":  true,
+var quickReactionEmojis = []string{"👍", "👎", "❤️", "😂", "😮", "🎉"}
+var quickReactionBodies = buildQuickReactionSet()
+
+func buildQuickReactionSet() map[string]bool {
+	set := make(map[string]bool, len(quickReactionEmojis))
+	for _, emoji := range quickReactionEmojis {
+		set[emoji] = true
+	}
+	return set
 }
 
 type setCommentModeRequest struct {
@@ -222,7 +224,11 @@ func (h *Handler) PostWatchComment(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if !req.IsPrivate && callerUserID != ownerID && h.commentNotifier != nil {
+	if !req.IsPrivate &&
+		!quickReaction &&
+		callerUserID != ownerID &&
+		h.commentNotifier != nil &&
+		h.shouldSendImmediateCommentNotification(r.Context(), ownerID) {
 		go func() {
 			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 			defer cancel()

--- a/internal/video/comment_test.go
+++ b/internal/video/comment_test.go
@@ -190,6 +190,10 @@ func TestPostWatchComment_AnonymousMode_Success(t *testing.T) {
 		WithArgs(videoID, (*string)(nil), "Someone", "", "Great video!", false, (*float64)(nil)).
 		WillReturnRows(pgxmock.NewRows([]string{"id", "created_at"}).AddRow("comment-1", time.Now()))
 
+	mock.ExpectQuery(`SELECT view_notification FROM notification_preferences WHERE user_id = \$1`).
+		WithArgs(ownerID).
+		WillReturnRows(pgxmock.NewRows([]string{"view_notification"}).AddRow("views_and_comments"))
+
 	mock.ExpectQuery(`SELECT u\.email, u\.name, v\.title FROM users u JOIN videos v ON v\.user_id = u\.id WHERE v\.id = \$1`).
 		WithArgs(videoID).
 		WillReturnRows(pgxmock.NewRows([]string{"email", "name", "title"}).AddRow("owner@example.com", "Owner", "My Video"))
@@ -401,6 +405,200 @@ func TestPostWatchComment_NameEmailRequired_ReactionAllowsAnonymous(t *testing.T
 
 	if rec.Code != http.StatusCreated {
 		t.Fatalf("expected status %d, got %d: %s", http.StatusCreated, rec.Code, rec.Body.String())
+	}
+}
+
+func TestPostWatchComment_NameRequired_NonQuickReactionEmojiStillRequiresName(t *testing.T) {
+	mock, err := pgxmock.NewPool()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer mock.Close()
+
+	storage := &mockStorage{}
+	handler := NewHandler(mock, storage, testBaseURL, 0, 0, 0, testJWTSecret, false)
+
+	shareToken := "abc123defghi"
+	expiresAt := time.Now().Add(24 * time.Hour)
+
+	mock.ExpectQuery(`SELECT v\.id, v\.user_id, v\.comment_mode, v\.share_expires_at, v\.share_password FROM videos v WHERE v\.share_token = \$1 AND v\.status IN \('ready', 'processing'\)`).
+		WithArgs(shareToken).
+		WillReturnRows(commentVideoRows().AddRow("video-123", "owner-1", "name_required", expiresAt, (*string)(nil)))
+
+	body, _ := json.Marshal(postCommentRequest{Body: "🔥"})
+
+	r := chi.NewRouter()
+	r.Post("/api/watch/{shareToken}/comments", handler.PostWatchComment)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/watch/"+shareToken+"/comments", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected status %d, got %d: %s", http.StatusBadRequest, rec.Code, rec.Body.String())
+	}
+}
+
+func TestPostWatchComment_QuickReaction_DoesNotSendCommentNotification(t *testing.T) {
+	mock, err := pgxmock.NewPool()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer mock.Close()
+
+	storage := &mockStorage{}
+	handler := NewHandler(mock, storage, testBaseURL, 0, 0, 0, testJWTSecret, false)
+	notifier := &mockCommentNotifier{}
+	handler.SetCommentNotifier(notifier)
+
+	shareToken := "abc123defghi"
+	videoID := "video-123"
+	ownerID := "owner-user-1"
+	expiresAt := time.Now().Add(24 * time.Hour)
+
+	mock.ExpectQuery(`SELECT v\.id, v\.user_id, v\.comment_mode, v\.share_expires_at, v\.share_password FROM videos v WHERE v\.share_token = \$1 AND v\.status IN \('ready', 'processing'\)`).
+		WithArgs(shareToken).
+		WillReturnRows(commentVideoRows().AddRow(videoID, ownerID, "anonymous", expiresAt, (*string)(nil)))
+
+	mock.ExpectQuery(`INSERT INTO video_comments`).
+		WithArgs(videoID, (*string)(nil), "", "", "🎉", false, (*float64)(nil)).
+		WillReturnRows(pgxmock.NewRows([]string{"id", "created_at"}).AddRow("comment-1", time.Now()))
+
+	body, _ := json.Marshal(postCommentRequest{Body: "🎉"})
+
+	r := chi.NewRouter()
+	r.Post("/api/watch/{shareToken}/comments", handler.PostWatchComment)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/watch/"+shareToken+"/comments", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("expected status %d, got %d: %s", http.StatusCreated, rec.Code, rec.Body.String())
+	}
+
+	// Notification is sent asynchronously for non-reaction comments.
+	time.Sleep(50 * time.Millisecond)
+	if notifier.called {
+		t.Fatal("expected no comment notification for quick reactions")
+	}
+}
+
+func TestPostWatchComment_NotificationModeViewsOnly_DoesNotSendCommentNotification(t *testing.T) {
+	mock, err := pgxmock.NewPool()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer mock.Close()
+
+	storage := &mockStorage{}
+	handler := NewHandler(mock, storage, testBaseURL, 0, 0, 0, testJWTSecret, false)
+	notifier := &mockCommentNotifier{}
+	handler.SetCommentNotifier(notifier)
+
+	shareToken := "abc123defghi"
+	videoID := "video-123"
+	ownerID := "owner-user-1"
+	expiresAt := time.Now().Add(24 * time.Hour)
+
+	mock.ExpectQuery(`SELECT v\.id, v\.user_id, v\.comment_mode, v\.share_expires_at, v\.share_password FROM videos v WHERE v\.share_token = \$1 AND v\.status IN \('ready', 'processing'\)`).
+		WithArgs(shareToken).
+		WillReturnRows(commentVideoRows().AddRow(videoID, ownerID, "anonymous", expiresAt, (*string)(nil)))
+
+	mock.ExpectQuery(`INSERT INTO video_comments`).
+		WithArgs(videoID, (*string)(nil), "Someone", "", "Great video!", false, (*float64)(nil)).
+		WillReturnRows(pgxmock.NewRows([]string{"id", "created_at"}).AddRow("comment-1", time.Now()))
+
+	mock.ExpectQuery(`SELECT view_notification FROM notification_preferences WHERE user_id = \$1`).
+		WithArgs(ownerID).
+		WillReturnRows(pgxmock.NewRows([]string{"view_notification"}).AddRow("views_only"))
+
+	body, _ := json.Marshal(postCommentRequest{
+		AuthorName: "Someone",
+		Body:       "Great video!",
+	})
+
+	r := chi.NewRouter()
+	r.Post("/api/watch/{shareToken}/comments", handler.PostWatchComment)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/watch/"+shareToken+"/comments", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("expected status %d, got %d: %s", http.StatusCreated, rec.Code, rec.Body.String())
+	}
+
+	time.Sleep(50 * time.Millisecond)
+	if notifier.called {
+		t.Fatal("expected no comment notification when account mode is views_only")
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet pgxmock expectations: %v", err)
+	}
+}
+
+func TestPostWatchComment_NotificationModeCommentsOnly_SendsCommentNotification(t *testing.T) {
+	mock, err := pgxmock.NewPool()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer mock.Close()
+
+	storage := &mockStorage{}
+	handler := NewHandler(mock, storage, testBaseURL, 0, 0, 0, testJWTSecret, false)
+	notifier := &mockCommentNotifier{}
+	handler.SetCommentNotifier(notifier)
+
+	shareToken := "abc123defghi"
+	videoID := "video-123"
+	ownerID := "owner-user-1"
+	expiresAt := time.Now().Add(24 * time.Hour)
+
+	mock.ExpectQuery(`SELECT v\.id, v\.user_id, v\.comment_mode, v\.share_expires_at, v\.share_password FROM videos v WHERE v\.share_token = \$1 AND v\.status IN \('ready', 'processing'\)`).
+		WithArgs(shareToken).
+		WillReturnRows(commentVideoRows().AddRow(videoID, ownerID, "anonymous", expiresAt, (*string)(nil)))
+
+	mock.ExpectQuery(`INSERT INTO video_comments`).
+		WithArgs(videoID, (*string)(nil), "Someone", "", "Great video!", false, (*float64)(nil)).
+		WillReturnRows(pgxmock.NewRows([]string{"id", "created_at"}).AddRow("comment-1", time.Now()))
+
+	mock.ExpectQuery(`SELECT view_notification FROM notification_preferences WHERE user_id = \$1`).
+		WithArgs(ownerID).
+		WillReturnRows(pgxmock.NewRows([]string{"view_notification"}).AddRow("comments_only"))
+
+	mock.ExpectQuery(`SELECT u\.email, u\.name, v\.title FROM users u JOIN videos v ON v\.user_id = u\.id WHERE v\.id = \$1`).
+		WithArgs(videoID).
+		WillReturnRows(pgxmock.NewRows([]string{"email", "name", "title"}).AddRow("owner@example.com", "Owner", "My Video"))
+
+	body, _ := json.Marshal(postCommentRequest{
+		AuthorName: "Someone",
+		Body:       "Great video!",
+	})
+
+	r := chi.NewRouter()
+	r.Post("/api/watch/{shareToken}/comments", handler.PostWatchComment)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/watch/"+shareToken+"/comments", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("expected status %d, got %d: %s", http.StatusCreated, rec.Code, rec.Body.String())
+	}
+
+	time.Sleep(50 * time.Millisecond)
+	if !notifier.called {
+		t.Fatal("expected comment notification when account mode is comments_only")
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet pgxmock expectations: %v", err)
 	}
 }
 

--- a/internal/video/digest_worker.go
+++ b/internal/video/digest_worker.go
@@ -27,17 +27,40 @@ type userDigest struct {
 
 func processDigest(ctx context.Context, db database.DBTX, notifier ViewNotifier, baseURL string) {
 	rows, err := db.Query(ctx,
-		`SELECT v.id, v.title, v.share_token, v.user_id, u.email, u.name,
-		        COUNT(vv.id) as view_count
-		 FROM video_views vv
-		 JOIN videos v ON v.id = vv.video_id
+		`WITH recent_views AS (
+		     SELECT video_id, COUNT(*) AS view_count
+		     FROM video_views
+		     WHERE created_at >= NOW() - INTERVAL '24 hours'
+		     GROUP BY video_id
+		 ),
+		 recent_comments AS (
+		     SELECT video_id, COUNT(*) AS comment_count
+		     FROM video_comments
+		     WHERE created_at >= NOW() - INTERVAL '24 hours'
+		       AND is_private = false
+		     GROUP BY video_id
+		 )
+		 SELECT v.id, v.title, v.share_token, v.user_id, u.email, u.name,
+		        CASE
+		          WHEN COALESCE(v.view_notification, 'digest') = 'digest' THEN COALESCE(rv.view_count, 0)
+		          ELSE 0
+		        END AS view_count,
+		        COALESCE(rc.comment_count, 0) AS comment_count
+		 FROM videos v
 		 JOIN users u ON u.id = v.user_id
 		 LEFT JOIN notification_preferences np ON np.user_id = v.user_id
-		 WHERE vv.created_at >= NOW() - INTERVAL '24 hours'
-		   AND COALESCE(v.view_notification, np.view_notification, 'off') = 'digest'
-		   AND v.status != 'deleted'
-		 GROUP BY v.id, v.title, v.share_token, v.user_id, u.email, u.name
-		 ORDER BY v.user_id, view_count DESC`)
+		 LEFT JOIN recent_views rv ON rv.video_id = v.id
+		 LEFT JOIN recent_comments rc ON rc.video_id = v.id
+		 WHERE v.status != 'deleted'
+		   AND COALESCE(np.view_notification, 'off') = 'digest'
+		   AND (
+		     CASE
+		       WHEN COALESCE(v.view_notification, 'digest') = 'digest' THEN COALESCE(rv.view_count, 0)
+		       ELSE 0
+		     END > 0
+		     OR COALESCE(rc.comment_count, 0) > 0
+		   )
+		 ORDER BY v.user_id, view_count DESC, comment_count DESC`)
 	if err != nil {
 		log.Printf("digest-worker: query failed: %v", err)
 		return
@@ -47,8 +70,8 @@ func processDigest(ctx context.Context, db database.DBTX, notifier ViewNotifier,
 	digests := make(map[string]*userDigest)
 	for rows.Next() {
 		var videoID, title, shareToken, userID, ownerEmail, name string
-		var viewCount int64
-		if err := rows.Scan(&videoID, &title, &shareToken, &userID, &ownerEmail, &name, &viewCount); err != nil {
+		var viewCount, commentCount int64
+		if err := rows.Scan(&videoID, &title, &shareToken, &userID, &ownerEmail, &name, &viewCount, &commentCount); err != nil {
 			log.Printf("digest-worker: scan failed: %v", err)
 			continue
 		}
@@ -58,9 +81,10 @@ func processDigest(ctx context.Context, db database.DBTX, notifier ViewNotifier,
 			digests[userID] = d
 		}
 		d.videos = append(d.videos, email.DigestVideoSummary{
-			Title:     title,
-			ViewCount: int(viewCount),
-			WatchURL:  baseURL + "/watch/" + shareToken,
+			Title:        title,
+			ViewCount:    int(viewCount),
+			CommentCount: int(commentCount),
+			WatchURL:     baseURL + "/watch/" + shareToken,
 		})
 	}
 	if err := rows.Err(); err != nil {

--- a/internal/video/watch_page_test.go
+++ b/internal/video/watch_page_test.go
@@ -355,6 +355,24 @@ func TestWatchPage_CommentsEnabled_RendersCommentForm(t *testing.T) {
 	if !strings.Contains(body, "body: JSON.stringify({authorName: '', authorEmail: '', body: emoji, isPrivate: false, videoTimestamp: timestamp})") {
 		t.Error("expected reaction payload to use anonymous author name/email")
 	}
+	if !strings.Contains(body, `id="reaction-error"`) {
+		t.Error("expected reaction error feedback element")
+	}
+	if !strings.Contains(body, `var reactionEmojis = ["👍","👎","❤️","😂","😮","🎉"];`) {
+		t.Error("expected reaction emojis to be sourced from backend-generated JSON list")
+	}
+	if !strings.Contains(body, `class="reaction-btn"`) || !strings.Contains(body, `aria-label="React with`) {
+		t.Error("expected reaction buttons to include accessibility labels")
+	}
+	if !strings.Contains(body, `dot.type = 'button';`) {
+		t.Error("expected marker dots to be keyboard-accessible buttons")
+	}
+	if !strings.Contains(body, `type="button" class="comment emoji-reaction"`) {
+		t.Error("expected emoji reactions to render as button elements for keyboard access")
+	}
+	if !strings.Contains(body, `reactionErrorEl.textContent =`) {
+		t.Error("expected reaction errors to be surfaced to users")
+	}
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Errorf("unmet expectations: %v", err)
 	}

--- a/migrations/000028_unified_notification_modes.down.sql
+++ b/migrations/000028_unified_notification_modes.down.sql
@@ -1,0 +1,25 @@
+UPDATE notification_preferences
+SET view_notification = CASE view_notification
+    WHEN 'views_only' THEN 'every'
+    WHEN 'views_and_comments' THEN 'every'
+    WHEN 'comments_only' THEN 'off'
+    WHEN 'digest' THEN 'digest'
+    WHEN 'off' THEN 'off'
+    WHEN 'every' THEN 'every'
+    WHEN 'first' THEN 'first'
+    ELSE 'off'
+END;
+
+ALTER TABLE notification_preferences
+    DROP CONSTRAINT IF EXISTS notification_preferences_view_notification_check;
+
+ALTER TABLE notification_preferences
+    ADD CONSTRAINT notification_preferences_view_notification_check
+    CHECK (view_notification IN ('off', 'every', 'first', 'digest'));
+
+ALTER TABLE videos
+    DROP CONSTRAINT IF EXISTS videos_view_notification_check;
+
+ALTER TABLE videos
+    ADD CONSTRAINT videos_view_notification_check
+    CHECK (view_notification IS NULL OR view_notification IN ('off', 'every', 'first', 'digest'));

--- a/migrations/000028_unified_notification_modes.up.sql
+++ b/migrations/000028_unified_notification_modes.up.sql
@@ -1,0 +1,29 @@
+UPDATE notification_preferences
+SET view_notification = CASE view_notification
+    WHEN 'every' THEN 'views_only'
+    WHEN 'first' THEN 'views_only'
+    WHEN 'off' THEN 'off'
+    WHEN 'digest' THEN 'digest'
+    WHEN 'views_only' THEN 'views_only'
+    WHEN 'comments_only' THEN 'comments_only'
+    WHEN 'views_and_comments' THEN 'views_and_comments'
+    ELSE 'off'
+END;
+
+ALTER TABLE notification_preferences
+    DROP CONSTRAINT IF EXISTS notification_preferences_view_notification_check;
+
+ALTER TABLE notification_preferences
+    ADD CONSTRAINT notification_preferences_view_notification_check
+    CHECK (view_notification IN ('off', 'views_only', 'comments_only', 'views_and_comments', 'digest'));
+
+UPDATE videos
+SET view_notification = 'every'
+WHERE view_notification = 'first';
+
+ALTER TABLE videos
+    DROP CONSTRAINT IF EXISTS videos_view_notification_check;
+
+ALTER TABLE videos
+    ADD CONSTRAINT videos_view_notification_check
+    CHECK (view_notification IS NULL OR view_notification IN ('off', 'every', 'digest'));

--- a/web/src/pages/Library.test.tsx
+++ b/web/src/pages/Library.test.tsx
@@ -937,12 +937,12 @@ describe("Library", () => {
     });
 
     await openOverflowMenu(user);
-    await user.selectOptions(screen.getByLabelText("View notifications"), "first");
+    await user.selectOptions(screen.getByLabelText("View notifications"), "every");
 
     await waitFor(() => {
       expect(mockApiFetch).toHaveBeenCalledWith("/api/videos/v1/notifications", {
         method: "PUT",
-        body: JSON.stringify({ viewNotification: "first" }),
+        body: JSON.stringify({ viewNotification: "every" }),
       });
     });
   });

--- a/web/src/pages/Library.tsx
+++ b/web/src/pages/Library.tsx
@@ -787,7 +787,6 @@ export function Library() {
                               <option value="">Account default</option>
                               <option value="off">Off</option>
                               <option value="every">Every view</option>
-                              <option value="first">First view only</option>
                               <option value="digest">Daily digest</option>
                             </select>
                           </label>

--- a/web/src/pages/Settings.test.tsx
+++ b/web/src/pages/Settings.test.tsx
@@ -36,7 +36,7 @@ describe("Settings", () => {
   it("loads and displays profile", async () => {
     mockApiFetch
       .mockResolvedValueOnce({ name: "Alice", email: "alice@example.com" })
-      .mockResolvedValueOnce({ viewNotification: "off" })
+      .mockResolvedValueOnce({ notificationMode: "off" })
       .mockResolvedValueOnce({ brandingEnabled: false })
       .mockResolvedValueOnce([]);
     renderSettings();
@@ -50,7 +50,7 @@ describe("Settings", () => {
   it("disables email field", async () => {
     mockApiFetch
       .mockResolvedValueOnce({ name: "Alice", email: "alice@example.com" })
-      .mockResolvedValueOnce({ viewNotification: "off" })
+      .mockResolvedValueOnce({ notificationMode: "off" })
       .mockResolvedValueOnce({ brandingEnabled: false })
       .mockResolvedValueOnce([]);
     renderSettings();
@@ -63,7 +63,7 @@ describe("Settings", () => {
   it("disables save button when name is unchanged", async () => {
     mockApiFetch
       .mockResolvedValueOnce({ name: "Alice", email: "alice@example.com" })
-      .mockResolvedValueOnce({ viewNotification: "off" })
+      .mockResolvedValueOnce({ notificationMode: "off" })
       .mockResolvedValueOnce({ brandingEnabled: false })
       .mockResolvedValueOnce([]);
     renderSettings();
@@ -77,7 +77,7 @@ describe("Settings", () => {
     const user = userEvent.setup();
     mockApiFetch
       .mockResolvedValueOnce({ name: "Alice", email: "alice@example.com" })
-      .mockResolvedValueOnce({ viewNotification: "off" })
+      .mockResolvedValueOnce({ notificationMode: "off" })
       .mockResolvedValueOnce({ brandingEnabled: false })
       .mockResolvedValueOnce([]);
     renderSettings();
@@ -96,7 +96,7 @@ describe("Settings", () => {
     const user = userEvent.setup();
     mockApiFetch
       .mockResolvedValueOnce({ name: "Alice", email: "alice@example.com" })
-      .mockResolvedValueOnce({ viewNotification: "off" })
+      .mockResolvedValueOnce({ notificationMode: "off" })
       .mockResolvedValueOnce({ brandingEnabled: false })
       .mockResolvedValueOnce([]) // api-keys
       .mockResolvedValueOnce(undefined); // PATCH response
@@ -124,7 +124,7 @@ describe("Settings", () => {
     const user = userEvent.setup();
     mockApiFetch
       .mockResolvedValueOnce({ name: "Alice", email: "alice@example.com" })
-      .mockResolvedValueOnce({ viewNotification: "off" })
+      .mockResolvedValueOnce({ notificationMode: "off" })
       .mockResolvedValueOnce({ brandingEnabled: false })
       .mockResolvedValueOnce([])
       .mockRejectedValueOnce(new Error("Failed to update name"));
@@ -147,7 +147,7 @@ describe("Settings", () => {
     const user = userEvent.setup();
     mockApiFetch
       .mockResolvedValueOnce({ name: "Alice", email: "alice@example.com" })
-      .mockResolvedValueOnce({ viewNotification: "off" })
+      .mockResolvedValueOnce({ notificationMode: "off" })
       .mockResolvedValueOnce({ brandingEnabled: false })
       .mockResolvedValueOnce([]);
     renderSettings();
@@ -168,7 +168,7 @@ describe("Settings", () => {
     const user = userEvent.setup();
     mockApiFetch
       .mockResolvedValueOnce({ name: "Alice", email: "alice@example.com" })
-      .mockResolvedValueOnce({ viewNotification: "off" })
+      .mockResolvedValueOnce({ notificationMode: "off" })
       .mockResolvedValueOnce({ brandingEnabled: false })
       .mockResolvedValueOnce([]) // api-keys
       .mockResolvedValueOnce(undefined); // PATCH response
@@ -197,7 +197,7 @@ describe("Settings", () => {
     const user = userEvent.setup();
     mockApiFetch
       .mockResolvedValueOnce({ name: "Alice", email: "alice@example.com" })
-      .mockResolvedValueOnce({ viewNotification: "off" })
+      .mockResolvedValueOnce({ notificationMode: "off" })
       .mockResolvedValueOnce({ brandingEnabled: false })
       .mockResolvedValueOnce([]) // api-keys
       .mockResolvedValueOnce(undefined); // PATCH response
@@ -224,27 +224,27 @@ describe("Settings", () => {
   it("loads and displays notification preference", async () => {
     mockApiFetch
       .mockResolvedValueOnce({ name: "Alice", email: "alice@example.com" })
-      .mockResolvedValueOnce({ viewNotification: "every" })
+      .mockResolvedValueOnce({ notificationMode: "views_and_comments" })
       .mockResolvedValueOnce({ brandingEnabled: false })
       .mockResolvedValueOnce([]);
     renderSettings();
 
     await waitFor(() => {
-      const select = screen.getByLabelText("View notifications") as HTMLSelectElement;
-      expect(select.value).toBe("every");
+      const select = screen.getByLabelText("Notifications") as HTMLSelectElement;
+      expect(select.value).toBe("views_and_comments");
     });
   });
 
   it("defaults notification preference to off", async () => {
     mockApiFetch
       .mockResolvedValueOnce({ name: "Alice", email: "alice@example.com" })
-      .mockResolvedValueOnce({ viewNotification: "off" })
+      .mockResolvedValueOnce({ notificationMode: "off" })
       .mockResolvedValueOnce({ brandingEnabled: false })
       .mockResolvedValueOnce([]);
     renderSettings();
 
     await waitFor(() => {
-      const select = screen.getByLabelText("View notifications") as HTMLSelectElement;
+      const select = screen.getByLabelText("Notifications") as HTMLSelectElement;
       expect(select.value).toBe("off");
     });
   });
@@ -253,22 +253,22 @@ describe("Settings", () => {
     const user = userEvent.setup();
     mockApiFetch
       .mockResolvedValueOnce({ name: "Alice", email: "alice@example.com" })
-      .mockResolvedValueOnce({ viewNotification: "off" })
+      .mockResolvedValueOnce({ notificationMode: "off" })
       .mockResolvedValueOnce({ brandingEnabled: false })
       .mockResolvedValueOnce([]) // api-keys
       .mockResolvedValueOnce(undefined); // PUT response
     renderSettings();
 
     await waitFor(() => {
-      expect(screen.getByLabelText("View notifications")).toBeInTheDocument();
+      expect(screen.getByLabelText("Notifications")).toBeInTheDocument();
     });
 
-    await user.selectOptions(screen.getByLabelText("View notifications"), "digest");
+    await user.selectOptions(screen.getByLabelText("Notifications"), "digest");
 
     await waitFor(() => {
       expect(mockApiFetch).toHaveBeenCalledWith("/api/settings/notifications", {
         method: "PUT",
-        body: JSON.stringify({ viewNotification: "digest" }),
+        body: JSON.stringify({ notificationMode: "digest" }),
       });
     });
   });
@@ -277,17 +277,17 @@ describe("Settings", () => {
     const user = userEvent.setup();
     mockApiFetch
       .mockResolvedValueOnce({ name: "Alice", email: "alice@example.com" })
-      .mockResolvedValueOnce({ viewNotification: "off" })
+      .mockResolvedValueOnce({ notificationMode: "off" })
       .mockResolvedValueOnce({ brandingEnabled: false })
       .mockResolvedValueOnce([]) // api-keys
       .mockResolvedValueOnce(undefined); // PUT response
     renderSettings();
 
     await waitFor(() => {
-      expect(screen.getByLabelText("View notifications")).toBeInTheDocument();
+      expect(screen.getByLabelText("Notifications")).toBeInTheDocument();
     });
 
-    await user.selectOptions(screen.getByLabelText("View notifications"), "every");
+    await user.selectOptions(screen.getByLabelText("Notifications"), "views_only");
 
     await waitFor(() => {
       expect(screen.getByText("Preference saved")).toBeInTheDocument();
@@ -297,7 +297,7 @@ describe("Settings", () => {
   it("shows branding section when enabled", async () => {
     mockApiFetch
       .mockResolvedValueOnce({ name: "Alice", email: "alice@example.com" })
-      .mockResolvedValueOnce({ viewNotification: "off" })
+      .mockResolvedValueOnce({ notificationMode: "off" })
       .mockResolvedValueOnce({ brandingEnabled: true })
       .mockResolvedValueOnce([])
       .mockResolvedValueOnce({ companyName: null, colorBackground: null, colorSurface: null, colorText: null, colorAccent: null, footerText: null, logoKey: null, customCss: null });
@@ -311,7 +311,7 @@ describe("Settings", () => {
   it("hides branding section when disabled", async () => {
     mockApiFetch
       .mockResolvedValueOnce({ name: "Alice", email: "alice@example.com" })
-      .mockResolvedValueOnce({ viewNotification: "off" })
+      .mockResolvedValueOnce({ notificationMode: "off" })
       .mockResolvedValueOnce({ brandingEnabled: false })
       .mockResolvedValueOnce([]);
     renderSettings();
@@ -325,7 +325,7 @@ describe("Settings", () => {
   it("loads existing branding settings", async () => {
     mockApiFetch
       .mockResolvedValueOnce({ name: "Alice", email: "alice@example.com" })
-      .mockResolvedValueOnce({ viewNotification: "off" })
+      .mockResolvedValueOnce({ notificationMode: "off" })
       .mockResolvedValueOnce({ brandingEnabled: true })
       .mockResolvedValueOnce([])
       .mockResolvedValueOnce({ companyName: "Acme Corp", colorBackground: "#112233", colorSurface: null, colorText: null, colorAccent: null, footerText: null, logoKey: null, customCss: null });
@@ -340,7 +340,7 @@ describe("Settings", () => {
     const user = userEvent.setup();
     mockApiFetch
       .mockResolvedValueOnce({ name: "Alice", email: "alice@example.com" })
-      .mockResolvedValueOnce({ viewNotification: "off" })
+      .mockResolvedValueOnce({ notificationMode: "off" })
       .mockResolvedValueOnce({ brandingEnabled: true })
       .mockResolvedValueOnce([])
       .mockResolvedValueOnce({ companyName: null, colorBackground: null, colorSurface: null, colorText: null, colorAccent: null, footerText: null, logoKey: null, customCss: null })
@@ -363,7 +363,7 @@ describe("Settings", () => {
     const user = userEvent.setup();
     mockApiFetch
       .mockResolvedValueOnce({ name: "Alice", email: "alice@example.com" })
-      .mockResolvedValueOnce({ viewNotification: "off" })
+      .mockResolvedValueOnce({ notificationMode: "off" })
       .mockResolvedValueOnce({ brandingEnabled: true })
       .mockResolvedValueOnce([])
       .mockResolvedValueOnce({ companyName: "Acme Corp", colorBackground: "#112233", colorSurface: null, colorText: null, colorAccent: null, footerText: null, logoKey: null, customCss: null });
@@ -381,7 +381,7 @@ describe("Settings", () => {
   it("shows API Keys section", async () => {
     mockApiFetch
       .mockResolvedValueOnce({ name: "Alice", email: "alice@example.com" })
-      .mockResolvedValueOnce({ viewNotification: "off" })
+      .mockResolvedValueOnce({ notificationMode: "off" })
       .mockResolvedValueOnce({ brandingEnabled: false })
       .mockResolvedValueOnce([]);
     renderSettings();
@@ -394,7 +394,7 @@ describe("Settings", () => {
   it("displays existing API keys", async () => {
     mockApiFetch
       .mockResolvedValueOnce({ name: "Alice", email: "alice@example.com" })
-      .mockResolvedValueOnce({ viewNotification: "off" })
+      .mockResolvedValueOnce({ notificationMode: "off" })
       .mockResolvedValueOnce({ brandingEnabled: false })
       .mockResolvedValueOnce([
         { id: "key-1", name: "My Nextcloud", createdAt: "2026-02-16T10:00:00Z", lastUsedAt: "2026-02-16T12:00:00Z" },
@@ -412,7 +412,7 @@ describe("Settings", () => {
     const user = userEvent.setup();
     mockApiFetch
       .mockResolvedValueOnce({ name: "Alice", email: "alice@example.com" })
-      .mockResolvedValueOnce({ viewNotification: "off" })
+      .mockResolvedValueOnce({ notificationMode: "off" })
       .mockResolvedValueOnce({ brandingEnabled: false })
       .mockResolvedValueOnce([])
       .mockResolvedValueOnce({ id: "new-key-1", key: "sr_abc123", name: "Test Key", createdAt: "2026-02-16T10:00:00Z" });
@@ -436,7 +436,7 @@ describe("Settings", () => {
     const user = userEvent.setup();
     mockApiFetch
       .mockResolvedValueOnce({ name: "Alice", email: "alice@example.com" })
-      .mockResolvedValueOnce({ viewNotification: "off" })
+      .mockResolvedValueOnce({ notificationMode: "off" })
       .mockResolvedValueOnce({ brandingEnabled: false })
       .mockResolvedValueOnce([
         { id: "key-1", name: "My Key", createdAt: "2026-02-16T10:00:00Z", lastUsedAt: null },
@@ -460,7 +460,7 @@ describe("Settings", () => {
   it("shows custom CSS textarea when branding enabled", async () => {
     mockApiFetch
       .mockResolvedValueOnce({ name: "Alice", email: "alice@example.com" })
-      .mockResolvedValueOnce({ viewNotification: "off" })
+      .mockResolvedValueOnce({ notificationMode: "off" })
       .mockResolvedValueOnce({ brandingEnabled: true })
       .mockResolvedValueOnce([])
       .mockResolvedValueOnce({ companyName: null, colorBackground: null, colorSurface: null, colorText: null, colorAccent: null, footerText: null, logoKey: null, customCss: null });
@@ -475,7 +475,7 @@ describe("Settings", () => {
     const user = userEvent.setup();
     mockApiFetch
       .mockResolvedValueOnce({ name: "Alice", email: "alice@example.com" })
-      .mockResolvedValueOnce({ viewNotification: "off" })
+      .mockResolvedValueOnce({ notificationMode: "off" })
       .mockResolvedValueOnce({ brandingEnabled: true })
       .mockResolvedValueOnce([])
       .mockResolvedValueOnce({ companyName: null, colorBackground: null, colorSurface: null, colorText: null, colorAccent: null, footerText: null, logoKey: null, customCss: null })
@@ -506,7 +506,7 @@ describe("Settings", () => {
     const user = userEvent.setup();
     mockApiFetch
       .mockResolvedValueOnce({ name: "Alice", email: "alice@example.com" })
-      .mockResolvedValueOnce({ viewNotification: "off" })
+      .mockResolvedValueOnce({ notificationMode: "off" })
       .mockResolvedValueOnce({ brandingEnabled: false })
       .mockResolvedValueOnce([])
       .mockRejectedValueOnce(new Error("maximum number of API keys reached"));

--- a/web/src/pages/Settings.tsx
+++ b/web/src/pages/Settings.tsx
@@ -38,7 +38,7 @@ export function Settings() {
   const [passwordError, setPasswordError] = useState("");
   const [savingName, setSavingName] = useState(false);
   const [savingPassword, setSavingPassword] = useState(false);
-  const [viewNotification, setViewNotification] = useState("off");
+  const [notificationMode, setNotificationMode] = useState("off");
   const [notificationMessage, setNotificationMessage] = useState("");
   const [apiKeys, setApiKeys] = useState<APIKeyItem[]>([]);
   const [newKeyName, setNewKeyName] = useState("");
@@ -62,7 +62,7 @@ export function Settings() {
       try {
         const [result, notifPrefs, limits, keys] = await Promise.all([
           apiFetch<UserProfile>("/api/user"),
-          apiFetch<{ viewNotification: string }>("/api/settings/notifications"),
+          apiFetch<{ notificationMode: string }>("/api/settings/notifications"),
           apiFetch<{ brandingEnabled: boolean }>("/api/videos/limits"),
           apiFetch<APIKeyItem[]>("/api/settings/api-keys"),
         ]);
@@ -71,7 +71,7 @@ export function Settings() {
           setName(result.name);
         }
         if (notifPrefs) {
-          setViewNotification(notifPrefs.viewNotification);
+          setNotificationMode(notifPrefs.notificationMode);
         }
         if (keys) {
           setApiKeys(keys);
@@ -144,16 +144,16 @@ export function Settings() {
 
   async function handleNotificationChange(value: string) {
     setNotificationMessage("");
-    const previous = viewNotification;
-    setViewNotification(value);
+    const previous = notificationMode;
+    setNotificationMode(value);
     try {
       await apiFetch("/api/settings/notifications", {
         method: "PUT",
-        body: JSON.stringify({ viewNotification: value }),
+        body: JSON.stringify({ notificationMode: value }),
       });
       setNotificationMessage("Preference saved");
     } catch {
-      setViewNotification(previous);
+      setNotificationMode(previous);
       setNotificationMessage("Failed to save");
     }
   }
@@ -377,20 +377,21 @@ export function Settings() {
       >
         <h2 style={{ color: "var(--color-text)", fontSize: 18, margin: 0 }}>Notifications</h2>
         <p style={{ color: "var(--color-text-secondary)", fontSize: 14, margin: 0 }}>
-          When someone watches one of your videos, get notified by email.
+          Choose when to get email notifications for views and comments.
         </p>
 
         <label style={{ display: "flex", flexDirection: "column", gap: 4 }}>
-          <span style={{ color: "var(--color-text-secondary)", fontSize: 14 }}>View notifications</span>
+          <span style={{ color: "var(--color-text-secondary)", fontSize: 14 }}>Notifications</span>
           <select
-            value={viewNotification}
+            value={notificationMode}
             onChange={(e) => handleNotificationChange(e.target.value)}
             style={inputStyle}
           >
             <option value="off">Off</option>
-            <option value="every">Every view</option>
-            <option value="first">First view only</option>
-            <option value="digest">Daily digest</option>
+            <option value="views_only">Views only</option>
+            <option value="comments_only">Comments only</option>
+            <option value="views_and_comments">Views + comments</option>
+            <option value="digest">Daily digest (views + comments)</option>
           </select>
         </label>
 


### PR DESCRIPTION
## Summary
- replace account-level view-only preference with a unified `notificationMode` model:
  - `off`, `views_only`, `comments_only`, `views_and_comments`, `digest`
- keep per-video override for view delivery only, removing legacy `first` option
- gate immediate comment emails behind notification settings (while still skipping quick-reaction and private comments)
- extend daily digest payload to include both views and comments
- update Settings UI to a single Notifications dropdown with agreed options
- add migration to map legacy values and enforce updated DB constraints

## API and Docs
- `/api/settings/notifications` now reads/writes `notificationMode`
- OpenAPI schemas updated for account and per-video notification enums

## Testing
- `go test ./... -count=1`
- `npm test`
- `npm run typecheck`
- `npm run build`
