### PR TITLE
Kubernetes Helm chart and documenation for sendrec

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 # Go
 bin/
-sendrec
+/sendrec
 
 # Node
 web/node_modules/

--- a/README.md
+++ b/README.md
@@ -121,6 +121,62 @@ Open http://localhost:8080, register an account, and start recording.
 
 For S3 storage, transcription, and production setup, see the [Self-Hosting Guide](SELF-HOSTING.md).
 
+### Helm Chart
+
+SendRec also ships with a Helm chart in [helm/sendrec](helm/sendrec) for Kubernetes deployments.
+
+Create your own values file such as `values-prod.yaml` and keep environment-specific settings there instead of editing the chart defaults in-place:
+
+```yaml
+sendrec:
+  env:
+    baseUrl: "https://sendrec.yourdomain.com"
+    s3Endpoint: "https://s3.amazonaws.com"
+    s3PublicEndpoint: "https://cdn.yourdomain.com"
+    s3Bucket: "your-bucket-name"
+    s3Region: "eu-central-1"
+    transcriptionEnabled: "false"
+    googleAuthAllowedDomains: "example.com"
+
+  secrets:
+    databaseUrl: "postgres://sendrec:secret@postgres:5432/sendrec?sslmode=disable"
+    jwtSecret: "change-me-to-a-long-random-string"
+    s3AccessKey: "your-access-key"
+    s3SecretKey: "your-secret-key"
+```
+
+Install the chart:
+
+```bash
+helm upgrade --install sendrec ./helm/sendrec \
+  --namespace sendrec \
+  --create-namespace
+```
+
+Preview the rendered manifests before applying changes:
+
+```bash
+helm template sendrec ./helm/sendrec -f values.yaml
+```
+
+Upgrade an existing release after changing your values file:
+
+```bash
+helm upgrade sendrec ./helm/sendrec \
+  --namespace sendrec
+```
+
+The chart configures:
+
+- A Deployment for the SendRec app
+- A ConfigMap for non-secret environment variables
+- A Secret for credentials and API keys
+- A Service and optional Ingress
+- An optional NetworkPolicy
+- Optional whisper model storage and init container when `sendrec.env.transcriptionEnabled="true"`
+
+For production setup details such as reverse proxying, object storage, and operational guidance, see the [Self-Hosting Guide](SELF-HOSTING.md).
+
 ### One-Click Deploy
 
 [![Deploy on Railway](https://railway.com/button.svg)](https://railway.com/template/sendrec)
@@ -177,9 +233,10 @@ After upload, the server generates a thumbnail with ffmpeg and enqueues the vide
 
 ## Self-Hosting
 
-SendRec runs on a single server with Docker Compose. See the **[Self-Hosting Guide](SELF-HOSTING.md)** for full setup instructions, including:
+SendRec can run either on a single server with Docker Compose or on Kubernetes with the included Helm chart. See the **[Self-Hosting Guide](SELF-HOSTING.md)** for full setup instructions, including:
 
 - Production Docker Compose configuration
+- Helm and Kubernetes configuration
 - Environment variables reference
 - Reverse proxy setup (Caddy example)
 - Enabling transcription with whisper.cpp

--- a/README.md
+++ b/README.md
@@ -132,14 +132,14 @@ sendrec:
   env:
     baseUrl: "https://sendrec.yourdomain.com"
     s3Endpoint: "https://s3.amazonaws.com"
-    s3PublicEndpoint: "https://cdn.yourdomain.com"
+    s3PublicEndpoint: "https://s3.amazonaws.com"
     s3Bucket: "your-bucket-name"
     s3Region: "eu-central-1"
     transcriptionEnabled: "false"
     googleAuthAllowedDomains: "example.com"
 
   secrets:
-    databaseUrl: "postgres://sendrec:secret@postgres:5432/sendrec?sslmode=disable"
+    databaseUrl: "postgres://sendrec:secret@postgres:5432/sendrec"
     jwtSecret: "change-me-to-a-long-random-string"
     s3AccessKey: "your-access-key"
     s3SecretKey: "your-secret-key"
@@ -148,7 +148,7 @@ sendrec:
 Install the chart:
 
 ```bash
-helm upgrade --install sendrec ./helm/sendrec \
+helm install sendrec ./helm/sendrec \
   --namespace sendrec \
   --create-namespace
 ```

--- a/README.md
+++ b/README.md
@@ -150,20 +150,22 @@ Install the chart:
 ```bash
 helm install sendrec ./helm/sendrec \
   --namespace sendrec \
-  --create-namespace
+  --create-namespace \
+  -f values-prod.yaml
 ```
 
 Preview the rendered manifests before applying changes:
 
 ```bash
-helm template sendrec ./helm/sendrec -f values.yaml
+helm template sendrec ./helm/sendrec -f values-prod.yaml
 ```
 
 Upgrade an existing release after changing your values file:
 
 ```bash
 helm upgrade sendrec ./helm/sendrec \
-  --namespace sendrec
+  --namespace sendrec \
+  -f values-prod.yaml
 ```
 
 The chart configures:

--- a/SELF-HOSTING.md
+++ b/SELF-HOSTING.md
@@ -30,9 +30,6 @@ Create a deployment-specific values file (for example `values-prod.yaml`) and ke
 
 ```yaml
 sendrec:
-  image:
-    tag: "v1.84.4"
-
   env:
     baseUrl: "https://sendrec.yourdomain.com"
     s3Endpoint: "https://s3.amazonaws.com"

--- a/SELF-HOSTING.md
+++ b/SELF-HOSTING.md
@@ -13,6 +13,77 @@ docker compose -f docker-compose.dev.yml up --build
 
 Open http://localhost:8080, register an account, and start recording or uploading videos.
 
+## Kubernetes with Helm
+
+SendRec includes a Helm chart at `helm/sendrec` for Kubernetes deployments.
+
+### Prerequisites
+
+- Kubernetes cluster with an ingress controller (Traefik, nginx, etc.)
+- Helm 3
+- PostgreSQL database
+- S3-compatible object storage
+
+### 1. Create a values file
+
+Create a deployment-specific values file (for example `values-prod.yaml`) and keep your environment settings there:
+
+```yaml
+sendrec:
+  image:
+    tag: "v1.84.4"
+
+  env:
+    baseUrl: "https://sendrec.yourdomain.com"
+    s3Endpoint: "https://s3.amazonaws.com"
+    s3PublicEndpoint: "https://s3.amazonaws.com"
+    s3Bucket: "recordings"
+    s3Region: "eu-central-1"
+    transcriptionEnabled: "false"
+    googleAuthAllowedDomains: "example.com"
+
+  secrets:
+    databaseUrl: "postgres://sendrec:secret@postgres:5432/sendrec"
+    jwtSecret: "change-me-to-a-long-random-string"
+    s3AccessKey: "your-access-key"
+    s3SecretKey: "your-secret-key"
+```
+
+### 2. Install the chart
+
+```bash
+helm install sendrec ./helm/sendrec \
+  --namespace sendrec \
+  --create-namespace
+```
+
+### 3. Verify rollout
+
+```bash
+kubectl -n sendrec get pods
+kubectl -n sendrec get svc
+```
+
+### 4. Upgrade after changes
+
+```bash
+helm upgrade sendrec ./helm/sendrec \
+  --namespace sendrec
+```
+
+### Optional: preview rendered manifests
+
+```bash
+helm template sendrec ./helm/sendrec
+```
+
+### Helm notes
+
+- Non-secret environment variables are configured under `sendrec.env` (camelCase keys).
+- Sensitive values are configured under `sendrec.secrets`.
+- Transcription model resources (init container, model volume, and optional PVC) are controlled by `sendrec.env.transcriptionEnabled`.
+- To persist the Whisper model, set `sendrec.transcription.type: volume`.
+
 ## Standalone binary
 
 SendRec is a single ~32 MB executable with the React frontend, database migrations, and HTML templates all embedded. No Docker required — just a PostgreSQL database and S3-compatible storage.

--- a/SELF-HOSTING.md
+++ b/SELF-HOSTING.md
@@ -51,7 +51,8 @@ sendrec:
 ```bash
 helm install sendrec ./helm/sendrec \
   --namespace sendrec \
-  --create-namespace
+  --create-namespace \
+  -f values-prod.yaml
 ```
 
 ### 3. Verify rollout
@@ -65,13 +66,14 @@ kubectl -n sendrec get svc
 
 ```bash
 helm upgrade sendrec ./helm/sendrec \
-  --namespace sendrec
+  --namespace sendrec \
+  -f values-prod.yaml
 ```
 
 ### Optional: preview rendered manifests
 
 ```bash
-helm template sendrec ./helm/sendrec
+helm template sendrec ./helm/sendrec -f values-prod.yaml
 ```
 
 ### Helm notes

--- a/helm/sendrec/Chart.yaml
+++ b/helm/sendrec/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: sendrec
+description: A Helm chart for SendRec - screen recording and video sharing app
+type: application
+
+home: https://sendrec.eu
+
+sources:
+- https://github.com/sendrec/sendrec
+
+keywords:
+- video
+- recording
+- screen-recording
+- async-video
+- self-hosted
+- collaboration
+
+maintainers:
+- name: mark24slides
+- name: alexneamtu 
+
+version: "1.0.0"
+appVersion: "1.84.4"

--- a/helm/sendrec/templates/_helpers.tpl
+++ b/helm/sendrec/templates/_helpers.tpl
@@ -1,0 +1,12 @@
+{{- define "sendrec.validateRequired" -}}
+{{- $_ := required "sendrec.env.baseUrl is required (maps to BASE_URL)" .Values.sendrec.env.baseUrl -}}
+{{- $_ := required "sendrec.env.s3Endpoint is required (maps to S3_ENDPOINT)" .Values.sendrec.env.s3Endpoint -}}
+{{- $_ := required "sendrec.env.s3PublicEndpoint is required (maps to S3_PUBLIC_ENDPOINT)" .Values.sendrec.env.s3PublicEndpoint -}}
+{{- $_ := required "sendrec.env.s3Bucket is required (maps to S3_BUCKET)" .Values.sendrec.env.s3Bucket -}}
+{{- if not .Values.sendrec.existingSecret -}}
+{{- $_ := required "sendrec.secrets.databaseUrl is required unless sendrec.existingSecret is set" .Values.sendrec.secrets.databaseUrl -}}
+{{- $_ := required "sendrec.secrets.jwtSecret is required unless sendrec.existingSecret is set" .Values.sendrec.secrets.jwtSecret -}}
+{{- $_ := required "sendrec.secrets.s3AccessKey is required unless sendrec.existingSecret is set" .Values.sendrec.secrets.s3AccessKey -}}
+{{- $_ := required "sendrec.secrets.s3SecretKey is required unless sendrec.existingSecret is set" .Values.sendrec.secrets.s3SecretKey -}}
+{{- end -}}
+{{- end -}}

--- a/helm/sendrec/templates/configmap.yaml
+++ b/helm/sendrec/templates/configmap.yaml
@@ -1,0 +1,43 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Chart.Name }}-configmap
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ .Chart.Name }}
+data:
+  BASE_URL: {{ .Values.sendrec.env.baseUrl | quote }}
+  S3_ENDPOINT: {{ .Values.sendrec.env.s3Endpoint | quote }}
+  S3_PUBLIC_ENDPOINT: {{ .Values.sendrec.env.s3PublicEndpoint | quote }}
+  S3_BUCKET: {{ .Values.sendrec.env.s3Bucket | quote }}
+  S3_REGION: {{ .Values.sendrec.env.s3Region | quote }}
+  AWS_REQUEST_CHECKSUM_CALCULATION: {{ .Values.sendrec.env.awsRequestChecksumCalculation | quote }}
+  AWS_RESPONSE_CHECKSUM_VALIDATION: {{ .Values.sendrec.env.awsResponseChecksumValidation | quote }}
+  MAX_UPLOAD_BYTES: {{ .Values.sendrec.env.maxUploadBytes | quote }}
+  MAX_VIDEOS_PER_MONTH: {{ .Values.sendrec.env.maxVideosPerMonth | quote }}
+  MAX_VIDEO_DURATION_SECONDS: {{ .Values.sendrec.env.maxVideoDurationSeconds | quote }}
+  MAX_PLAYLISTS: {{ .Values.sendrec.env.maxPlaylists | quote }}
+  API_DOCS_ENABLED: {{ .Values.sendrec.env.apiDocsEnabled | quote }}
+  BRANDING_ENABLED: {{ .Values.sendrec.env.brandingEnabled | quote }}
+  REGISTRATION_ENABLED: {{ .Values.sendrec.env.registrationEnabled | quote }}
+  TRANSCRIPTION_ENABLED: {{ .Values.sendrec.env.transcriptionEnabled | quote }}
+  WHISPER_MODEL_PATH: {{ .Values.sendrec.env.whisperModelPath | quote }}
+  AI_ENABLED: {{ .Values.sendrec.env.aiEnabled | quote }}
+  AI_BASE_URL: {{ .Values.sendrec.env.aiBaseUrl | quote }}
+  AI_MODEL: {{ .Values.sendrec.env.aiModel | quote }}
+  AI_TIMEOUT: {{ .Values.sendrec.env.aiTimeout | quote }}
+  ANALYTICS_SCRIPT: {{ .Values.sendrec.env.analyticsScript | quote }}
+  ALLOWED_FRAME_ANCESTORS: {{ .Values.sendrec.env.allowedFrameAncestors | quote }}
+  GOOGLE_AUTH_ALLOWED_DOMAINS: {{ .Values.sendrec.env.googleAuthAllowedDomains | quote }}
+  CREEM_PRO_PRODUCT_ID: {{ .Values.sendrec.env.creemProProductId | quote }}
+  LISTMONK_BASE_URL: {{ .Values.sendrec.env.listmonkBaseUrl | quote }}
+  LISTMONK_TEMPLATE_ID: {{ .Values.sendrec.env.listmonkTemplateId | quote }}
+  LISTMONK_COMMENT_TEMPLATE_ID: {{ .Values.sendrec.env.listmonkCommentTemplateId | quote }}
+  LISTMONK_VIEW_TEMPLATE_ID: {{ .Values.sendrec.env.listmonkViewTemplateId | quote }}
+  LISTMONK_CONFIRM_TEMPLATE_ID: {{ .Values.sendrec.env.listmonkConfirmTemplateId | quote }}
+  LISTMONK_WELCOME_TEMPLATE_ID: {{ .Values.sendrec.env.listmonkWelcomeTemplateId | quote }}
+  LISTMONK_ONBOARDING_DAY2_TEMPLATE_ID: {{ .Values.sendrec.env.listmonkOnboardingDay2TemplateId | quote }}
+  LISTMONK_ONBOARDING_DAY7_TEMPLATE_ID: {{ .Values.sendrec.env.listmonkOnboardingDay7TemplateId | quote }}
+  LISTMONK_ORG_INVITE_TEMPLATE_ID: {{ .Values.sendrec.env.listmonkOrgInviteTemplateId | quote }}
+  LISTMONK_RETENTION_WARNING_TEMPLATE_ID: {{ .Values.sendrec.env.listmonkRetentionWarningTemplateId | quote }}
+  EMAIL_ALLOWLIST: {{ .Values.sendrec.env.emailAllowlist | quote }}

--- a/helm/sendrec/templates/configmap.yaml
+++ b/helm/sendrec/templates/configmap.yaml
@@ -7,6 +7,7 @@ metadata:
     app: {{ .Chart.Name }}
 data:
   BASE_URL: {{ .Values.sendrec.env.baseUrl | quote }}
+  PORT: {{ .Values.sendrec.port | quote }}
   S3_ENDPOINT: {{ .Values.sendrec.env.s3Endpoint | quote }}
   S3_PUBLIC_ENDPOINT: {{ .Values.sendrec.env.s3PublicEndpoint | quote }}
   S3_BUCKET: {{ .Values.sendrec.env.s3Bucket | quote }}
@@ -30,7 +31,7 @@ data:
   ALLOWED_FRAME_ANCESTORS: {{ .Values.sendrec.env.allowedFrameAncestors | quote }}
   GOOGLE_AUTH_ALLOWED_DOMAINS: {{ .Values.sendrec.env.googleAuthAllowedDomains | quote }}
   CREEM_PRO_PRODUCT_ID: {{ .Values.sendrec.env.creemProProductId | quote }}
-  LISTMONK_BASE_URL: {{ .Values.sendrec.env.listmonkBaseUrl | quote }}
+  LISTMONK_URL: {{ .Values.sendrec.env.listmonkBaseUrl | quote }}
   LISTMONK_TEMPLATE_ID: {{ .Values.sendrec.env.listmonkTemplateId | quote }}
   LISTMONK_COMMENT_TEMPLATE_ID: {{ .Values.sendrec.env.listmonkCommentTemplateId | quote }}
   LISTMONK_VIEW_TEMPLATE_ID: {{ .Values.sendrec.env.listmonkViewTemplateId | quote }}

--- a/helm/sendrec/templates/deployment.yaml
+++ b/helm/sendrec/templates/deployment.yaml
@@ -1,0 +1,92 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Chart.Name }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ .Chart.Name }}
+spec:
+  replicas: {{ .Values.sendrec.replicas }}
+{{- with .Values.sendrec.deploymentStrategy }}
+  strategy:
+{{ toYaml . | trim | indent 4 }}
+{{- end }}
+  selector:
+    matchLabels:
+      app: {{ .Chart.Name }}
+      instance: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app: {{ .Chart.Name }}
+        instance: {{ .Release.Name }}
+      annotations:
+        checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+        checksum/configmap: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+    spec:
+      {{- if or .Values.sendrec.deployment.extraInitContainers (eq (toString .Values.sendrec.env.transcriptionEnabled) "true") }}
+      initContainers:
+        {{- if eq (toString .Values.sendrec.env.transcriptionEnabled) "true" }}
+        - name: download-whisper-model
+          image: {{ .Values.sendrec.transcription.initImage }}
+          command:
+            - sh
+            - -c
+            - |
+              curl -L -o {{ .Values.sendrec.transcription.modelPath }} \
+                {{ .Values.sendrec.transcription.modelUrl }}
+          volumeMounts:
+            - name: whisper-models
+              mountPath: /models
+        {{- end }}
+        {{- with .Values.sendrec.deployment.extraInitContainers }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- end }}
+      containers:
+        {{- with .Values.sendrec.deployment.extraContainers }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        - name: sendrec
+          image: {{ .Values.sendrec.image.repository }}:{{ .Values.sendrec.image.tag | default .Chart.AppVersion }}
+          imagePullPolicy: {{ .Values.sendrec.image.pullPolicy }}
+          envFrom:
+            - configMapRef:
+                name: {{ .Chart.Name }}-configmap
+            - secretRef:
+                name: {{ .Chart.Name }}-secret
+          ports:
+            - containerPort: {{ .Values.sendrec.port }}
+              name: http
+              protocol: TCP
+          resources: {{- toYaml .Values.sendrec.resources | nindent 12 }}
+          livenessProbe:
+            {{- toYaml .Values.sendrec.livenessProbe | nindent 12 }}
+          readinessProbe:
+            {{- toYaml .Values.sendrec.readinessProbe | nindent 12 }}
+          {{- if or .Values.sendrec.deployment.extraVolumeMounts (eq (toString .Values.sendrec.env.transcriptionEnabled) "true") }}
+          volumeMounts:
+            {{- if eq (toString .Values.sendrec.env.transcriptionEnabled) "true" }}
+            - name: whisper-models
+              mountPath: /models
+            {{- end }}
+            {{- with .Values.sendrec.deployment.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- end }}
+      {{- if or .Values.sendrec.deployment.extraVolumes (eq (toString .Values.sendrec.env.transcriptionEnabled) "true") }}
+      volumes:
+        {{- if eq (toString .Values.sendrec.env.transcriptionEnabled) "true" }}
+        - name: whisper-models
+          {{- if eq .Values.sendrec.transcription.type "volume" }}
+          persistentVolumeClaim:
+            claimName: {{ .Chart.Name }}-whisper-pvc
+          {{- else }}
+          emptyDir:
+            sizeLimit: {{ .Values.sendrec.transcription.size }}
+          {{- end }}
+        {{- end }}
+        {{- with .Values.sendrec.deployment.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- end }}

--- a/helm/sendrec/templates/deployment.yaml
+++ b/helm/sendrec/templates/deployment.yaml
@@ -1,3 +1,4 @@
+{{- include "sendrec.validateRequired" . }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -21,7 +22,7 @@ spec:
         app: {{ .Chart.Name }}
         instance: {{ .Release.Name }}
       annotations:
-        checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+        checksum/secret: {{- if .Values.sendrec.existingSecret }} "external-secret" {{- else }} {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }} {{- end }}
         checksum/configmap: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
     spec:
       {{- if or .Values.sendrec.deployment.extraInitContainers (eq (toString .Values.sendrec.env.transcriptionEnabled) "true") }}
@@ -48,13 +49,13 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
         - name: sendrec
-          image: {{ .Values.sendrec.image.repository }}:{{ .Values.sendrec.image.tag | default .Chart.AppVersion }}
+          image: {{ .Values.sendrec.image.repository }}:{{ .Values.sendrec.image.tag | default (printf "v%s" .Chart.AppVersion) }}
           imagePullPolicy: {{ .Values.sendrec.image.pullPolicy }}
           envFrom:
             - configMapRef:
                 name: {{ .Chart.Name }}-configmap
             - secretRef:
-                name: {{ .Chart.Name }}-secret
+                name: {{ .Values.sendrec.existingSecret | default (printf "%s-secret" .Chart.Name) }}
           ports:
             - containerPort: {{ .Values.sendrec.port }}
               name: http

--- a/helm/sendrec/templates/extra.yaml
+++ b/helm/sendrec/templates/extra.yaml
@@ -1,3 +1,4 @@
-{{- with .Values.sendrec.extraResources }}
+{{- range .Values.sendrec.extraResources }}
+---
 {{- toYaml . | nindent 0 }}
 {{- end }}

--- a/helm/sendrec/templates/extra.yaml
+++ b/helm/sendrec/templates/extra.yaml
@@ -1,0 +1,3 @@
+{{- with .Values.sendrec.extraResources }}
+{{- toYaml . | nindent 0 }}
+{{- end }}

--- a/helm/sendrec/templates/ingress.yaml
+++ b/helm/sendrec/templates/ingress.yaml
@@ -1,0 +1,38 @@
+{{- if .Values.sendrec.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ .Chart.Name }}-ingress
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ .Chart.Name }}
+  {{- with .Values.sendrec.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  ingressClassName: {{ .Values.sendrec.ingress.className }}
+  {{- if .Values.sendrec.ingress.tls }}
+  tls:
+    {{- range .Values.sendrec.ingress.tls }}
+    - hosts:
+      {{- range .hosts }}
+        - {{ . }}
+      {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+  {{- range .Values.sendrec.ingress.hosts }}
+  - host: {{ .name }}
+    http:
+      paths:
+      - pathType: {{ $.Values.sendrec.ingress.pathType }}
+        path: {{ .path }}
+        backend:
+          service:
+            name: {{ $.Chart.Name }}-service
+            port:
+              number: {{ $.Values.sendrec.service.port }}
+  {{- end }}
+{{- end }}

--- a/helm/sendrec/templates/networkpolicy.yaml
+++ b/helm/sendrec/templates/networkpolicy.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.sendrec.networkPolicy.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ .Chart.Name }}-networkpolicy
+  namespace: {{ .Release.Namespace }}
+spec:
+  podSelector:
+    matchLabels:
+      app: {{ .Chart.Name }}
+      instance: {{ .Release.Name }}
+  policyTypes:
+    {{- toYaml .Values.sendrec.networkPolicy.policyTypes | nindent 4 }}
+  {{- with .Values.sendrec.networkPolicy.ingress }}
+  ingress:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.sendrec.networkPolicy.egress }}
+  egress:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/helm/sendrec/templates/persistentvolumeclaim.yaml
+++ b/helm/sendrec/templates/persistentvolumeclaim.yaml
@@ -1,0 +1,15 @@
+{{- if and (eq (toString .Values.sendrec.env.transcriptionEnabled) "true") (eq .Values.sendrec.transcription.type "volume") }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ .Chart.Name }}-whisper-pvc
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ .Chart.Name }}
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: {{ .Values.sendrec.transcription.size }}
+{{- end }}

--- a/helm/sendrec/templates/secret.yaml
+++ b/helm/sendrec/templates/secret.yaml
@@ -1,0 +1,24 @@
+kind: Secret
+apiVersion: v1
+metadata:
+  name: {{ .Chart.Name }}-secret
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ .Chart.Name }}
+data:
+  DATABASE_URL: "{{ .Values.sendrec.secrets.databaseUrl | b64enc }}"
+  JWT_SECRET: "{{ .Values.sendrec.secrets.jwtSecret | b64enc }}"
+  S3_ACCESS_KEY: "{{ .Values.sendrec.secrets.s3AccessKey | b64enc }}"
+  S3_SECRET_KEY: "{{ .Values.sendrec.secrets.s3SecretKey | b64enc }}"
+  GOOGLE_CLIENT_ID: "{{ .Values.sendrec.secrets.googleClientId | b64enc }}"
+  GOOGLE_CLIENT_SECRET: "{{ .Values.sendrec.secrets.googleClientSecret | b64enc }}"
+  MICROSOFT_CLIENT_ID: "{{ .Values.sendrec.secrets.microsoftClientId | b64enc }}"
+  MICROSOFT_CLIENT_SECRET: "{{ .Values.sendrec.secrets.microsoftClientSecret | b64enc }}"
+  GITHUB_SSO_CLIENT_ID: "{{ .Values.sendrec.secrets.githubSsoClientId | b64enc }}"
+  GITHUB_SSO_CLIENT_SECRET: "{{ .Values.sendrec.secrets.githubSsoClientSecret | b64enc }}"
+  AI_API_KEY: "{{ .Values.sendrec.secrets.aiApiKey | b64enc }}"
+  LISTMONK_USERNAME: "{{ .Values.sendrec.secrets.listmonkUsername | b64enc }}"
+  LISTMONK_PASSWORD: "{{ .Values.sendrec.secrets.listmonkPassword | b64enc }}"
+  CREEM_API_KEY: "{{ .Values.sendrec.secrets.creemApiKey | b64enc }}"
+  CREEM_WEBHOOK_SECRET: "{{ .Values.sendrec.secrets.creemWebhookSecret | b64enc }}"
+type: Opaque

--- a/helm/sendrec/templates/secret.yaml
+++ b/helm/sendrec/templates/secret.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.sendrec.existingSecret }}
 kind: Secret
 apiVersion: v1
 metadata:
@@ -5,20 +6,21 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     app: {{ .Chart.Name }}
-data:
-  DATABASE_URL: "{{ .Values.sendrec.secrets.databaseUrl | b64enc }}"
-  JWT_SECRET: "{{ .Values.sendrec.secrets.jwtSecret | b64enc }}"
-  S3_ACCESS_KEY: "{{ .Values.sendrec.secrets.s3AccessKey | b64enc }}"
-  S3_SECRET_KEY: "{{ .Values.sendrec.secrets.s3SecretKey | b64enc }}"
-  GOOGLE_CLIENT_ID: "{{ .Values.sendrec.secrets.googleClientId | b64enc }}"
-  GOOGLE_CLIENT_SECRET: "{{ .Values.sendrec.secrets.googleClientSecret | b64enc }}"
-  MICROSOFT_CLIENT_ID: "{{ .Values.sendrec.secrets.microsoftClientId | b64enc }}"
-  MICROSOFT_CLIENT_SECRET: "{{ .Values.sendrec.secrets.microsoftClientSecret | b64enc }}"
-  GITHUB_SSO_CLIENT_ID: "{{ .Values.sendrec.secrets.githubSsoClientId | b64enc }}"
-  GITHUB_SSO_CLIENT_SECRET: "{{ .Values.sendrec.secrets.githubSsoClientSecret | b64enc }}"
-  AI_API_KEY: "{{ .Values.sendrec.secrets.aiApiKey | b64enc }}"
-  LISTMONK_USERNAME: "{{ .Values.sendrec.secrets.listmonkUsername | b64enc }}"
-  LISTMONK_PASSWORD: "{{ .Values.sendrec.secrets.listmonkPassword | b64enc }}"
-  CREEM_API_KEY: "{{ .Values.sendrec.secrets.creemApiKey | b64enc }}"
-  CREEM_WEBHOOK_SECRET: "{{ .Values.sendrec.secrets.creemWebhookSecret | b64enc }}"
+stringData:
+  DATABASE_URL: {{ .Values.sendrec.secrets.databaseUrl | quote }}
+  JWT_SECRET: {{ .Values.sendrec.secrets.jwtSecret | quote }}
+  S3_ACCESS_KEY: {{ .Values.sendrec.secrets.s3AccessKey | quote }}
+  S3_SECRET_KEY: {{ .Values.sendrec.secrets.s3SecretKey | quote }}
+  GOOGLE_CLIENT_ID: {{ .Values.sendrec.secrets.googleClientId | quote }}
+  GOOGLE_CLIENT_SECRET: {{ .Values.sendrec.secrets.googleClientSecret | quote }}
+  MICROSOFT_CLIENT_ID: {{ .Values.sendrec.secrets.microsoftClientId | quote }}
+  MICROSOFT_CLIENT_SECRET: {{ .Values.sendrec.secrets.microsoftClientSecret | quote }}
+  GITHUB_SSO_CLIENT_ID: {{ .Values.sendrec.secrets.githubSsoClientId | quote }}
+  GITHUB_SSO_CLIENT_SECRET: {{ .Values.sendrec.secrets.githubSsoClientSecret | quote }}
+  AI_API_KEY: {{ .Values.sendrec.secrets.aiApiKey | quote }}
+  LISTMONK_USER: {{ .Values.sendrec.secrets.listmonkUsername | quote }}
+  LISTMONK_PASSWORD: {{ .Values.sendrec.secrets.listmonkPassword | quote }}
+  CREEM_API_KEY: {{ .Values.sendrec.secrets.creemApiKey | quote }}
+  CREEM_WEBHOOK_SECRET: {{ .Values.sendrec.secrets.creemWebhookSecret | quote }}
 type: Opaque
+{{- end }}

--- a/helm/sendrec/templates/service.yaml
+++ b/helm/sendrec/templates/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Chart.Name }}-service
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ .Chart.Name }}
+spec:
+  type: {{ .Values.sendrec.service.type }}
+  selector:
+    app: {{ .Chart.Name }}
+    instance: {{ .Release.Name }}
+  ports:
+    - port: {{ .Values.sendrec.service.port }}
+      targetPort: http
+      name: http

--- a/helm/sendrec/values.yaml
+++ b/helm/sendrec/values.yaml
@@ -97,6 +97,9 @@ sendrec:
     creemApiKey: ""            # Creem API key for billing integration
     creemWebhookSecret: ""     # Creem webhook signing secret
 
+  # Use an existing Kubernetes Secret name instead of creating upper secret
+  existingSecret: ""
+
   port: 8080
 
   resources:
@@ -160,7 +163,7 @@ sendrec:
         path: /
 
     tls: []
-    # Example TLS configuration with Cloudflare Origin CA certificate:
+    # Example TLS configuration:
     # - hosts:
     #     - sendrec.yourdomain.com
     #   secretName: yourdomain-tls-secret

--- a/helm/sendrec/values.yaml
+++ b/helm/sendrec/values.yaml
@@ -111,7 +111,7 @@ sendrec:
   livenessProbe:
     httpGet:
       path: /api/health
-      port: 8080
+      port: http
     initialDelaySeconds: 30
     periodSeconds: 30
     timeoutSeconds: 10
@@ -120,7 +120,7 @@ sendrec:
   readinessProbe:
     httpGet:
       path: /api/health
-      port: 8080
+      port: http
     initialDelaySeconds: 10
     periodSeconds: 15
     timeoutSeconds: 10

--- a/helm/sendrec/values.yaml
+++ b/helm/sendrec/values.yaml
@@ -110,7 +110,7 @@ sendrec:
 
   livenessProbe:
     httpGet:
-      path: /
+      path: /api/health
       port: 8080
     initialDelaySeconds: 30
     periodSeconds: 30
@@ -119,7 +119,7 @@ sendrec:
 
   readinessProbe:
     httpGet:
-      path: /
+      path: /api/health
       port: 8080
     initialDelaySeconds: 10
     periodSeconds: 15

--- a/helm/sendrec/values.yaml
+++ b/helm/sendrec/values.yaml
@@ -1,0 +1,169 @@
+sendrec:
+  replicas: 1
+
+  image:
+    repository: ghcr.io/sendrec/sendrec
+    tag: "" # appVersion in Chart.yaml if empty
+    pullPolicy: Always
+
+  deploymentStrategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
+
+  # Extra resources injected into the deployment pod
+  deployment:
+    extraInitContainers: []  # run before main container (e.g. migrations, wait-for)
+    extraContainers: []      # sidecar containers
+    extraVolumes: []         # pod-level volumes
+    extraVolumeMounts: []    # mounts on the main sendrec container
+
+  # Transcription model configuration, activation is controlled by env.transcriptionEnabled
+  transcription:
+    type: emptyDir           # volume type: emptyDir or volume (persistent volume)
+    size: 1Gi                # max size for the model volume (for emptyDir) or PVC storage request (for volume)
+    initImage: alpine/curl:8.17.0  # image for the model download init container
+    modelUrl: https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-small.bin
+    modelPath: /models/ggml-small.bin
+
+  env:
+    baseUrl: "https://sendrec.yourdomain.com"
+
+    # Storage (S3-compatible)
+    s3Endpoint: "" # e.g. https://s3.amazonaws.com or https://<your-minio-endpoint>
+    s3PublicEndpoint: "" # e.g. https://cdn.yourdomain.com, used for generating public URLs to videos
+    s3Bucket: "" # e.g. your-bucket-name
+    s3Region: "" # e.g. us-east-1
+    awsRequestChecksumCalculation: "when_required"
+    awsResponseChecksumValidation: "when_required"
+
+    # Upload / recording limits (0 = unlimited)
+    maxUploadBytes: "524288000"   # 500 MB
+    maxVideosPerMonth: "0"
+    maxVideoDurationSeconds: "0"
+    maxPlaylists: "0"
+
+    # Features
+    apiDocsEnabled: "true"
+    brandingEnabled: "true"
+    registrationEnabled: "false"
+
+    # Transcription
+    transcriptionEnabled: "false"
+    whisperModelPath: "/models/ggml-small.bin"
+
+    # AI
+    aiEnabled: "false"
+    aiBaseUrl: ""
+    aiModel: "mistral-small-latest"
+    aiTimeout: "60s"
+
+    analyticsScript: ""
+
+    allowedFrameAncestors: "'self'"
+    googleAuthAllowedDomains: ""  # Comma-separated email domains allowed for Google SSO, e.g. example.com,example.org
+
+    # Billing (Creem)
+    creemProProductId: ""
+
+    # Email (Listmonk)
+    listmonkBaseUrl: ""
+    listmonkTemplateId: ""
+    listmonkCommentTemplateId: ""
+    listmonkViewTemplateId: ""
+    listmonkConfirmTemplateId: ""
+    listmonkWelcomeTemplateId: ""
+    listmonkOnboardingDay2TemplateId: ""
+    listmonkOnboardingDay7TemplateId: ""
+    listmonkOrgInviteTemplateId: ""
+    listmonkRetentionWarningTemplateId: ""
+    emailAllowlist: ""
+
+  secrets:
+    databaseUrl: ""            # Postgres connection string, e.g. postgres://user:pass@host:5432/db?sslmode=require
+    jwtSecret: ""              # Random secret used to sign JWTs (`openssl rand -hex 32`)
+    s3AccessKey: ""            # S3 access key ID for the configured bucket
+    s3SecretKey: ""            # S3 secret access key for the configured bucket
+    googleClientId: ""         # Google OAuth client ID, use /api/auth/sso/google/callback as the redirect URI path
+    googleClientSecret: ""     # Google OAuth client secret
+    microsoftClientId: ""      # Microsoft OAuth client ID, use /api/auth/sso/microsoft/callback as the redirect URI path
+    microsoftClientSecret: ""  # Microsoft OAuth client secret
+    githubSsoClientId: ""      # GitHub SSO OAuth client ID, use /api/auth/sso/github/callback as the redirect URI path
+    githubSsoClientSecret: ""  # GitHub SSO OAuth client secret
+    aiApiKey: ""               # API key for the configured AI provider
+    listmonkUsername: ""       # Listmonk API username
+    listmonkPassword: ""       # Listmonk API password
+    creemApiKey: ""            # Creem API key for billing integration
+    creemWebhookSecret: ""     # Creem webhook signing secret
+
+  port: 8080
+
+  resources:
+    limits: {}
+    requests:
+      cpu: 100m
+      memory: 128Mi
+
+  livenessProbe:
+    httpGet:
+      path: /
+      port: 8080
+    initialDelaySeconds: 30
+    periodSeconds: 30
+    timeoutSeconds: 10
+    failureThreshold: 3
+
+  readinessProbe:
+    httpGet:
+      path: /
+      port: 8080
+    initialDelaySeconds: 10
+    periodSeconds: 15
+    timeoutSeconds: 10
+    failureThreshold: 3
+
+  # NetworkPolicy: restrict ingress to allowed sources only
+  networkPolicy:
+    enabled: false
+
+    policyTypes:
+      - Ingress
+
+    ingress: {}
+      # Example allowing ingress only from Traefik in the same cluster:
+      # - from:
+      #     - namespaceSelector:
+      #         matchLabels:
+      #           kubernetes.io/metadata.name: traefik
+
+    egress: {}
+
+  service:
+    port: 8080
+    type: ClusterIP
+
+  ingress:
+    enabled: true
+
+    className: "traefik"
+
+    annotations:
+      traefik.ingress.kubernetes.io/buffering-maxRequestBodyBytes: "536870912"  # 512 MB
+      traefik.ingress.kubernetes.io/buffering-maxResponseBodyBytes: "536870912"
+      traefik.ingress.kubernetes.io/buffering-memRequestBodyBytes: "1048576"
+      traefik.ingress.kubernetes.io/buffering-memResponseBodyBytes: "1048576"
+    pathType: ImplementationSpecific
+
+    hosts:
+      - name: sendrec.yourdomain.com
+        path: /
+
+    tls: []
+    # Example TLS configuration with Cloudflare Origin CA certificate:
+    # - hosts:
+    #     - sendrec.yourdomain.com
+    #   secretName: yourdomain-tls-secret
+
+  # Arbitrary extra Kubernetes resources rendered as-is (e.g. CronJob, ConfigMap)
+  extraResources: []


### PR DESCRIPTION
## What does this PR do?

This PR introduces a brand-new Helm chart for SendRec, built from scratch, and adds documentation for how to use it in Kubernetes environments.

What is included
- New Helm chart structure and metadata
- Templates for core Kubernetes resources:
  - Deployment
  - Service
  - ConfigMap
  - Secret
  - Ingress
  - NetworkPolicy
  - PersistentVolumeClaim for whisper model storage
- Values structure with camelCase configuration under sendrec.env and documented secret keys
- Explicit environment-variable mappings in the ConfigMap template
- Transcription resource behavior controlled by sendrec.env.transcriptionEnabled

## How to test
Tested on local-mini and actual prod-like kubernetes cluster v1.35.1, via helm v3.18.2.

Rendered chart with default values.

Rendered chart with transcription enabled and volume mode.

## Checklist

- [x] ~`make test` passes~
- [x] ~`make build` succeeds~
- [x] New code has tests where applicable
- [x] No unrelated changes included

