### PR TITLE
Fix transcript polling inflating view counts

### DIFF
--- a/internal/video/watch_page.go
+++ b/internal/video/watch_page.go
@@ -1274,7 +1274,7 @@ var watchPageTemplate = template.Must(template.New("watch").Funcs(watchFuncs).Pa
         {{if or (eq .TranscriptStatus "processing") (eq .TranscriptStatus "pending")}}
         (function() {
             var pollInterval = setInterval(function() {
-                fetch('/api/watch/{{.ShareToken}}')
+                fetch('/api/watch/{{.ShareToken}}?poll=transcript')
                     .then(function(r) { return r.json(); })
                     .then(function(data) {
                         if (data.transcriptStatus === 'ready' || data.transcriptStatus === 'failed') {


### PR DESCRIPTION
## Summary

- Fix watch page transcript polling recording a new view + triggering a notification every 10 seconds while the transcript is processing
- Add `?poll=transcript` query param to the Watch API; when present, view recording and notifications are skipped
- Update watch page JS to use the new param for transcript status polling

## Test plan

- [x] Verify `TestWatch_TranscriptPoll_SkipsViewRecording` passes — poll request returns video data without recording a view
- [x] Verify `TestWatch_RecordsView` still passes — normal watch requests still record views
- [x] Manual: upload a video, open the watch page while transcript is processing, confirm view count doesn't inflate every 10s