### PR TITLE
feat(sso): add GOOGLE_AUTH_ALLOWED_DOMAINS env var

### DIFF
--- a/SELF-HOSTING.md
+++ b/SELF-HOSTING.md
@@ -300,6 +300,7 @@ SendRec supports Google, Microsoft, and GitHub as social login providers via OAu
 | `MICROSOFT_CLIENT_SECRET` | Microsoft (Entra ID) OAuth 2.0 client secret |
 | `GITHUB_SSO_CLIENT_ID` | GitHub OAuth App client ID |
 | `GITHUB_SSO_CLIENT_SECRET` | GitHub OAuth App client secret |
+| `GOOGLE_AUTH_ALLOWED_DOMAINS` | Comma-separated list of email domains permitted to sign in with Google (e.g. `example.com,partner.com`). When set, only verified Google accounts whose email domain matches one of these entries can authenticate. Exact match only — `example.com` does **not** imply `mail.example.com`. Leave unset to allow any Google account |
 
 Configure the following authorized redirect URIs in each provider's console (replace `<your-base-url>` with your `BASE_URL`, no trailing slash):
 

--- a/cmd/sendrec/main.go
+++ b/cmd/sendrec/main.go
@@ -154,6 +154,7 @@ func main() {
 		CreemOrgBusinessProductID: creemOrgBusinessProductID,
 		GoogleClientID:          getEnv("GOOGLE_CLIENT_ID", ""),
 		GoogleClientSecret:      getEnv("GOOGLE_CLIENT_SECRET", ""),
+		GoogleAllowedDomains:    email.ParseAllowlist(getEnv("GOOGLE_AUTH_ALLOWED_DOMAINS", "")),
 		MicrosoftClientID:       getEnv("MICROSOFT_CLIENT_ID", ""),
 		MicrosoftClientSecret:   getEnv("MICROSOFT_CLIENT_SECRET", ""),
 		GitHubSSOClientID:       getEnv("GITHUB_SSO_CLIENT_ID", ""),

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -63,6 +63,7 @@ type Config struct {
 	GeoIPDBPath             string
 	GoogleClientID          string
 	GoogleClientSecret      string
+	GoogleAllowedDomains    []string
 	MicrosoftClientID       string
 	MicrosoftClientSecret   string
 	GitHubSSOClientID       string
@@ -169,10 +170,11 @@ func New(cfg Config) *Server {
 
 		if cfg.GoogleClientID != "" {
 			googleProvider, err := sso.NewOIDCProvider(context.Background(), sso.OIDCConfig{
-				IssuerURL:    "https://accounts.google.com",
-				ClientID:     cfg.GoogleClientID,
-				ClientSecret: cfg.GoogleClientSecret,
-				RedirectURL:  baseURL + "/api/auth/sso/google/callback",
+				IssuerURL:           "https://accounts.google.com",
+				ClientID:            cfg.GoogleClientID,
+				ClientSecret:        cfg.GoogleClientSecret,
+				RedirectURL:         baseURL + "/api/auth/sso/google/callback",
+				AllowedEmailDomains: cfg.GoogleAllowedDomains,
 			})
 			if err == nil {
 				s.ssoHandler.RegisterProvider("google", googleProvider)

--- a/internal/sso/oidc.go
+++ b/internal/sso/oidc.go
@@ -16,13 +16,21 @@ type OIDCConfig struct {
 	ClientSecret string
 	RedirectURL  string
 	Scopes       []string
+	// AllowedEmailDomains, when non-empty, restricts sign-in to users whose
+	// verified email address matches one of the listed domains exactly
+	// (case-insensitive, without a leading '@'; subdomains are not implied).
+	// The provider must emit an `email_verified` claim equal to true; missing
+	// or false is rejected. Configure per provider — the field is not shared
+	// across providers and currently only Google sets it from env vars.
+	AllowedEmailDomains []string
 }
 
 // OIDCProvider authenticates users via the OpenID Connect protocol.
 type OIDCProvider struct {
-	provider    *oidc.Provider
-	verifier    *oidc.IDTokenVerifier
-	oauthConfig oauth2.Config
+	provider            *oidc.Provider
+	verifier            *oidc.IDTokenVerifier
+	oauthConfig         oauth2.Config
+	allowedEmailDomains []string
 }
 
 // NewOIDCProvider performs OIDC discovery on the issuer URL and returns a
@@ -62,10 +70,53 @@ func NewOIDCProvider(ctx context.Context, cfg OIDCConfig) (*OIDCProvider, error)
 	verifier := provider.Verifier(&oidc.Config{ClientID: cfg.ClientID})
 
 	return &OIDCProvider{
-		provider:    provider,
-		verifier:    verifier,
-		oauthConfig: oauthCfg,
+		provider:            provider,
+		verifier:            verifier,
+		oauthConfig:         oauthCfg,
+		allowedEmailDomains: normalizeDomains(cfg.AllowedEmailDomains),
 	}, nil
+}
+
+func normalizeDomains(in []string) []string {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(in))
+	for _, d := range in {
+		d = strings.TrimSpace(d)
+		d = strings.TrimPrefix(d, "@")
+		d = strings.ToLower(d)
+		if d != "" {
+			out = append(out, d)
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+// matchAllowedDomain reports whether the email's domain is in the allowlist.
+// emailVerified must be true; the caller is responsible for surfacing an error
+// when an unverified email is presented while the allowlist is active.
+func (p *OIDCProvider) checkEmailAllowed(email string, emailVerified bool) error {
+	if len(p.allowedEmailDomains) == 0 {
+		return nil
+	}
+	if !emailVerified {
+		return fmt.Errorf("email %q is not verified by the identity provider", email)
+	}
+	at := strings.LastIndex(email, "@")
+	if at < 0 || at == len(email)-1 {
+		return fmt.Errorf("email %q is malformed", email)
+	}
+	domain := strings.ToLower(email[at+1:])
+	for _, allowed := range p.allowedEmailDomains {
+		if domain == allowed {
+			return nil
+		}
+	}
+	return fmt.Errorf("email domain %q is not in the allowed list", domain)
 }
 
 // AuthURL returns the authorization URL the user should be redirected to.
@@ -97,12 +148,17 @@ func (p *OIDCProvider) extractFromIDToken(ctx context.Context, rawIDToken string
 	}
 
 	var claims struct {
-		Subject string `json:"sub"`
-		Email   string `json:"email"`
-		Name    string `json:"name"`
+		Subject       string `json:"sub"`
+		Email         string `json:"email"`
+		EmailVerified bool   `json:"email_verified"`
+		Name          string `json:"name"`
 	}
 	if err := idToken.Claims(&claims); err != nil {
 		return nil, fmt.Errorf("parse id token claims: %w", err)
+	}
+
+	if err := p.checkEmailAllowed(claims.Email, claims.EmailVerified); err != nil {
+		return nil, err
 	}
 
 	return &UserInfo{
@@ -121,10 +177,15 @@ func (p *OIDCProvider) extractFromUserInfo(ctx context.Context, token *oauth2.To
 	}
 
 	var claims struct {
-		Name string `json:"name"`
+		Name          string `json:"name"`
+		EmailVerified bool   `json:"email_verified"`
 	}
 	if err := userInfo.Claims(&claims); err != nil {
 		return nil, fmt.Errorf("parse userinfo claims: %w", err)
+	}
+
+	if err := p.checkEmailAllowed(userInfo.Email, claims.EmailVerified); err != nil {
+		return nil, err
 	}
 
 	return &UserInfo{

--- a/internal/sso/oidc_test.go
+++ b/internal/sso/oidc_test.go
@@ -62,8 +62,9 @@ func newOIDCTestServer(t *testing.T) (*httptest.Server, *rsa.PrivateKey) {
 		now := time.Now()
 		claims := struct {
 			josejwt.Claims
-			Email string `json:"email"`
-			Name  string `json:"name"`
+			Email         string `json:"email"`
+			EmailVerified bool   `json:"email_verified"`
+			Name          string `json:"name"`
 		}{
 			Claims: josejwt.Claims{
 				Issuer:    serverURL,
@@ -73,8 +74,9 @@ func newOIDCTestServer(t *testing.T) (*httptest.Server, *rsa.PrivateKey) {
 				Expiry:    josejwt.NewNumericDate(now.Add(time.Hour)),
 				NotBefore: josejwt.NewNumericDate(now.Add(-time.Minute)),
 			},
-			Email: "oidc@example.com",
-			Name:  "OIDC User",
+			Email:         "oidc@example.com",
+			EmailVerified: true,
+			Name:          "OIDC User",
 		}
 
 		rawToken, err := josejwt.Signed(signer).Claims(claims).Serialize()
@@ -251,5 +253,269 @@ func TestNewOIDCProvider_InvalidIssuer(t *testing.T) {
 	})
 	if err == nil {
 		t.Fatal("NewOIDCProvider() expected error for invalid issuer")
+	}
+}
+
+// oidcTestOpts controls behavior of newOIDCTestServerWithEmail.
+type oidcTestOpts struct {
+	email           string
+	emailVerified   bool
+	useUserInfoOnly bool // if true, omit id_token from /token; rely on /userinfo
+}
+
+// newOIDCTestServerWithEmail starts an OIDC test server whose token and
+// userinfo endpoints emit a configurable email address and email_verified flag.
+// When opts.useUserInfoOnly is true, the /token endpoint omits id_token, forcing
+// the provider to fall back to the /userinfo endpoint.
+func newOIDCTestServerWithEmail(t *testing.T, opts oidcTestOpts) *httptest.Server {
+	t.Helper()
+
+	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("generate RSA key: %v", err)
+	}
+
+	var serverURL string
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("GET /.well-known/openid-configuration", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"issuer":                 serverURL,
+			"authorization_endpoint": serverURL + "/authorize",
+			"token_endpoint":         serverURL + "/token",
+			"userinfo_endpoint":      serverURL + "/userinfo",
+			"jwks_uri":               serverURL + "/jwks",
+			"id_token_signing_alg_values_supported": []string{"RS256"},
+		})
+	})
+	mux.HandleFunc("GET /jwks", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		jwks := jose.JSONWebKeySet{Keys: []jose.JSONWebKey{{Key: &privateKey.PublicKey, KeyID: "test-key", Algorithm: "RS256", Use: "sig"}}}
+		_ = json.NewEncoder(w).Encode(jwks)
+	})
+	mux.HandleFunc("POST /token", func(w http.ResponseWriter, r *http.Request) {
+		resp := map[string]any{
+			"access_token": "mock-access-token",
+			"token_type":   "Bearer",
+		}
+		if !opts.useUserInfoOnly {
+			signer, err := jose.NewSigner(
+				jose.SigningKey{Algorithm: jose.RS256, Key: privateKey},
+				(&jose.SignerOptions{}).WithHeader("kid", "test-key"),
+			)
+			if err != nil {
+				http.Error(w, "signer error", 500)
+				return
+			}
+			now := time.Now()
+			claims := struct {
+				josejwt.Claims
+				Email         string `json:"email"`
+				EmailVerified bool   `json:"email_verified"`
+				Name          string `json:"name"`
+			}{
+				Claims: josejwt.Claims{
+					Issuer:    serverURL,
+					Subject:   "oidc-user-123",
+					Audience:  josejwt.Audience{"test-client-id"},
+					IssuedAt:  josejwt.NewNumericDate(now),
+					Expiry:    josejwt.NewNumericDate(now.Add(time.Hour)),
+					NotBefore: josejwt.NewNumericDate(now.Add(-time.Minute)),
+				},
+				Email:         opts.email,
+				EmailVerified: opts.emailVerified,
+				Name:          "OIDC User",
+			}
+			rawToken, err := josejwt.Signed(signer).Claims(claims).Serialize()
+			if err != nil {
+				http.Error(w, "token error", 500)
+				return
+			}
+			resp["id_token"] = rawToken
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	})
+	mux.HandleFunc("GET /userinfo", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"sub":            "oidc-user-123",
+			"email":          opts.email,
+			"email_verified": opts.emailVerified,
+			"name":           "OIDC User",
+		})
+	})
+
+	server := httptest.NewServer(mux)
+	serverURL = server.URL
+	return server
+}
+
+func TestOIDCProvider_Exchange_AllowedDomain_Match(t *testing.T) {
+	server := newOIDCTestServerWithEmail(t, oidcTestOpts{email: "user@allowed.com", emailVerified: true})
+	defer server.Close()
+
+	provider, err := NewOIDCProvider(context.Background(), OIDCConfig{
+		IssuerURL:           server.URL,
+		ClientID:            "test-client-id",
+		ClientSecret:        "test-client-secret",
+		RedirectURL:         "http://localhost/callback",
+		AllowedEmailDomains: []string{"allowed.com", "other.com"},
+	})
+	if err != nil {
+		t.Fatalf("NewOIDCProvider() error: %v", err)
+	}
+
+	info, err := provider.Exchange(context.Background(), "code")
+	if err != nil {
+		t.Fatalf("Exchange() error: %v", err)
+	}
+	if info.Email != "user@allowed.com" {
+		t.Errorf("Email = %q, want %q", info.Email, "user@allowed.com")
+	}
+}
+
+func TestOIDCProvider_Exchange_AllowedDomain_NoMatch(t *testing.T) {
+	server := newOIDCTestServerWithEmail(t, oidcTestOpts{email: "user@blocked.com", emailVerified: true})
+	defer server.Close()
+
+	provider, err := NewOIDCProvider(context.Background(), OIDCConfig{
+		IssuerURL:           server.URL,
+		ClientID:            "test-client-id",
+		ClientSecret:        "test-client-secret",
+		RedirectURL:         "http://localhost/callback",
+		AllowedEmailDomains: []string{"allowed.com"},
+	})
+	if err != nil {
+		t.Fatalf("NewOIDCProvider() error: %v", err)
+	}
+
+	if _, err := provider.Exchange(context.Background(), "code"); err == nil {
+		t.Fatal("Exchange() expected error for blocked domain, got nil")
+	} else if !strings.Contains(err.Error(), "not in the allowed list") {
+		t.Fatalf("Exchange() error = %v, want 'not in the allowed list'", err)
+	}
+}
+
+func TestOIDCProvider_Exchange_AllowedDomain_Unverified(t *testing.T) {
+	server := newOIDCTestServerWithEmail(t, oidcTestOpts{email: "user@allowed.com", emailVerified: false})
+	defer server.Close()
+
+	provider, err := NewOIDCProvider(context.Background(), OIDCConfig{
+		IssuerURL:           server.URL,
+		ClientID:            "test-client-id",
+		ClientSecret:        "test-client-secret",
+		RedirectURL:         "http://localhost/callback",
+		AllowedEmailDomains: []string{"allowed.com"},
+	})
+	if err != nil {
+		t.Fatalf("NewOIDCProvider() error: %v", err)
+	}
+
+	if _, err := provider.Exchange(context.Background(), "code"); err == nil {
+		t.Fatal("Exchange() expected error for unverified email, got nil")
+	} else if !strings.Contains(err.Error(), "not verified") {
+		t.Fatalf("Exchange() error = %v, want 'not verified'", err)
+	}
+}
+
+func TestOIDCProvider_Exchange_AllowedDomain_CaseInsensitive(t *testing.T) {
+	server := newOIDCTestServerWithEmail(t, oidcTestOpts{email: "User@Allowed.COM", emailVerified: true})
+	defer server.Close()
+
+	provider, err := NewOIDCProvider(context.Background(), OIDCConfig{
+		IssuerURL:           server.URL,
+		ClientID:            "test-client-id",
+		ClientSecret:        "test-client-secret",
+		RedirectURL:         "http://localhost/callback",
+		AllowedEmailDomains: []string{"  @ALLOWED.com  ", ""},
+	})
+	if err != nil {
+		t.Fatalf("NewOIDCProvider() error: %v", err)
+	}
+
+	if _, err := provider.Exchange(context.Background(), "code"); err != nil {
+		t.Fatalf("Exchange() should accept case-insensitive domain match, got: %v", err)
+	}
+}
+
+func TestOIDCProvider_Exchange_AllowedDomain_UserInfoPath_Match(t *testing.T) {
+	server := newOIDCTestServerWithEmail(t, oidcTestOpts{
+		email:           "user@allowed.com",
+		emailVerified:   true,
+		useUserInfoOnly: true,
+	})
+	defer server.Close()
+
+	provider, err := NewOIDCProvider(context.Background(), OIDCConfig{
+		IssuerURL:           server.URL,
+		ClientID:            "test-client-id",
+		ClientSecret:        "test-client-secret",
+		RedirectURL:         "http://localhost/callback",
+		AllowedEmailDomains: []string{"allowed.com"},
+	})
+	if err != nil {
+		t.Fatalf("NewOIDCProvider() error: %v", err)
+	}
+
+	info, err := provider.Exchange(context.Background(), "code")
+	if err != nil {
+		t.Fatalf("Exchange() error: %v", err)
+	}
+	if info.Email != "user@allowed.com" {
+		t.Errorf("Email = %q, want %q", info.Email, "user@allowed.com")
+	}
+}
+
+func TestOIDCProvider_Exchange_AllowedDomain_UserInfoPath_NoMatch(t *testing.T) {
+	server := newOIDCTestServerWithEmail(t, oidcTestOpts{
+		email:           "user@blocked.com",
+		emailVerified:   true,
+		useUserInfoOnly: true,
+	})
+	defer server.Close()
+
+	provider, err := NewOIDCProvider(context.Background(), OIDCConfig{
+		IssuerURL:           server.URL,
+		ClientID:            "test-client-id",
+		ClientSecret:        "test-client-secret",
+		RedirectURL:         "http://localhost/callback",
+		AllowedEmailDomains: []string{"allowed.com"},
+	})
+	if err != nil {
+		t.Fatalf("NewOIDCProvider() error: %v", err)
+	}
+
+	if _, err := provider.Exchange(context.Background(), "code"); err == nil {
+		t.Fatal("Exchange() expected error for blocked domain via userinfo, got nil")
+	} else if !strings.Contains(err.Error(), "not in the allowed list") {
+		t.Fatalf("Exchange() error = %v, want 'not in the allowed list'", err)
+	}
+}
+
+func TestOIDCProvider_Exchange_AllowedDomain_UserInfoPath_Unverified(t *testing.T) {
+	server := newOIDCTestServerWithEmail(t, oidcTestOpts{
+		email:           "user@allowed.com",
+		emailVerified:   false,
+		useUserInfoOnly: true,
+	})
+	defer server.Close()
+
+	provider, err := NewOIDCProvider(context.Background(), OIDCConfig{
+		IssuerURL:           server.URL,
+		ClientID:            "test-client-id",
+		ClientSecret:        "test-client-secret",
+		RedirectURL:         "http://localhost/callback",
+		AllowedEmailDomains: []string{"allowed.com"},
+	})
+	if err != nil {
+		t.Fatalf("NewOIDCProvider() error: %v", err)
+	}
+
+	if _, err := provider.Exchange(context.Background(), "code"); err == nil {
+		t.Fatal("Exchange() expected error for unverified email via userinfo, got nil")
+	} else if !strings.Contains(err.Error(), "not verified") {
+		t.Fatalf("Exchange() error = %v, want 'not verified'", err)
 	}
 }


### PR DESCRIPTION
## Summary
- New `GOOGLE_AUTH_ALLOWED_DOMAINS` env var (comma-separated). Restricts Google sign-in to verified accounts whose email domain matches the list (exact match, case-insensitive, no implicit subdomains).
- Enforced in both the OIDC ID-token path and the userinfo fallback. Requires `email_verified=true`.
- Field lives on `OIDCConfig.AllowedEmailDomains` so any future per-provider opt-in can reuse it; today only Google is wired (via `cfg.GoogleAllowedDomains` in `cmd/sendrec/main.go` → `internal/server/server.go`).
- Doc row added to `SELF-HOSTING.md`.

Closes #129.

## Test plan
- [x] `go test ./internal/sso/...` — 12 OIDC tests pass, 7 new (ID-token + userinfo paths × match / no-match / unverified, plus case-insensitivity).
- [x] Smoke test in a self-hosted instance with `GOOGLE_AUTH_ALLOWED_DOMAINS=example.com`: allowed domain logs in, blocked domain rejected.