### PR TITLE
fix(ci): keep v prefix in published image tags

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -35,7 +35,7 @@ jobs:
 
       - name: Extract version from tag
         id: version
-        run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+        run: echo "version=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
 
       - name: Build and push
         uses: docker/build-push-action@v6


### PR DESCRIPTION
## Summary
- Workflow stripped the `v` from `GITHUB_REF_NAME`, publishing `ghcr.io/sendrec/sendrec:1.84.2` while `SELF-HOSTING.md` and the GitHub releases page use `v1.84.2`.
- Keep the `v` so image tags match docs and release names.

Related: #127 (the public 404 on ghcr is a separate issue — package visibility needs to be flipped to public in package settings).

## Test plan
- [x] Tag a release; confirm `ghcr.io/sendrec/sendrec:v<version>` and `:latest` both publish.
- [x] Confirm Docker Hub tag `:v<version>` publishes alongside `:latest`.