### PR TITLE
fix(e2e): register redirects to /login when no email backend

### DIFF
--- a/web/e2e/tests/auth.spec.ts
+++ b/web/e2e/tests/auth.spec.ts
@@ -46,7 +46,10 @@ test.describe("Authentication", () => {
     await expect(passwordInputs).toHaveCount(2);
   });
 
-  test("register with new email redirects to check-email", async ({
+  // The e2e stack runs without an email backend (no Listmonk, no SMTP), so
+  // registration auto-verifies and redirects to /login instead of /check-email.
+  // The /check-email branch is exercised by Register.test.tsx unit tests.
+  test("register with new email redirects to login when no email backend", async ({
     page,
   }) => {
     const uniqueEmail = `e2e-register-${Date.now()}@test.sendrec.local`;
@@ -57,6 +60,6 @@ test.describe("Authentication", () => {
     await passwordInputs.nth(0).fill("TestPassword123!");
     await passwordInputs.nth(1).fill("TestPassword123!");
     await page.getByRole("button", { name: "Create account" }).click();
-    await expect(page).toHaveURL(/\/check-email/);
+    await expect(page).toHaveURL(/\/login/);
   });
 });


### PR DESCRIPTION
## Summary
v1.85.0 introduced auto-skip-confirmation when no email backend is configured. The e2e stack has no Listmonk/SMTP, so registration now lands on `/login` instead of `/check-email`. This updates the assertion to match.

The `/check-email` branch is still covered by `Register.test.tsx` unit tests.

## Test plan
- [ ] e2e job passes