### PR TITLE
Add configurable AI_TIMEOUT for AI API requests

### DIFF
--- a/SELF-HOSTING.md
+++ b/SELF-HOSTING.md
@@ -272,13 +272,14 @@ Generate automatic summaries and chapter markers for transcribed videos using an
 | `AI_BASE_URL` | OpenAI-compatible API base URL | — |
 | `AI_API_KEY` | API key for the AI provider | — |
 | `AI_MODEL` | Model name to use | `mistral-small-latest` |
+| `AI_TIMEOUT` | HTTP timeout for AI API requests. Applies to all providers. Increase for slower endpoints like local Ollama. Uses Go duration format (`60s`, `5m`, `10m`) | `60s` |
 
 **Supported providers:** Any OpenAI-compatible API — Mistral AI, OpenAI, Ollama (local), and others.
 
 Examples:
 - **Mistral AI:** `AI_BASE_URL=https://api.mistral.ai`, `AI_API_KEY=your-key`, `AI_MODEL=mistral-small-latest`
 - **OpenAI:** `AI_BASE_URL=https://api.openai.com`, `AI_API_KEY=your-key`, `AI_MODEL=gpt-4o-mini`
-- **Ollama (local):** `AI_BASE_URL=http://ollama:11434`, `AI_API_KEY=` (empty), `AI_MODEL=llama3.2`
+- **Ollama (local):** `AI_BASE_URL=http://ollama:11434`, `AI_API_KEY=` (empty), `AI_MODEL=llama3.2`, `AI_TIMEOUT=5m`
 
 ### Webhooks (optional)
 

--- a/cmd/sendrec/main.go
+++ b/cmd/sendrec/main.go
@@ -137,12 +137,19 @@ func main() {
 
 	var aiClient *video.AIClient
 	if aiEnabled {
+		aiTimeout := 60 * time.Second
+		if v := os.Getenv("AI_TIMEOUT"); v != "" {
+			if d, err := time.ParseDuration(v); err == nil {
+				aiTimeout = d
+			}
+		}
 		aiClient = video.NewAIClient(
 			os.Getenv("AI_BASE_URL"),
 			os.Getenv("AI_API_KEY"),
 			getEnv("AI_MODEL", "mistral-small-latest"),
+			aiTimeout,
 		)
-		log.Printf("AI summaries enabled (model: %s)", getEnv("AI_MODEL", "mistral-small-latest"))
+		log.Printf("AI summaries enabled (model: %s, timeout: %s)", getEnv("AI_MODEL", "mistral-small-latest"), aiTimeout)
 	}
 
 	cleanupCtx, cleanupCancel := context.WithCancel(context.Background())

--- a/internal/video/ai_client.go
+++ b/internal/video/ai_client.go
@@ -28,13 +28,16 @@ type AIClient struct {
 	httpClient *http.Client
 }
 
-func NewAIClient(baseURL, apiKey, model string) *AIClient {
+func NewAIClient(baseURL, apiKey, model string, timeout time.Duration) *AIClient {
+	if timeout <= 0 {
+		timeout = 60 * time.Second
+	}
 	return &AIClient{
 		baseURL: baseURL,
 		apiKey:  apiKey,
 		model:   model,
 		httpClient: &http.Client{
-			Timeout: 60 * time.Second,
+			Timeout: timeout,
 		},
 	}
 }

--- a/internal/video/ai_client_test.go
+++ b/internal/video/ai_client_test.go
@@ -35,7 +35,7 @@ func TestAIClient_GenerateSummary(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewAIClient(server.URL, "test-api-key", "gpt-4")
+	client := NewAIClient(server.URL, "test-api-key", "gpt-4", 0)
 	result, err := client.GenerateSummary(context.Background(), "00:00 Hello world 00:45 Testing patterns")
 
 	if err != nil {
@@ -85,7 +85,7 @@ func TestAIClient_GenerateSummary_MarkdownFence(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewAIClient(server.URL, "key", "model")
+	client := NewAIClient(server.URL, "key", "model", 0)
 	result, err := client.GenerateSummary(context.Background(), "transcript")
 
 	if err != nil {
@@ -117,7 +117,7 @@ func TestAIClient_GenerateSummary_InvalidJSON(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewAIClient(server.URL, "key", "model")
+	client := NewAIClient(server.URL, "key", "model", 0)
 	_, err := client.GenerateSummary(context.Background(), "transcript")
 
 	if err == nil {
@@ -135,7 +135,7 @@ func TestAIClient_GenerateSummary_EmptyChoices(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewAIClient(server.URL, "key", "model")
+	client := NewAIClient(server.URL, "key", "model", 0)
 	_, err := client.GenerateSummary(context.Background(), "transcript")
 
 	if err == nil {
@@ -155,7 +155,7 @@ func TestAIClient_GenerateSummary_HTTPError(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewAIClient(server.URL, "bad-key", "model")
+	client := NewAIClient(server.URL, "bad-key", "model", 0)
 	_, err := client.GenerateSummary(context.Background(), "transcript")
 
 	if err == nil {
@@ -213,7 +213,7 @@ func TestGenerateTitle(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewAIClient(server.URL, "test-key", "gpt-4")
+	client := NewAIClient(server.URL, "test-key", "gpt-4", 0)
 	title, err := client.GenerateTitle(context.Background(), "[00:00] Hello world\n[00:45] Testing patterns")
 
 	if err != nil {
@@ -253,7 +253,7 @@ func TestGenerateTitleTrimsQuotes(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewAIClient(server.URL, "key", "model")
+	client := NewAIClient(server.URL, "key", "model", 0)
 	title, err := client.GenerateTitle(context.Background(), "transcript")
 
 	if err != nil {
@@ -282,7 +282,7 @@ func TestGenerateTitleTruncates(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewAIClient(server.URL, "key", "model")
+	client := NewAIClient(server.URL, "key", "model", 0)
 	title, err := client.GenerateTitle(context.Background(), "transcript")
 
 	if err != nil {

--- a/internal/video/summary_worker_test.go
+++ b/internal/video/summary_worker_test.go
@@ -57,7 +57,7 @@ func TestProcessNextSummary_SkipsTrivialTranscript(t *testing.T) {
 	}
 	transcriptJSON, _ := json.Marshal(segments)
 
-	ai := NewAIClient("http://localhost", "key", "model")
+	ai := NewAIClient("http://localhost", "key", "model", 0)
 
 	mock.ExpectExec(`UPDATE videos SET summary_status = 'pending'`).
 		WillReturnResult(pgxmock.NewResult("UPDATE", 0))
@@ -113,7 +113,7 @@ func TestProcessNextSummary_ClaimsAndProcesses(t *testing.T) {
 	}))
 	defer server.Close()
 
-	ai := NewAIClient(server.URL, "test-key", "test-model")
+	ai := NewAIClient(server.URL, "test-key", "test-model", 0)
 
 	// Stuck job reset
 	mock.ExpectExec(`UPDATE videos SET summary_status = 'pending'`).
@@ -181,7 +181,7 @@ func TestProcessNextSummary_SkipsTitleForCustomTitle(t *testing.T) {
 	}))
 	defer server.Close()
 
-	ai := NewAIClient(server.URL, "test-key", "test-model")
+	ai := NewAIClient(server.URL, "test-key", "test-model", 0)
 
 	// Stuck job reset
 	mock.ExpectExec(`UPDATE videos SET summary_status = 'pending'`).
@@ -259,7 +259,7 @@ func TestProcessNextSummary_AIFailure(t *testing.T) {
 	}))
 	defer server.Close()
 
-	ai := NewAIClient(server.URL, "test-key", "test-model")
+	ai := NewAIClient(server.URL, "test-key", "test-model", 0)
 
 	// Stuck job reset
 	mock.ExpectExec(`UPDATE videos SET summary_status = 'pending'`).


### PR DESCRIPTION
## Summary

- Add `AI_TIMEOUT` env var to configure the HTTP timeout for AI API requests (default: `60s`)
- Accepts Go duration format (e.g. `5m`, `300s`, `10m`)
- Document in SELF-HOSTING.md with note that it applies to all providers

Fixes #63 — local Ollama inference on basic GPUs can exceed the previously hardcoded 60-second timeout.

## Test plan

- [x] All existing AI client tests pass with `timeout: 0` (uses default 60s)
- [x] `NewAIClient` accepts duration parameter
- [x] `main.go` parses `AI_TIMEOUT` env var via `time.ParseDuration`
- [x] Full Go test suite passes