### PR TITLE
Fix recorder floating controls

### DIFF
--- a/web/e2e/helpers/auth.ts
+++ b/web/e2e/helpers/auth.ts
@@ -62,6 +62,7 @@ export async function loginAsSecondUser(page: Page): Promise<void> {
     if (response.ok()) {
       const body = await response.json();
       accessTokenStore.set(page, body.accessToken);
+      await waitForAuthenticatedShell(page);
       return;
     }
     if (response.status() === 429) {
@@ -81,6 +82,7 @@ export async function loginViaAPI(page: Page): Promise<void> {
     if (response.ok()) {
       const body = await response.json();
       accessTokenStore.set(page, body.accessToken);
+      await waitForAuthenticatedShell(page);
       return;
     }
     if (response.status() === 429) {
@@ -93,6 +95,11 @@ export async function loginViaAPI(page: Page): Promise<void> {
 }
 
 const accessTokenStore = new WeakMap<Page, string>();
+
+async function waitForAuthenticatedShell(page: Page): Promise<void> {
+  await page.goto("/");
+  await page.getByLabel("Switch workspace").waitFor({ timeout: 10000 });
+}
 
 export function getAccessToken(page: Page): string {
   const token = accessTokenStore.get(page);

--- a/web/e2e/helpers/workspace.ts
+++ b/web/e2e/helpers/workspace.ts
@@ -77,6 +77,7 @@ export async function switchToPersonal(page: Page): Promise<void> {
 
 export async function navigateToOrgSettings(page: Page, orgId: string): Promise<void> {
   await page.goto("/");
+  await page.getByLabel("Switch workspace").waitFor({ timeout: 10000 });
   await page.evaluate((id) => localStorage.setItem("sendrec-org-id", id), orgId);
   await page.goto(`/organizations/${orgId}/settings`);
 }

--- a/web/e2e/playwright.config.ts
+++ b/web/e2e/playwright.config.ts
@@ -21,7 +21,14 @@ export default defineConfig({
       use: {
         ...devices["Desktop Chrome"],
         launchOptions: {
-          args: ["--disable-web-security"],
+          args: [
+            "--disable-web-security",
+            "--use-fake-device-for-media-stream",
+            "--use-fake-ui-for-media-stream",
+            "--auto-select-desktop-capture-source=Entire screen",
+            "--enable-usermedia-screen-capturing",
+            "--allow-http-screen-capture",
+          ],
         },
       },
     },

--- a/web/e2e/tests/recording-floating-controls.spec.ts
+++ b/web/e2e/tests/recording-floating-controls.spec.ts
@@ -23,7 +23,6 @@ test.describe("Recording floating controls", () => {
     );
 
     await page.getByRole("button", { name: "Start recording" }).click();
-    await page.getByTestId("countdown-overlay").click();
 
     await expect
       .poll(() =>

--- a/web/e2e/tests/recording-floating-controls.spec.ts
+++ b/web/e2e/tests/recording-floating-controls.spec.ts
@@ -36,7 +36,15 @@ test.describe("Recording floating controls", () => {
       .toContain("Stop");
 
     await expect(page.locator(".recording-header")).toHaveCount(0);
-    await page.waitForTimeout(1500);
+    await expect
+      .poll(() =>
+        page.evaluate(() =>
+          window.documentPictureInPicture?.window?.document.querySelector(
+            ".recording-dot--active",
+          ) !== null,
+        ),
+      )
+      .toBe(true);
 
     await page.evaluate(() => {
       const pipDocument = window.documentPictureInPicture?.window?.document;

--- a/web/e2e/tests/recording-floating-controls.spec.ts
+++ b/web/e2e/tests/recording-floating-controls.spec.ts
@@ -1,0 +1,55 @@
+import { test, expect } from "@playwright/test";
+import { loginViaAPI } from "../helpers/auth";
+
+test.describe("Recording floating controls", () => {
+  test.beforeEach(async ({ page }) => {
+    await loginViaAPI(page);
+  });
+
+  test("opens Document Picture-in-Picture controls and stops recording from there", async ({
+    page,
+  }) => {
+    await page.goto("/");
+    await expect(
+      page.getByRole("heading", { name: /new recording/i }),
+    ).toBeVisible();
+
+    const supportsDocumentPictureInPicture = await page.evaluate(
+      () => "documentPictureInPicture" in window,
+    );
+    test.skip(
+      !supportsDocumentPictureInPicture,
+      "Document Picture-in-Picture is not available in this Chromium build",
+    );
+
+    await page.getByRole("button", { name: "Start recording" }).click();
+    await page.getByTestId("countdown-overlay").click();
+
+    await expect
+      .poll(() =>
+        page.evaluate(
+          () =>
+            window.documentPictureInPicture?.window?.document.body
+              .textContent ?? "",
+        ),
+      )
+      .toContain("Stop");
+
+    await expect(page.locator(".recording-header")).toHaveCount(0);
+    await page.waitForTimeout(1500);
+
+    await page.evaluate(() => {
+      const pipDocument = window.documentPictureInPicture?.window?.document;
+      const stopButton = pipDocument?.querySelector<HTMLButtonElement>(
+        '[aria-label="Stop recording"]',
+      );
+      stopButton?.click();
+    });
+
+    await expect(
+      page.getByText(
+        /Creating video|Uploading recording|Finalizing|Your video is ready/i,
+      ),
+    ).toBeVisible({ timeout: 30_000 });
+  });
+});

--- a/web/e2e/tests/recording-floating-controls.spec.ts
+++ b/web/e2e/tests/recording-floating-controls.spec.ts
@@ -45,6 +45,15 @@ test.describe("Recording floating controls", () => {
         ),
       )
       .toBe(true);
+    await expect
+      .poll(() =>
+        page.evaluate(
+          () =>
+            window.documentPictureInPicture?.window?.document.body
+              .textContent ?? "",
+        ),
+      )
+      .toMatch(/0:0[1-9]/);
 
     await page.evaluate(() => {
       const pipDocument = window.documentPictureInPicture?.window?.document;

--- a/web/src/components/Recorder.test.tsx
+++ b/web/src/components/Recorder.test.tsx
@@ -225,7 +225,7 @@ describe("Recorder", () => {
     });
   });
 
-  it("opens Document Picture-in-Picture from the countdown click", async () => {
+  it("opens Document Picture-in-Picture after countdown completes", async () => {
     const { requestWindow } = installDocumentPictureInPicture();
     const user = userEvent.setup();
 
@@ -234,8 +234,8 @@ describe("Recorder", () => {
 
     expect(requestWindow).not.toHaveBeenCalled();
     expect(screen.getByTestId("countdown-overlay")).toBeInTheDocument();
-    expect(screen.getByText("Ready")).toBeInTheDocument();
-    expect(screen.getByText("Click to open floating controls")).toBeInTheDocument();
+    expect(screen.getByText("3")).toBeInTheDocument();
+    expect(screen.getByText("Click to start now")).toBeInTheDocument();
     await user.click(screen.getByTestId("countdown-overlay"));
 
     await vi.waitFor(() => {
@@ -244,7 +244,7 @@ describe("Recorder", () => {
     expect(document.querySelector(".recording-header")).not.toBeInTheDocument();
   });
 
-  it("keeps the Doc PiP countdown waiting for a click instead of auto-starting without activation", async () => {
+  it("auto-starts recording after countdown when Document Picture-in-Picture is supported", async () => {
     vi.useFakeTimers({ shouldAdvanceTime: true });
     const { requestWindow } = installDocumentPictureInPicture();
     const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
@@ -256,8 +256,9 @@ describe("Recorder", () => {
       vi.advanceTimersByTime(4000);
     });
 
-    expect(screen.getByTestId("countdown-overlay")).toBeInTheDocument();
-    expect(requestWindow).not.toHaveBeenCalled();
+    await vi.waitFor(() => {
+      expect(requestWindow).toHaveBeenCalledWith({ width: 280, height: 220 });
+    });
     expect(document.querySelector(".recording-header")).not.toBeInTheDocument();
     vi.useRealTimers();
   });

--- a/web/src/components/Recorder.test.tsx
+++ b/web/src/components/Recorder.test.tsx
@@ -694,6 +694,41 @@ describe("Recorder", () => {
     expect(videos.length).toBe(1);
   });
 
+  it("requests camera stream when saved screen-camera mode starts recording", async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    localStorage.setItem("recording-mode", "screen-camera");
+    localStorage.setItem("recording-audio", "false");
+    const webcamStream = new MockMediaStream();
+    (navigator.mediaDevices.getUserMedia as ReturnType<typeof vi.fn>).mockResolvedValue(webcamStream);
+    const onComplete = vi.fn();
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+
+    render(<Recorder onRecordingComplete={onComplete} />);
+    expect(screen.getByText("Camera On")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Start recording" }));
+    await user.click(screen.getByTestId("countdown-overlay"));
+
+    expect(navigator.mediaDevices.getUserMedia).toHaveBeenCalledWith({
+      video: { width: 320, height: 240, facingMode: "user" },
+      audio: false,
+    });
+
+    await act(() => {
+      vi.advanceTimersByTime(1500);
+    });
+    await user.click(screen.getByRole("button", { name: "Stop recording" }));
+
+    await vi.waitFor(() => {
+      expect(onComplete).toHaveBeenCalledWith(
+        expect.any(Blob),
+        expect.any(Number),
+        expect.any(Blob),
+      );
+    });
+    vi.useRealTimers();
+  });
+
   it("sets up webcam recorder when webcam is enabled before recording starts", async () => {
     vi.useFakeTimers({ shouldAdvanceTime: true });
     // Return a proper mock stream from getUserMedia

--- a/web/src/components/Recorder.test.tsx
+++ b/web/src/components/Recorder.test.tsx
@@ -101,14 +101,18 @@ function createPictureInPictureWindow() {
   } as unknown as Window;
 }
 
-function installDocumentPictureInPicture(
-  requestWindow = vi.fn().mockResolvedValue(createPictureInPictureWindow()),
-) {
+function installDocumentPictureInPicture(requestWindow?: ReturnType<typeof vi.fn>) {
+  const pipWindow = createPictureInPictureWindow();
+  const resolvedRequestWindow = requestWindow ?? vi.fn().mockResolvedValue(pipWindow);
   Object.defineProperty(window, "documentPictureInPicture", {
-    value: { requestWindow },
+    value: { requestWindow: resolvedRequestWindow },
     configurable: true,
   });
-  return { requestWindow };
+  return {
+    requestWindow: resolvedRequestWindow,
+    pipWindow,
+    close: pipWindow.close as unknown as ReturnType<typeof vi.fn>,
+  };
 }
 
 beforeEach(() => {
@@ -225,27 +229,22 @@ describe("Recorder", () => {
     });
   });
 
-  it("opens Document Picture-in-Picture from the countdown click", async () => {
+  it("opens Document Picture-in-Picture from the Start click", async () => {
     const { requestWindow } = installDocumentPictureInPicture();
     const user = userEvent.setup();
 
     render(<Recorder onRecordingComplete={vi.fn()} />);
     await user.click(screen.getByRole("button", { name: "Start recording" }));
 
-    expect(requestWindow).not.toHaveBeenCalled();
-    expect(screen.getByTestId("countdown-overlay")).toBeInTheDocument();
-    expect(screen.getByText("Ready")).toBeInTheDocument();
-    expect(screen.getByText("Click to start recording")).toBeInTheDocument();
-
-    await user.click(screen.getByTestId("countdown-overlay"));
-
     await vi.waitFor(() => {
       expect(requestWindow).toHaveBeenCalledWith({ width: 280, height: 220 });
     });
-    expect(document.querySelector(".recording-header")).not.toBeInTheDocument();
+    expect(screen.getByTestId("countdown-overlay")).toBeInTheDocument();
+    expect(screen.getByText("3")).toBeInTheDocument();
+    expect(screen.getByText("Click to start now")).toBeInTheDocument();
   });
 
-  it("keeps Document Picture-in-Picture countdown waiting for the click gesture", async () => {
+  it("auto-starts recording after countdown when Document Picture-in-Picture is supported", async () => {
     vi.useFakeTimers({ shouldAdvanceTime: true });
     const { requestWindow } = installDocumentPictureInPicture();
     const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
@@ -257,9 +256,28 @@ describe("Recorder", () => {
       vi.advanceTimersByTime(4000);
     });
 
-    expect(screen.getByTestId("countdown-overlay")).toBeInTheDocument();
-    expect(requestWindow).not.toHaveBeenCalled();
+    await vi.waitFor(() => {
+      expect(requestWindow).toHaveBeenCalledWith({ width: 280, height: 220 });
+      expect(screen.queryByTestId("countdown-overlay")).not.toBeInTheDocument();
+      expect(document.querySelector(".recording-header")).not.toBeInTheDocument();
+    });
     vi.useRealTimers();
+  });
+
+  it("closes Document Picture-in-Picture when unmounting during countdown", async () => {
+    const { requestWindow, close } = installDocumentPictureInPicture();
+    const user = userEvent.setup();
+
+    const { unmount } = render(<Recorder onRecordingComplete={vi.fn()} />);
+    await user.click(screen.getByRole("button", { name: "Start recording" }));
+
+    await vi.waitFor(() => {
+      expect(requestWindow).toHaveBeenCalledWith({ width: 280, height: 220 });
+    });
+
+    unmount();
+
+    expect(close).toHaveBeenCalledTimes(1);
   });
 
   it("keeps the main recording header and shows the Tier-2 banner without Document Picture-in-Picture", async () => {
@@ -589,8 +607,8 @@ describe("Recorder", () => {
     expect(screen.getByText("Screen recording was blocked or failed. Please allow screen capture and try again.")).toBeInTheDocument();
   });
 
-  it("does not open Document Picture-in-Picture when screen capture fails", async () => {
-    const { requestWindow } = installDocumentPictureInPicture();
+  it("closes Document Picture-in-Picture when screen capture fails", async () => {
+    const { requestWindow, close } = installDocumentPictureInPicture();
     (navigator.mediaDevices.getDisplayMedia as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
       new Error("User cancelled"),
     );
@@ -599,7 +617,8 @@ describe("Recorder", () => {
     render(<Recorder onRecordingComplete={vi.fn()} />);
     await user.click(screen.getByRole("button", { name: "Start recording" }));
 
-    expect(requestWindow).not.toHaveBeenCalled();
+    expect(requestWindow).toHaveBeenCalledWith({ width: 280, height: 220 });
+    expect(close).toHaveBeenCalledTimes(1);
     expect(screen.getByRole("alert")).toBeInTheDocument();
   });
 

--- a/web/src/components/Recorder.test.tsx
+++ b/web/src/components/Recorder.test.tsx
@@ -88,9 +88,35 @@ class MockMediaRecorder {
   });
 }
 
+function createPictureInPictureWindow() {
+  const pipDocument = document.implementation.createHTMLDocument("pip");
+  const eventTarget = new EventTarget();
+  const close = vi.fn();
+  return {
+    document: pipDocument,
+    close,
+    addEventListener: eventTarget.addEventListener.bind(eventTarget),
+    removeEventListener: eventTarget.removeEventListener.bind(eventTarget),
+    dispatchEvent: eventTarget.dispatchEvent.bind(eventTarget),
+  } as unknown as Window;
+}
+
+function installDocumentPictureInPicture(
+  requestWindow = vi.fn().mockResolvedValue(createPictureInPictureWindow()),
+) {
+  Object.defineProperty(window, "documentPictureInPicture", {
+    value: { requestWindow },
+    configurable: true,
+  });
+  return { requestWindow };
+}
+
 beforeEach(() => {
   mockDrawMode = false;
   vi.clearAllMocks();
+  localStorage.clear();
+  delete (window as unknown as { documentPictureInPicture?: unknown })
+    .documentPictureInPicture;
 
   Object.defineProperty(globalThis.navigator, "mediaDevices", {
     value: {
@@ -183,6 +209,131 @@ describe("Recorder", () => {
     expect(
       screen.getByRole("button", { name: "Stop recording" }),
     ).toBeInTheDocument();
+  });
+
+  it("hides the main recording header when Document Picture-in-Picture is supported", async () => {
+    const { requestWindow } = installDocumentPictureInPicture();
+    const user = userEvent.setup();
+
+    render(<Recorder onRecordingComplete={vi.fn()} />);
+    await user.click(screen.getByRole("button", { name: "Start recording" }));
+    await user.click(screen.getByTestId("countdown-overlay"));
+
+    expect(document.querySelector(".recording-header")).not.toBeInTheDocument();
+    await vi.waitFor(() => {
+      expect(requestWindow).toHaveBeenCalledWith({ width: 280, height: 220 });
+    });
+  });
+
+  it("opens Document Picture-in-Picture from the countdown click", async () => {
+    const { requestWindow } = installDocumentPictureInPicture();
+    const user = userEvent.setup();
+
+    render(<Recorder onRecordingComplete={vi.fn()} />);
+    await user.click(screen.getByRole("button", { name: "Start recording" }));
+
+    expect(requestWindow).not.toHaveBeenCalled();
+    expect(screen.getByTestId("countdown-overlay")).toBeInTheDocument();
+    expect(screen.getByText("Ready")).toBeInTheDocument();
+    expect(screen.getByText("Click to open floating controls")).toBeInTheDocument();
+    await user.click(screen.getByTestId("countdown-overlay"));
+
+    await vi.waitFor(() => {
+      expect(requestWindow).toHaveBeenCalledWith({ width: 280, height: 220 });
+    });
+    expect(document.querySelector(".recording-header")).not.toBeInTheDocument();
+  });
+
+  it("keeps the Doc PiP countdown waiting for a click instead of auto-starting without activation", async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    const { requestWindow } = installDocumentPictureInPicture();
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+
+    render(<Recorder onRecordingComplete={vi.fn()} />);
+    await user.click(screen.getByRole("button", { name: "Start recording" }));
+
+    act(() => {
+      vi.advanceTimersByTime(4000);
+    });
+
+    expect(screen.getByTestId("countdown-overlay")).toBeInTheDocument();
+    expect(requestWindow).not.toHaveBeenCalled();
+    expect(document.querySelector(".recording-header")).not.toBeInTheDocument();
+    vi.useRealTimers();
+  });
+
+  it("keeps the main recording header and shows the Tier-2 banner without Document Picture-in-Picture", async () => {
+    const user = userEvent.setup();
+
+    render(<Recorder onRecordingComplete={vi.fn()} />);
+    await user.click(screen.getByRole("button", { name: "Start recording" }));
+    await user.click(screen.getByTestId("countdown-overlay"));
+
+    expect(document.querySelector(".recording-header")).toBeInTheDocument();
+    expect(
+      screen.getByText("For controls that float over your recording, use Chrome."),
+    ).toBeInTheDocument();
+    expect(localStorage.getItem("sendrec.floating-banner-shown")).toBe("1");
+  });
+
+  it("shows the Tier-2 banner only once per browser", async () => {
+    localStorage.setItem("sendrec.floating-banner-shown", "1");
+    const user = userEvent.setup();
+
+    render(<Recorder onRecordingComplete={vi.fn()} />);
+    await user.click(screen.getByRole("button", { name: "Start recording" }));
+    await user.click(screen.getByTestId("countdown-overlay"));
+
+    expect(document.querySelector(".recording-header")).toBeInTheDocument();
+    expect(
+      screen.queryByText("For controls that float over your recording, use Chrome."),
+    ).not.toBeInTheDocument();
+  });
+
+  it("falls back to the main recording header when Document Picture-in-Picture cannot open", async () => {
+    installDocumentPictureInPicture(
+      vi.fn().mockRejectedValue(new Error("PiP blocked")),
+    );
+    const user = userEvent.setup();
+
+    render(<Recorder onRecordingComplete={vi.fn()} />);
+    await user.click(screen.getByRole("button", { name: "Start recording" }));
+    await user.click(screen.getByTestId("countdown-overlay"));
+
+    await vi.waitFor(() => {
+      expect(document.querySelector(".recording-header")).toBeInTheDocument();
+    });
+    expect(
+      screen.queryByText("For controls that float over your recording, use Chrome."),
+    ).not.toBeInTheDocument();
+  });
+
+  it("does not persist the Tier-2 banner when countdown aborts before recording starts", async () => {
+    let endedCallback: (() => void) | undefined;
+    const trackWithEndedCapture = {
+      getSettings: () => ({ width: 1920, height: 1080 }),
+      addEventListener: vi.fn().mockImplementation((event: string, handler: () => void) => {
+        if (event === "ended") {
+          endedCallback = handler;
+        }
+      }),
+      stop: vi.fn(),
+    };
+    mockScreenStream.getVideoTracks.mockReturnValue([trackWithEndedCapture]);
+    const user = userEvent.setup();
+
+    render(<Recorder onRecordingComplete={vi.fn()} />);
+    await user.click(screen.getByRole("button", { name: "Start recording" }));
+
+    expect(endedCallback).toBeDefined();
+    act(() => {
+      endedCallback!();
+    });
+
+    expect(localStorage.getItem("sendrec.floating-banner-shown")).toBeNull();
+    expect(
+      screen.queryByText("For controls that float over your recording, use Chrome."),
+    ).not.toBeInTheDocument();
   });
 
   it("calls toggleDrawMode when Draw button is clicked", async () => {

--- a/web/src/components/Recorder.test.tsx
+++ b/web/src/components/Recorder.test.tsx
@@ -225,22 +225,21 @@ describe("Recorder", () => {
     });
   });
 
-  it("opens Document Picture-in-Picture after countdown completes", async () => {
+  it("opens Document Picture-in-Picture during Start click, before countdown", async () => {
     const { requestWindow } = installDocumentPictureInPicture();
     const user = userEvent.setup();
 
     render(<Recorder onRecordingComplete={vi.fn()} />);
     await user.click(screen.getByRole("button", { name: "Start recording" }));
 
-    expect(requestWindow).not.toHaveBeenCalled();
+    // PiP is opened inside startRecording (before getDisplayMedia) so it is
+    // already called by the time the countdown overlay appears.
+    expect(requestWindow).toHaveBeenCalledWith({ width: 280, height: 220 });
     expect(screen.getByTestId("countdown-overlay")).toBeInTheDocument();
     expect(screen.getByText("3")).toBeInTheDocument();
     expect(screen.getByText("Click to start now")).toBeInTheDocument();
     await user.click(screen.getByTestId("countdown-overlay"));
 
-    await vi.waitFor(() => {
-      expect(requestWindow).toHaveBeenCalledWith({ width: 280, height: 220 });
-    });
     expect(document.querySelector(".recording-header")).not.toBeInTheDocument();
   });
 
@@ -964,5 +963,57 @@ describe("Recorder", () => {
   it("has no accessibility violations", async () => {
     const { container } = render(<Recorder onRecordingComplete={vi.fn()} />);
     await expectNoA11yViolations(container);
+  });
+
+  it("awaits pending webcam request before starting recording (race condition)", async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+
+    // getUserMedia resolves only when we call resolveWebcam()
+    let resolveWebcam!: (stream: MockMediaStream) => void;
+    const webcamStream = new MockMediaStream();
+    const pendingWebcamPromise = new Promise<MockMediaStream>((res) => {
+      resolveWebcam = res;
+    });
+    (navigator.mediaDevices.getUserMedia as ReturnType<typeof vi.fn>).mockReturnValue(
+      pendingWebcamPromise,
+    );
+
+    localStorage.setItem("recording-mode", "screen-camera");
+    localStorage.setItem("recording-audio", "false");
+
+    // Track MediaRecorder constructor calls so we can assert webcam recorder was created
+    const constructorArgs: MediaStream[] = [];
+    const OriginalMock = MockMediaRecorder;
+    class TrackingMediaRecorder extends OriginalMock {
+      constructor(stream: MediaStream) {
+        super();
+        constructorArgs.push(stream);
+      }
+    }
+    globalThis.MediaRecorder = TrackingMediaRecorder as unknown as typeof MediaRecorder;
+
+    const onComplete = vi.fn();
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+    render(<Recorder onRecordingComplete={onComplete} />);
+
+    // Click Start immediately — webcam getUserMedia promise is still pending
+    await user.click(screen.getByRole("button", { name: "Start recording" }));
+    await user.click(screen.getByTestId("countdown-overlay"));
+
+    // Resolve webcam after startRecording has already been called
+    await act(async () => {
+      resolveWebcam(webcamStream);
+      // Flush microtasks so the pending promise settles
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    // Without the fix: webcamStreamRef.current was null when startRecording checked,
+    // so only 1 MediaRecorder (screen) was created.
+    // With the fix: startRecording awaits the pending promise, so webcamStreamRef.current
+    // is set before the guard, producing 2 MediaRecorder instances.
+    expect(constructorArgs.length).toBe(2);
+
+    vi.useRealTimers();
   });
 });

--- a/web/src/components/Recorder.test.tsx
+++ b/web/src/components/Recorder.test.tsx
@@ -225,25 +225,27 @@ describe("Recorder", () => {
     });
   });
 
-  it("opens Document Picture-in-Picture during Start click, before countdown", async () => {
+  it("opens Document Picture-in-Picture from the countdown click", async () => {
     const { requestWindow } = installDocumentPictureInPicture();
     const user = userEvent.setup();
 
     render(<Recorder onRecordingComplete={vi.fn()} />);
     await user.click(screen.getByRole("button", { name: "Start recording" }));
 
-    // PiP is opened inside startRecording (before getDisplayMedia) so it is
-    // already called by the time the countdown overlay appears.
-    expect(requestWindow).toHaveBeenCalledWith({ width: 280, height: 220 });
+    expect(requestWindow).not.toHaveBeenCalled();
     expect(screen.getByTestId("countdown-overlay")).toBeInTheDocument();
-    expect(screen.getByText("3")).toBeInTheDocument();
-    expect(screen.getByText("Click to start now")).toBeInTheDocument();
+    expect(screen.getByText("Ready")).toBeInTheDocument();
+    expect(screen.getByText("Click to start recording")).toBeInTheDocument();
+
     await user.click(screen.getByTestId("countdown-overlay"));
 
+    await vi.waitFor(() => {
+      expect(requestWindow).toHaveBeenCalledWith({ width: 280, height: 220 });
+    });
     expect(document.querySelector(".recording-header")).not.toBeInTheDocument();
   });
 
-  it("auto-starts recording after countdown when Document Picture-in-Picture is supported", async () => {
+  it("keeps Document Picture-in-Picture countdown waiting for the click gesture", async () => {
     vi.useFakeTimers({ shouldAdvanceTime: true });
     const { requestWindow } = installDocumentPictureInPicture();
     const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
@@ -255,10 +257,8 @@ describe("Recorder", () => {
       vi.advanceTimersByTime(4000);
     });
 
-    await vi.waitFor(() => {
-      expect(requestWindow).toHaveBeenCalledWith({ width: 280, height: 220 });
-    });
-    expect(document.querySelector(".recording-header")).not.toBeInTheDocument();
+    expect(screen.getByTestId("countdown-overlay")).toBeInTheDocument();
+    expect(requestWindow).not.toHaveBeenCalled();
     vi.useRealTimers();
   });
 
@@ -587,6 +587,20 @@ describe("Recorder", () => {
 
     expect(screen.getByRole("alert")).toBeInTheDocument();
     expect(screen.getByText("Screen recording was blocked or failed. Please allow screen capture and try again.")).toBeInTheDocument();
+  });
+
+  it("does not open Document Picture-in-Picture when screen capture fails", async () => {
+    const { requestWindow } = installDocumentPictureInPicture();
+    (navigator.mediaDevices.getDisplayMedia as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
+      new Error("User cancelled"),
+    );
+
+    const user = userEvent.setup();
+    render(<Recorder onRecordingComplete={vi.fn()} />);
+    await user.click(screen.getByRole("button", { name: "Start recording" }));
+
+    expect(requestWindow).not.toHaveBeenCalled();
+    expect(screen.getByRole("alert")).toBeInTheDocument();
   });
 
   it("dismisses media error when dismiss button is clicked", async () => {

--- a/web/src/components/Recorder.test.tsx
+++ b/web/src/components/Recorder.test.tsx
@@ -730,6 +730,19 @@ describe("Recorder", () => {
     );
   });
 
+  it("calls getDisplayMedia with selfBrowserSurface=exclude and preferCurrentTab=false", async () => {
+    const user = userEvent.setup();
+    render(<Recorder onRecordingComplete={vi.fn()} />);
+    await user.click(screen.getByRole("button", { name: "Start recording" }));
+
+    expect(navigator.mediaDevices.getDisplayMedia).toHaveBeenCalledWith(
+      expect.objectContaining({
+        selfBrowserSurface: "exclude",
+        preferCurrentTab: false,
+      }),
+    );
+  });
+
   it("calls onRecordingError when recording is shorter than 1 second", async () => {
     const onComplete = vi.fn();
     const onError = vi.fn();

--- a/web/src/components/Recorder.tsx
+++ b/web/src/components/Recorder.tsx
@@ -27,7 +27,6 @@ export function Recorder({ onRecordingComplete, onRecordingError, maxDurationSec
   const [mediaError, setMediaError] = useState<string | null>(null);
   const [showFloatingControlsBanner, setShowFloatingControlsBanner] = useState(false);
   const [floatingControlsUnavailable, setFloatingControlsUnavailable] = useState(false);
-  const [floatingControlsWindow, setFloatingControlsWindow] = useState<Window | null>(null);
   const [supportsDocPiP] = useState(() => supportsDocumentPictureInPicture());
   const countdownEnabled = useRef(localStorage.getItem("recording-countdown") !== "false");
 
@@ -36,7 +35,6 @@ export function Recorder({ onRecordingComplete, onRecordingError, maxDurationSec
   const screenStreamRef = useRef<MediaStream | null>(null);
   const micStreamRef = useRef<MediaStream | null>(null);
   const audioContextRef = useRef<AudioContext | null>(null);
-  const floatingControlsWindowRef = useRef<Window | null>(null);
 
   const webcamStreamRef = useRef<MediaStream | null>(null);
   const webcamRecorderRef = useRef<MediaRecorder | null>(null);
@@ -102,31 +100,6 @@ export function Recorder({ onRecordingComplete, onRecordingError, maxDurationSec
     stopWebcamStream();
   }, [stopMicStream, stopWebcamStream]);
 
-  const clearFloatingControlsWindow = useCallback(() => {
-    floatingControlsWindowRef.current?.close();
-    floatingControlsWindowRef.current = null;
-    setFloatingControlsWindow(null);
-  }, []);
-
-  const openFloatingControlsWindow = useCallback(async () => {
-    if (!supportsDocPiP) return null;
-    const documentPictureInPicture = window.documentPictureInPicture;
-    if (!documentPictureInPicture) return null;
-
-    try {
-      const pipWindow = await documentPictureInPicture.requestWindow({
-        width: 280,
-        height: 220,
-      });
-      floatingControlsWindowRef.current = pipWindow;
-      setFloatingControlsWindow(pipWindow);
-      return pipWindow;
-    } catch {
-      setFloatingControlsUnavailable(true);
-      return null;
-    }
-  }, [supportsDocPiP]);
-
   // Stable refs for callbacks passed to useRecording to avoid stale closure issues
   const stopRecordingRef = useRef<() => void>(() => {});
   const beginRecordingRef = useRef<() => void>(() => {});
@@ -135,7 +108,6 @@ export function Recorder({ onRecordingComplete, onRecordingError, maxDurationSec
     maxDurationSeconds,
     () => beginRecordingRef.current(),
     () => stopRecordingRef.current(),
-    !supportsDocPiP,
   );
 
   const stopRecording = useCallback(() => {
@@ -197,11 +169,8 @@ export function Recorder({ onRecordingComplete, onRecordingError, maxDurationSec
     setFloatingControlsUnavailable(true);
   }, []);
 
-  const beginRecording = useCallback(async () => {
+  const beginRecording = useCallback(() => {
     clearInterval(recording.countdownTimerRef.current);
-    if (supportsDocPiP && !floatingControlsWindowRef.current && !floatingControlsUnavailable) {
-      await openFloatingControlsWindow();
-    }
     if (mediaRecorderRef.current) {
       // No timeslice — Chrome's MP4 MediaRecorder may produce empty fragments
       // with start(timeslice) on getDisplayMedia() streams. All data is buffered
@@ -218,17 +187,11 @@ export function Recorder({ onRecordingComplete, onRecordingError, maxDurationSec
       localStorage.setItem(FLOATING_CONTROLS_BANNER_KEY, "1");
       setShowFloatingControlsBanner(true);
     }
-  }, [
-    floatingControlsUnavailable,
-    openFloatingControlsWindow,
-    recording,
-    supportsDocPiP,
-  ]);
+  }, [recording, supportsDocPiP]);
 
   const abortCountdown = useCallback(() => {
     recording.reset();
     setShowFloatingControlsBanner(false);
-    clearFloatingControlsWindow();
     stopCompositing();
     if (screenVideoRef.current) {
       screenVideoRef.current.srcObject = null;
@@ -237,7 +200,7 @@ export function Recorder({ onRecordingComplete, onRecordingError, maxDurationSec
     mediaRecorderRef.current = null;
     webcamRecorderRef.current = null;
     webcamBlobPromiseRef.current = null;
-  }, [clearFloatingControlsWindow, recording, stopAllStreams, stopCompositing]);
+  }, [recording, stopAllStreams, stopCompositing]);
 
   const requestWebcamStream = useCallback(async () => {
     try {
@@ -253,6 +216,16 @@ export function Recorder({ onRecordingComplete, onRecordingError, maxDurationSec
       setWebcamEnabled(false);
       setMediaError("Could not access your camera. Please allow camera access and try again.");
       return null;
+    }
+  }, []);
+
+  // Restore saved camera preference immediately on mount so the stream is ready
+  // before the user hits Start (avoids a permission prompt mid-recording).
+  const requestWebcamStreamRef = useRef(requestWebcamStream);
+  requestWebcamStreamRef.current = requestWebcamStream;
+  useEffect(() => {
+    if (localStorage.getItem("recording-mode") === "screen-camera") {
+      void requestWebcamStreamRef.current();
     }
   }, []);
 
@@ -274,13 +247,7 @@ export function Recorder({ onRecordingComplete, onRecordingError, maxDurationSec
     setMediaError(null);
     setFloatingControlsUnavailable(false);
     setShowFloatingControlsBanner(false);
-    clearFloatingControlsWindow();
     try {
-      if (webcamEnabled && !webcamStreamRef.current) {
-        const stream = await requestWebcamStream();
-        if (!stream) return;
-      }
-
       const displayMediaOptions: DisplayMediaStreamOptions & Record<string, unknown> = {
         video: true,
         audio: systemAudioEnabled,
@@ -462,11 +429,11 @@ export function Recorder({ onRecordingComplete, onRecordingError, maxDurationSec
         }
       });
 
-      if (countdownEnabled.current || supportsDocPiP) {
+      if (countdownEnabled.current) {
         recording.setCountdown(3);
         recording.setState("countdown");
       } else {
-        void beginRecording();
+        beginRecording();
       }
     } catch (err) {
       console.error("Screen capture failed", err);
@@ -495,11 +462,7 @@ export function Recorder({ onRecordingComplete, onRecordingError, maxDurationSec
 
   const { elapsed: duration, countdown: countdownValue,
     isIdle, isCountdown, isPaused, isActive, isRecording, remaining } = recording;
-  const useFloatingControls =
-    isRecording &&
-    supportsDocPiP &&
-    !floatingControlsUnavailable &&
-    floatingControlsWindow !== null;
+  const useFloatingControls = isRecording && supportsDocPiP && !floatingControlsUnavailable;
 
   return (
     <div className="recorder-container">
@@ -574,12 +537,8 @@ export function Recorder({ onRecordingComplete, onRecordingError, maxDurationSec
             data-testid="countdown-overlay"
             onClick={beginRecording}
           >
-            <div className="countdown-number">
-              {supportsDocPiP ? "Ready" : countdownValue}
-            </div>
-            <div className="countdown-hint">
-              {supportsDocPiP ? "Click to open floating controls" : "Click to start now"}
-            </div>
+            <div className="countdown-number">{countdownValue}</div>
+            <div className="countdown-hint">Click to start now</div>
           </div>
         )}
       </div>
@@ -686,7 +645,6 @@ export function Recorder({ onRecordingComplete, onRecordingError, maxDurationSec
 
       {useFloatingControls && (
         <RecordingFloatingControls
-          pipWindow={floatingControlsWindow}
           webcamStream={webcamStreamRef.current}
           webcamEnabled={webcamEnabled}
           duration={duration}

--- a/web/src/components/Recorder.tsx
+++ b/web/src/components/Recorder.tsx
@@ -4,6 +4,7 @@ import { useCanvasCompositing } from "../hooks/useCanvasCompositing";
 import { useRecording, MIN_RECORDING_SECONDS, MIN_RECORDING_BYTES } from "../hooks/useRecording";
 import { getSupportedMimeType, blobTypeFromMimeType } from "../utils/mediaFormat";
 import { formatDuration } from "../utils/format";
+import { RecordingHeader } from "./RecordingHeader";
 
 interface RecorderProps {
   onRecordingComplete: (blob: Blob, duration: number, webcamBlob?: Blob) => void;
@@ -578,102 +579,21 @@ export function Recorder({ onRecordingComplete, onRecordingError, maxDurationSec
 
       {/* Recording controls — always above preview */}
       {isRecording && (
-        <div className="recording-header" role="status" aria-live="polite">
-          <div className={`recording-indicator ${isPaused ? "recording-indicator--paused" : "recording-indicator--active"}`}>
-            <div className={`recording-dot ${isPaused ? "recording-dot--paused" : "recording-dot--active"}`} />
-            {formatDuration(duration)}
-            {isPaused && <span className="recording-remaining">(Paused)</span>}
-            {!isPaused && remaining !== null && (
-              <span className="recording-remaining">({formatDuration(remaining)} remaining)</span>
-            )}
-          </div>
-
-          <button
-            onClick={toggleDrawMode}
-            aria-label={drawMode ? "Disable drawing" : "Enable drawing"}
-            data-testid="draw-toggle"
-            className={`btn-draw${drawMode ? " btn-draw--active" : ""}`}
-          >
-            Draw
-          </button>
-
-          {drawMode && (
-            <input
-              type="color"
-              value={drawColor}
-              onChange={(e) => setDrawColor(e.target.value)}
-              aria-label="Drawing color"
-              data-testid="color-picker"
-              style={{
-                width: 36,
-                height: 36,
-                border: "1px solid var(--color-border)",
-                borderRadius: 8,
-                padding: 2,
-                background: "transparent",
-                cursor: "pointer",
-              }}
-            />
-          )}
-
-          {drawMode && (
-            <button
-              onClick={clearCanvas}
-              aria-label="Clear drawing"
-              data-testid="clear-drawing"
-              className="btn-pause"
-            >
-              Clear
-            </button>
-          )}
-
-          {drawMode && (
-            <div style={{ display: "flex", gap: 4, alignItems: "center" }} data-testid="thickness-selector">
-              {[2, 4, 8].map((w) => (
-                <button
-                  key={w}
-                  onClick={() => setLineWidth(w)}
-                  aria-label={`Line width ${w}`}
-                  style={{
-                    width: 28,
-                    height: 28,
-                    borderRadius: "50%",
-                    border: lineWidth === w ? "2px solid var(--color-accent)" : "1px solid var(--color-border)",
-                    background: "transparent",
-                    display: "flex",
-                    alignItems: "center",
-                    justifyContent: "center",
-                    cursor: "pointer",
-                    padding: 0,
-                  }}
-                >
-                  <div
-                    style={{
-                      width: w + 2,
-                      height: w + 2,
-                      borderRadius: "50%",
-                      background: "var(--color-text)",
-                    }}
-                  />
-                </button>
-              ))}
-            </div>
-          )}
-
-          {isPaused ? (
-            <button onClick={resumeRecording} aria-label="Resume recording" className="btn-resume">
-              Resume
-            </button>
-          ) : (
-            <button onClick={pauseRecording} aria-label="Pause recording" className="btn-pause">
-              Pause
-            </button>
-          )}
-
-          <button onClick={stopRecording} aria-label="Stop recording" className="btn-stop">
-            Stop Recording
-          </button>
-        </div>
+        <RecordingHeader
+          duration={duration}
+          isPaused={isPaused}
+          remaining={remaining}
+          drawMode={drawMode}
+          drawColor={drawColor}
+          lineWidth={lineWidth}
+          onPause={pauseRecording}
+          onResume={resumeRecording}
+          onStop={stopRecording}
+          onToggleDraw={toggleDrawMode}
+          onClearCanvas={clearCanvas}
+          onSetDrawColor={setDrawColor}
+          onSetLineWidth={setLineWidth}
+        />
       )}
 
       {webcamEnabled && (

--- a/web/src/components/Recorder.tsx
+++ b/web/src/components/Recorder.tsx
@@ -213,6 +213,8 @@ export function Recorder({ onRecordingComplete, onRecordingError, maxDurationSec
       const displayMediaOptions: DisplayMediaStreamOptions & Record<string, unknown> = {
         video: true,
         audio: systemAudioEnabled,
+        selfBrowserSurface: "exclude",
+        preferCurrentTab: false,
       };
       if (systemAudioEnabled) {
         displayMediaOptions.systemAudio = "include";

--- a/web/src/components/Recorder.tsx
+++ b/web/src/components/Recorder.tsx
@@ -5,6 +5,12 @@ import { useRecording, MIN_RECORDING_SECONDS, MIN_RECORDING_BYTES } from "../hoo
 import { getSupportedMimeType, blobTypeFromMimeType } from "../utils/mediaFormat";
 import { formatDuration } from "../utils/format";
 import { RecordingHeader } from "./RecordingHeader";
+import { RecordingFloatingControls } from "./RecordingFloatingControls";
+import { supportsDocumentPictureInPicture } from "../utils/browserCapabilities";
+
+const FLOATING_CONTROLS_BANNER_KEY = "sendrec.floating-banner-shown";
+const FLOATING_CONTROLS_BANNER_MESSAGE =
+  "For controls that float over your recording, use Chrome.";
 
 interface RecorderProps {
   onRecordingComplete: (blob: Blob, duration: number, webcamBlob?: Blob) => void;
@@ -19,6 +25,10 @@ export function Recorder({ onRecordingComplete, onRecordingError, maxDurationSec
   const [previewExpanded, setPreviewExpanded] = useState(false);
   const [systemAudioEnabled, setSystemAudioEnabled] = useState(() => localStorage.getItem("recording-audio") !== "false");
   const [mediaError, setMediaError] = useState<string | null>(null);
+  const [showFloatingControlsBanner, setShowFloatingControlsBanner] = useState(false);
+  const [floatingControlsUnavailable, setFloatingControlsUnavailable] = useState(false);
+  const [floatingControlsWindow, setFloatingControlsWindow] = useState<Window | null>(null);
+  const [supportsDocPiP] = useState(() => supportsDocumentPictureInPicture());
   const countdownEnabled = useRef(localStorage.getItem("recording-countdown") !== "false");
 
   const mediaRecorderRef = useRef<MediaRecorder | null>(null);
@@ -26,6 +36,7 @@ export function Recorder({ onRecordingComplete, onRecordingError, maxDurationSec
   const screenStreamRef = useRef<MediaStream | null>(null);
   const micStreamRef = useRef<MediaStream | null>(null);
   const audioContextRef = useRef<AudioContext | null>(null);
+  const floatingControlsWindowRef = useRef<Window | null>(null);
 
   const webcamStreamRef = useRef<MediaStream | null>(null);
   const webcamRecorderRef = useRef<MediaRecorder | null>(null);
@@ -91,6 +102,31 @@ export function Recorder({ onRecordingComplete, onRecordingError, maxDurationSec
     stopWebcamStream();
   }, [stopMicStream, stopWebcamStream]);
 
+  const clearFloatingControlsWindow = useCallback(() => {
+    floatingControlsWindowRef.current?.close();
+    floatingControlsWindowRef.current = null;
+    setFloatingControlsWindow(null);
+  }, []);
+
+  const openFloatingControlsWindow = useCallback(async () => {
+    if (!supportsDocPiP) return null;
+    const documentPictureInPicture = window.documentPictureInPicture;
+    if (!documentPictureInPicture) return null;
+
+    try {
+      const pipWindow = await documentPictureInPicture.requestWindow({
+        width: 280,
+        height: 220,
+      });
+      floatingControlsWindowRef.current = pipWindow;
+      setFloatingControlsWindow(pipWindow);
+      return pipWindow;
+    } catch {
+      setFloatingControlsUnavailable(true);
+      return null;
+    }
+  }, [supportsDocPiP]);
+
   // Stable refs for callbacks passed to useRecording to avoid stale closure issues
   const stopRecordingRef = useRef<() => void>(() => {});
   const beginRecordingRef = useRef<() => void>(() => {});
@@ -99,6 +135,7 @@ export function Recorder({ onRecordingComplete, onRecordingError, maxDurationSec
     maxDurationSeconds,
     () => beginRecordingRef.current(),
     () => stopRecordingRef.current(),
+    !supportsDocPiP,
   );
 
   const stopRecording = useCallback(() => {
@@ -117,6 +154,7 @@ export function Recorder({ onRecordingComplete, onRecordingError, maxDurationSec
       webcamRecorderRef.current.stop();
     }
     recording.stopTimer();
+    setShowFloatingControlsBanner(false);
     stopCompositing();
     if (screenVideoRef.current) {
       screenVideoRef.current.srcObject = null;
@@ -155,8 +193,15 @@ export function Recorder({ onRecordingComplete, onRecordingError, maxDurationSec
     }
   }, [recording]);
 
-  const beginRecording = useCallback(() => {
+  const handleFloatingControlsUnavailable = useCallback(() => {
+    setFloatingControlsUnavailable(true);
+  }, []);
+
+  const beginRecording = useCallback(async () => {
     clearInterval(recording.countdownTimerRef.current);
+    if (supportsDocPiP && !floatingControlsWindowRef.current && !floatingControlsUnavailable) {
+      await openFloatingControlsWindow();
+    }
     if (mediaRecorderRef.current) {
       // No timeslice — Chrome's MP4 MediaRecorder may produce empty fragments
       // with start(timeslice) on getDisplayMedia() streams. All data is buffered
@@ -169,10 +214,21 @@ export function Recorder({ onRecordingComplete, onRecordingError, maxDurationSec
     recording.startTimeRef.current = Date.now();
     recording.setState("recording");
     recording.startTimer();
-  }, [recording]);
+    if (!supportsDocPiP && localStorage.getItem(FLOATING_CONTROLS_BANNER_KEY) !== "1") {
+      localStorage.setItem(FLOATING_CONTROLS_BANNER_KEY, "1");
+      setShowFloatingControlsBanner(true);
+    }
+  }, [
+    floatingControlsUnavailable,
+    openFloatingControlsWindow,
+    recording,
+    supportsDocPiP,
+  ]);
 
   const abortCountdown = useCallback(() => {
     recording.reset();
+    setShowFloatingControlsBanner(false);
+    clearFloatingControlsWindow();
     stopCompositing();
     if (screenVideoRef.current) {
       screenVideoRef.current.srcObject = null;
@@ -181,7 +237,7 @@ export function Recorder({ onRecordingComplete, onRecordingError, maxDurationSec
     mediaRecorderRef.current = null;
     webcamRecorderRef.current = null;
     webcamBlobPromiseRef.current = null;
-  }, [recording, stopAllStreams, stopCompositing]);
+  }, [clearFloatingControlsWindow, recording, stopAllStreams, stopCompositing]);
 
   // Keep stable callback refs up to date
   stopRecordingRef.current = stopRecording;
@@ -209,6 +265,9 @@ export function Recorder({ onRecordingComplete, onRecordingError, maxDurationSec
 
   async function startRecording() {
     setMediaError(null);
+    setFloatingControlsUnavailable(false);
+    setShowFloatingControlsBanner(false);
+    clearFloatingControlsWindow();
     try {
       const displayMediaOptions: DisplayMediaStreamOptions & Record<string, unknown> = {
         video: true,
@@ -391,11 +450,11 @@ export function Recorder({ onRecordingComplete, onRecordingError, maxDurationSec
         }
       });
 
-      if (countdownEnabled.current) {
+      if (countdownEnabled.current || supportsDocPiP) {
         recording.setCountdown(3);
         recording.setState("countdown");
       } else {
-        beginRecording();
+        void beginRecording();
       }
     } catch (err) {
       console.error("Screen capture failed", err);
@@ -424,6 +483,11 @@ export function Recorder({ onRecordingComplete, onRecordingError, maxDurationSec
 
   const { elapsed: duration, countdown: countdownValue,
     isIdle, isCountdown, isPaused, isActive, isRecording, remaining } = recording;
+  const useFloatingControls =
+    isRecording &&
+    supportsDocPiP &&
+    !floatingControlsUnavailable &&
+    floatingControlsWindow !== null;
 
   return (
     <div className="recorder-container">
@@ -498,8 +562,12 @@ export function Recorder({ onRecordingComplete, onRecordingError, maxDurationSec
             data-testid="countdown-overlay"
             onClick={beginRecording}
           >
-            <div className="countdown-number">{countdownValue}</div>
-            <div className="countdown-hint">Click to start now</div>
+            <div className="countdown-number">
+              {supportsDocPiP ? "Ready" : countdownValue}
+            </div>
+            <div className="countdown-hint">
+              {supportsDocPiP ? "Click to open floating controls" : "Click to start now"}
+            </div>
           </div>
         )}
       </div>
@@ -579,8 +647,14 @@ export function Recorder({ onRecordingComplete, onRecordingError, maxDurationSec
         </>
       )}
 
+      {showFloatingControlsBanner && isActive && !supportsDocPiP && (
+        <div className="recording-tier2-banner" role="status" aria-live="polite">
+          {FLOATING_CONTROLS_BANNER_MESSAGE}
+        </div>
+      )}
+
       {/* Recording controls — always above preview */}
-      {isRecording && (
+      {isRecording && !useFloatingControls && (
         <RecordingHeader
           duration={duration}
           isPaused={isPaused}
@@ -595,6 +669,21 @@ export function Recorder({ onRecordingComplete, onRecordingError, maxDurationSec
           onClearCanvas={clearCanvas}
           onSetDrawColor={setDrawColor}
           onSetLineWidth={setLineWidth}
+        />
+      )}
+
+      {useFloatingControls && (
+        <RecordingFloatingControls
+          pipWindow={floatingControlsWindow}
+          webcamStream={webcamStreamRef.current}
+          webcamEnabled={webcamEnabled}
+          duration={duration}
+          isPaused={isPaused}
+          remaining={remaining}
+          onPause={pauseRecording}
+          onResume={resumeRecording}
+          onStop={stopRecording}
+          onUnavailable={handleFloatingControlsUnavailable}
         />
       )}
 

--- a/web/src/components/Recorder.tsx
+++ b/web/src/components/Recorder.tsx
@@ -7,6 +7,7 @@ import { formatDuration } from "../utils/format";
 import { RecordingHeader } from "./RecordingHeader";
 import { RecordingFloatingControls } from "./RecordingFloatingControls";
 import { supportsDocumentPictureInPicture } from "../utils/browserCapabilities";
+import { useDocumentPictureInPictureWindow } from "../hooks/useDocumentPictureInPictureWindow";
 
 const FLOATING_CONTROLS_BANNER_KEY = "sendrec.floating-banner-shown";
 const FLOATING_CONTROLS_BANNER_MESSAGE =
@@ -27,6 +28,12 @@ export function Recorder({ onRecordingComplete, onRecordingError, maxDurationSec
   const [mediaError, setMediaError] = useState<string | null>(null);
   const [showFloatingControlsBanner, setShowFloatingControlsBanner] = useState(false);
   const [supportsDocPiP] = useState(() => supportsDocumentPictureInPicture());
+  const {
+    pipWindow: floatingControlsWindow,
+    open: openFloatingControlsWindow,
+    close: closeFloatingControlsWindow,
+    waitForOpen: waitForFloatingControlsWindow,
+  } = useDocumentPictureInPictureWindow(supportsDocPiP);
   const countdownEnabled = useRef(localStorage.getItem("recording-countdown") !== "false");
 
   const mediaRecorderRef = useRef<MediaRecorder | null>(null);
@@ -34,7 +41,6 @@ export function Recorder({ onRecordingComplete, onRecordingError, maxDurationSec
   const screenStreamRef = useRef<MediaStream | null>(null);
   const micStreamRef = useRef<MediaStream | null>(null);
   const audioContextRef = useRef<AudioContext | null>(null);
-  const floatingControlsWindowRef = useRef<Window | null>(null);
 
   const webcamStreamRef = useRef<MediaStream | null>(null);
   const webcamRecorderRef = useRef<MediaRecorder | null>(null);
@@ -108,7 +114,6 @@ export function Recorder({ onRecordingComplete, onRecordingError, maxDurationSec
     maxDurationSeconds,
     () => beginRecordingRef.current(),
     () => stopRecordingRef.current(),
-    !supportsDocPiP,
   );
 
   const stopRecording = useCallback(() => {
@@ -166,24 +171,10 @@ export function Recorder({ onRecordingComplete, onRecordingError, maxDurationSec
     }
   }, [recording]);
 
-  const openFloatingControlsWindow = useCallback(async () => {
-    if (!supportsDocPiP) return null;
-    const dpip = window.documentPictureInPicture;
-    if (!dpip) return null;
-    try {
-      const pipWindow = await dpip.requestWindow({ width: 280, height: 220 });
-      floatingControlsWindowRef.current = pipWindow;
-      return pipWindow;
-    } catch {
-      floatingControlsWindowRef.current = null;
-      return null;
-    }
-  }, [supportsDocPiP]);
-
   const beginRecording = useCallback(async () => {
     clearInterval(recording.countdownTimerRef.current);
 
-    await openFloatingControlsWindow();
+    await waitForFloatingControlsWindow();
 
     // Wait for any in-flight webcam permission request before checking the stream.
     // If the user clicks Start (or the countdown elapses) while getUserMedia is
@@ -233,7 +224,7 @@ export function Recorder({ onRecordingComplete, onRecordingError, maxDurationSec
       localStorage.setItem(FLOATING_CONTROLS_BANNER_KEY, "1");
       setShowFloatingControlsBanner(true);
     }
-  }, [openFloatingControlsWindow, recording, supportsDocPiP, webcamEnabled]);
+  }, [recording, supportsDocPiP, waitForFloatingControlsWindow, webcamEnabled]);
 
   const abortCountdown = useCallback(() => {
     recording.reset();
@@ -246,9 +237,8 @@ export function Recorder({ onRecordingComplete, onRecordingError, maxDurationSec
     mediaRecorderRef.current = null;
     webcamRecorderRef.current = null;
     webcamBlobPromiseRef.current = null;
-    floatingControlsWindowRef.current?.close();
-    floatingControlsWindowRef.current = null;
-  }, [recording, stopAllStreams, stopCompositing]);
+    closeFloatingControlsWindow();
+  }, [closeFloatingControlsWindow, recording, stopAllStreams, stopCompositing]);
 
   const pendingWebcamRequestRef = useRef<Promise<MediaStream | null> | null>(null);
 
@@ -298,9 +288,9 @@ export function Recorder({ onRecordingComplete, onRecordingError, maxDurationSec
   async function startRecording() {
     setMediaError(null);
     setShowFloatingControlsBanner(false);
-    floatingControlsWindowRef.current?.close();
-    floatingControlsWindowRef.current = null;
+    closeFloatingControlsWindow();
     try {
+      openFloatingControlsWindow();
       const displayMediaOptions: DisplayMediaStreamOptions & Record<string, unknown> = {
         video: true,
         audio: systemAudioEnabled,
@@ -464,6 +454,7 @@ export function Recorder({ onRecordingComplete, onRecordingError, maxDurationSec
     } catch (err) {
       console.error("Screen capture failed", err);
       setMediaError("Screen recording was blocked or failed. Please allow screen capture and try again.");
+      closeFloatingControlsWindow();
       stopAllStreams();
     }
   }
@@ -476,8 +467,9 @@ export function Recorder({ onRecordingComplete, onRecordingError, maxDurationSec
       stopTimerRef.current();
       stopCompositing();
       stopAllStreams();
+      closeFloatingControlsWindow();
     };
-  }, [stopAllStreams, stopCompositing]);
+  }, [closeFloatingControlsWindow, stopAllStreams, stopCompositing]);
 
   useEffect(() => {
     if (previewExpanded) {
@@ -488,9 +480,7 @@ export function Recorder({ onRecordingComplete, onRecordingError, maxDurationSec
 
   const { elapsed: duration, countdown: countdownValue,
     isIdle, isCountdown, isPaused, isActive, isRecording, remaining } = recording;
-  const useFloatingControls = isRecording && !!floatingControlsWindowRef.current;
-  const countdownLabel = supportsDocPiP ? "Ready" : countdownValue;
-  const countdownHint = supportsDocPiP ? "Click to start recording" : "Click to start now";
+  const useFloatingControls = isRecording && floatingControlsWindow !== null;
 
   return (
     <div className="recorder-container">
@@ -565,8 +555,8 @@ export function Recorder({ onRecordingComplete, onRecordingError, maxDurationSec
             data-testid="countdown-overlay"
             onClick={beginRecording}
           >
-            <div className="countdown-number">{countdownLabel}</div>
-            <div className="countdown-hint">{countdownHint}</div>
+            <div className="countdown-number">{countdownValue}</div>
+            <div className="countdown-hint">Click to start now</div>
           </div>
         )}
       </div>
@@ -673,7 +663,7 @@ export function Recorder({ onRecordingComplete, onRecordingError, maxDurationSec
 
       {useFloatingControls && (
         <RecordingFloatingControls
-          pipWindow={floatingControlsWindowRef.current!}
+          pipWindow={floatingControlsWindow}
           webcamStream={webcamStreamRef.current}
           webcamEnabled={webcamEnabled}
           duration={duration}

--- a/web/src/components/Recorder.tsx
+++ b/web/src/components/Recorder.tsx
@@ -26,7 +26,6 @@ export function Recorder({ onRecordingComplete, onRecordingError, maxDurationSec
   const [systemAudioEnabled, setSystemAudioEnabled] = useState(() => localStorage.getItem("recording-audio") !== "false");
   const [mediaError, setMediaError] = useState<string | null>(null);
   const [showFloatingControlsBanner, setShowFloatingControlsBanner] = useState(false);
-  const [floatingControlsUnavailable, setFloatingControlsUnavailable] = useState(false);
   const [supportsDocPiP] = useState(() => supportsDocumentPictureInPicture());
   const countdownEnabled = useRef(localStorage.getItem("recording-countdown") !== "false");
 
@@ -35,6 +34,7 @@ export function Recorder({ onRecordingComplete, onRecordingError, maxDurationSec
   const screenStreamRef = useRef<MediaStream | null>(null);
   const micStreamRef = useRef<MediaStream | null>(null);
   const audioContextRef = useRef<AudioContext | null>(null);
+  const floatingControlsWindowRef = useRef<Window | null>(null);
 
   const webcamStreamRef = useRef<MediaStream | null>(null);
   const webcamRecorderRef = useRef<MediaRecorder | null>(null);
@@ -165,12 +165,41 @@ export function Recorder({ onRecordingComplete, onRecordingError, maxDurationSec
     }
   }, [recording]);
 
-  const handleFloatingControlsUnavailable = useCallback(() => {
-    setFloatingControlsUnavailable(true);
-  }, []);
-
-  const beginRecording = useCallback(() => {
+  const beginRecording = useCallback(async () => {
     clearInterval(recording.countdownTimerRef.current);
+
+    // Wait for any in-flight webcam permission request before checking the stream.
+    // If the user clicks Start (or the countdown elapses) while getUserMedia is
+    // still pending from mount, we must not skip webcam recorder setup.
+    if (pendingWebcamRequestRef.current) {
+      await pendingWebcamRequestRef.current;
+    }
+
+    // Set up webcam recorder now that the stream ref is guaranteed to be settled.
+    webcamBlobPromiseRef.current = null;
+    if (webcamEnabled && webcamStreamRef.current) {
+      const webcamMimeType = MediaRecorder.isTypeSupported("video/webm;codecs=vp9")
+        ? "video/webm;codecs=vp9"
+        : "video/webm";
+      const webcamRecorder = new MediaRecorder(webcamStreamRef.current, {
+        mimeType: webcamMimeType,
+      });
+      webcamRecorderRef.current = webcamRecorder;
+      webcamChunksRef.current = [];
+
+      webcamRecorder.ondataavailable = (event) => {
+        if (event.data.size > 0) {
+          webcamChunksRef.current.push(event.data);
+        }
+      };
+
+      webcamBlobPromiseRef.current = new Promise<Blob>((resolve) => {
+        webcamRecorder.onstop = () => {
+          resolve(new Blob(webcamChunksRef.current, { type: "video/webm" }));
+        };
+      });
+    }
+
     if (mediaRecorderRef.current) {
       // No timeslice — Chrome's MP4 MediaRecorder may produce empty fragments
       // with start(timeslice) on getDisplayMedia() streams. All data is buffered
@@ -187,7 +216,7 @@ export function Recorder({ onRecordingComplete, onRecordingError, maxDurationSec
       localStorage.setItem(FLOATING_CONTROLS_BANNER_KEY, "1");
       setShowFloatingControlsBanner(true);
     }
-  }, [recording, supportsDocPiP]);
+  }, [recording, supportsDocPiP, webcamEnabled]);
 
   const abortCountdown = useCallback(() => {
     recording.reset();
@@ -200,7 +229,11 @@ export function Recorder({ onRecordingComplete, onRecordingError, maxDurationSec
     mediaRecorderRef.current = null;
     webcamRecorderRef.current = null;
     webcamBlobPromiseRef.current = null;
+    floatingControlsWindowRef.current?.close();
+    floatingControlsWindowRef.current = null;
   }, [recording, stopAllStreams, stopCompositing]);
+
+  const pendingWebcamRequestRef = useRef<Promise<MediaStream | null> | null>(null);
 
   const requestWebcamStream = useCallback(async () => {
     try {
@@ -216,6 +249,8 @@ export function Recorder({ onRecordingComplete, onRecordingError, maxDurationSec
       setWebcamEnabled(false);
       setMediaError("Could not access your camera. Please allow camera access and try again.");
       return null;
+    } finally {
+      pendingWebcamRequestRef.current = null;
     }
   }, []);
 
@@ -225,7 +260,7 @@ export function Recorder({ onRecordingComplete, onRecordingError, maxDurationSec
   requestWebcamStreamRef.current = requestWebcamStream;
   useEffect(() => {
     if (localStorage.getItem("recording-mode") === "screen-camera") {
-      void requestWebcamStreamRef.current();
+      pendingWebcamRequestRef.current = requestWebcamStreamRef.current();
     }
   }, []);
 
@@ -245,9 +280,22 @@ export function Recorder({ onRecordingComplete, onRecordingError, maxDurationSec
 
   async function startRecording() {
     setMediaError(null);
-    setFloatingControlsUnavailable(false);
     setShowFloatingControlsBanner(false);
     try {
+      // Open the Document PiP window synchronously inside the click handler, before
+      // getDisplayMedia consumes the transient user activation. Activation propagates
+      // through the async chain so requestWindow works here when called first.
+      if (supportsDocPiP) {
+        const dpip = window.documentPictureInPicture;
+        if (dpip) {
+          try {
+            floatingControlsWindowRef.current = await dpip.requestWindow({ width: 280, height: 220 });
+          } catch {
+            floatingControlsWindowRef.current = null;
+          }
+        }
+      }
+
       const displayMediaOptions: DisplayMediaStreamOptions & Record<string, unknown> = {
         video: true,
         audio: systemAudioEnabled,
@@ -332,33 +380,6 @@ export function Recorder({ onRecordingComplete, onRecordingError, maxDurationSec
       chunksRef.current = [];
       recording.pauseStartRef.current = 0;
       recording.totalPausedRef.current = 0;
-
-      // Set up webcam recorder if webcam is enabled (but don't start yet).
-      // Always use WebM for webcam — it's only used temporarily for server-side compositing,
-      // and WebM is more reliable for video-only MediaRecorder streams across browsers.
-      webcamBlobPromiseRef.current = null;
-      if (webcamEnabled && webcamStreamRef.current) {
-        const webcamMimeType = MediaRecorder.isTypeSupported("video/webm;codecs=vp9")
-          ? "video/webm;codecs=vp9"
-          : "video/webm";
-        const webcamRecorder = new MediaRecorder(webcamStreamRef.current, {
-          mimeType: webcamMimeType,
-        });
-        webcamRecorderRef.current = webcamRecorder;
-        webcamChunksRef.current = [];
-
-        webcamRecorder.ondataavailable = (event) => {
-          if (event.data.size > 0) {
-            webcamChunksRef.current.push(event.data);
-          }
-        };
-
-        webcamBlobPromiseRef.current = new Promise<Blob>((resolve) => {
-          webcamRecorder.onstop = () => {
-            resolve(new Blob(webcamChunksRef.current, { type: "video/webm" }));
-          };
-        });
-      }
 
       const handleDataAvailable = (event: BlobEvent) => {
         if (event.data.size > 0) {
@@ -462,7 +483,7 @@ export function Recorder({ onRecordingComplete, onRecordingError, maxDurationSec
 
   const { elapsed: duration, countdown: countdownValue,
     isIdle, isCountdown, isPaused, isActive, isRecording, remaining } = recording;
-  const useFloatingControls = isRecording && supportsDocPiP && !floatingControlsUnavailable;
+  const useFloatingControls = isRecording && !!floatingControlsWindowRef.current;
 
   return (
     <div className="recorder-container">
@@ -645,6 +666,7 @@ export function Recorder({ onRecordingComplete, onRecordingError, maxDurationSec
 
       {useFloatingControls && (
         <RecordingFloatingControls
+          pipWindow={floatingControlsWindowRef.current!}
           webcamStream={webcamStreamRef.current}
           webcamEnabled={webcamEnabled}
           duration={duration}
@@ -653,7 +675,6 @@ export function Recorder({ onRecordingComplete, onRecordingError, maxDurationSec
           onPause={pauseRecording}
           onResume={resumeRecording}
           onStop={stopRecording}
-          onUnavailable={handleFloatingControlsUnavailable}
         />
       )}
 

--- a/web/src/components/Recorder.tsx
+++ b/web/src/components/Recorder.tsx
@@ -108,6 +108,7 @@ export function Recorder({ onRecordingComplete, onRecordingError, maxDurationSec
     maxDurationSeconds,
     () => beginRecordingRef.current(),
     () => stopRecordingRef.current(),
+    !supportsDocPiP,
   );
 
   const stopRecording = useCallback(() => {
@@ -165,8 +166,24 @@ export function Recorder({ onRecordingComplete, onRecordingError, maxDurationSec
     }
   }, [recording]);
 
+  const openFloatingControlsWindow = useCallback(async () => {
+    if (!supportsDocPiP) return null;
+    const dpip = window.documentPictureInPicture;
+    if (!dpip) return null;
+    try {
+      const pipWindow = await dpip.requestWindow({ width: 280, height: 220 });
+      floatingControlsWindowRef.current = pipWindow;
+      return pipWindow;
+    } catch {
+      floatingControlsWindowRef.current = null;
+      return null;
+    }
+  }, [supportsDocPiP]);
+
   const beginRecording = useCallback(async () => {
     clearInterval(recording.countdownTimerRef.current);
+
+    await openFloatingControlsWindow();
 
     // Wait for any in-flight webcam permission request before checking the stream.
     // If the user clicks Start (or the countdown elapses) while getUserMedia is
@@ -216,7 +233,7 @@ export function Recorder({ onRecordingComplete, onRecordingError, maxDurationSec
       localStorage.setItem(FLOATING_CONTROLS_BANNER_KEY, "1");
       setShowFloatingControlsBanner(true);
     }
-  }, [recording, supportsDocPiP, webcamEnabled]);
+  }, [openFloatingControlsWindow, recording, supportsDocPiP, webcamEnabled]);
 
   const abortCountdown = useCallback(() => {
     recording.reset();
@@ -281,21 +298,9 @@ export function Recorder({ onRecordingComplete, onRecordingError, maxDurationSec
   async function startRecording() {
     setMediaError(null);
     setShowFloatingControlsBanner(false);
+    floatingControlsWindowRef.current?.close();
+    floatingControlsWindowRef.current = null;
     try {
-      // Open the Document PiP window synchronously inside the click handler, before
-      // getDisplayMedia consumes the transient user activation. Activation propagates
-      // through the async chain so requestWindow works here when called first.
-      if (supportsDocPiP) {
-        const dpip = window.documentPictureInPicture;
-        if (dpip) {
-          try {
-            floatingControlsWindowRef.current = await dpip.requestWindow({ width: 280, height: 220 });
-          } catch {
-            floatingControlsWindowRef.current = null;
-          }
-        }
-      }
-
       const displayMediaOptions: DisplayMediaStreamOptions & Record<string, unknown> = {
         video: true,
         audio: systemAudioEnabled,
@@ -450,7 +455,7 @@ export function Recorder({ onRecordingComplete, onRecordingError, maxDurationSec
         }
       });
 
-      if (countdownEnabled.current) {
+      if (countdownEnabled.current || supportsDocPiP) {
         recording.setCountdown(3);
         recording.setState("countdown");
       } else {
@@ -484,6 +489,8 @@ export function Recorder({ onRecordingComplete, onRecordingError, maxDurationSec
   const { elapsed: duration, countdown: countdownValue,
     isIdle, isCountdown, isPaused, isActive, isRecording, remaining } = recording;
   const useFloatingControls = isRecording && !!floatingControlsWindowRef.current;
+  const countdownLabel = supportsDocPiP ? "Ready" : countdownValue;
+  const countdownHint = supportsDocPiP ? "Click to start recording" : "Click to start now";
 
   return (
     <div className="recorder-container">
@@ -558,8 +565,8 @@ export function Recorder({ onRecordingComplete, onRecordingError, maxDurationSec
             data-testid="countdown-overlay"
             onClick={beginRecording}
           >
-            <div className="countdown-number">{countdownValue}</div>
-            <div className="countdown-hint">Click to start now</div>
+            <div className="countdown-number">{countdownLabel}</div>
+            <div className="countdown-hint">{countdownHint}</div>
           </div>
         )}
       </div>

--- a/web/src/components/Recorder.tsx
+++ b/web/src/components/Recorder.tsx
@@ -239,6 +239,23 @@ export function Recorder({ onRecordingComplete, onRecordingError, maxDurationSec
     webcamBlobPromiseRef.current = null;
   }, [clearFloatingControlsWindow, recording, stopAllStreams, stopCompositing]);
 
+  const requestWebcamStream = useCallback(async () => {
+    try {
+      const stream = await navigator.mediaDevices.getUserMedia({
+        video: { width: 320, height: 240, facingMode: "user" },
+        audio: false,
+      });
+      webcamStreamRef.current = stream;
+      setWebcamEnabled(true);
+      return stream;
+    } catch (err) {
+      console.error("Webcam access failed", err);
+      setWebcamEnabled(false);
+      setMediaError("Could not access your camera. Please allow camera access and try again.");
+      return null;
+    }
+  }, []);
+
   // Keep stable callback refs up to date
   stopRecordingRef.current = stopRecording;
   beginRecordingRef.current = beginRecording;
@@ -250,17 +267,7 @@ export function Recorder({ onRecordingComplete, onRecordingError, maxDurationSec
       setWebcamEnabled(false);
       return;
     }
-    try {
-      const stream = await navigator.mediaDevices.getUserMedia({
-        video: { width: 320, height: 240, facingMode: "user" },
-        audio: false,
-      });
-      webcamStreamRef.current = stream;
-      setWebcamEnabled(true);
-    } catch (err) {
-      console.error("Webcam access failed", err);
-      setMediaError("Could not access your camera. Please allow camera access and try again.");
-    }
+    await requestWebcamStream();
   }
 
   async function startRecording() {
@@ -269,6 +276,11 @@ export function Recorder({ onRecordingComplete, onRecordingError, maxDurationSec
     setShowFloatingControlsBanner(false);
     clearFloatingControlsWindow();
     try {
+      if (webcamEnabled && !webcamStreamRef.current) {
+        const stream = await requestWebcamStream();
+        if (!stream) return;
+      }
+
       const displayMediaOptions: DisplayMediaStreamOptions & Record<string, unknown> = {
         video: true,
         audio: systemAudioEnabled,

--- a/web/src/components/RecordingFloatingControls.test.tsx
+++ b/web/src/components/RecordingFloatingControls.test.tsx
@@ -101,4 +101,29 @@ describe("RecordingFloatingControls", () => {
 
     expect(close).toHaveBeenCalledTimes(1);
   });
+
+  it("clones linked and inline styles into the PiP window", async () => {
+    const link = document.createElement("link");
+    link.rel = "stylesheet";
+    link.href = "/assets/app.css";
+    document.head.appendChild(link);
+    const style = document.createElement("style");
+    style.textContent = ".recording-floating-panel { color: red; }";
+    document.head.appendChild(style);
+    const { pipWindow } = createPictureInPictureWindow();
+
+    render(<RecordingFloatingControls {...baseProps} pipWindow={pipWindow} />);
+
+    await waitFor(() => {
+      expect(pipWindow.document.body.querySelector("#root")).not.toBeNull();
+    });
+
+    expect(pipWindow.document.head.querySelector('link[rel="stylesheet"]')).not.toBeNull();
+    expect(pipWindow.document.head.querySelector("style")?.textContent).toContain(
+      ".recording-floating-panel",
+    );
+
+    link.remove();
+    style.remove();
+  });
 });

--- a/web/src/components/RecordingFloatingControls.test.tsx
+++ b/web/src/components/RecordingFloatingControls.test.tsx
@@ -89,17 +89,21 @@ describe("RecordingFloatingControls", () => {
     expect(onStop).toHaveBeenCalledTimes(1);
   });
 
-  it("closes the PiP window on unmount", async () => {
-    const { pipWindow, close } = createPictureInPictureWindow();
+  it("removes the pagehide listener on unmount", async () => {
+    const { pipWindow } = createPictureInPictureWindow();
+    const onStop = vi.fn();
 
-    const { unmount } = render(<RecordingFloatingControls {...baseProps} pipWindow={pipWindow} />);
+    const { unmount } = render(
+      <RecordingFloatingControls {...baseProps} pipWindow={pipWindow} onStop={onStop} />,
+    );
 
     await waitFor(() => {
       expect(pipWindow.document.body.querySelector("#root")).not.toBeNull();
     });
     unmount();
+    pipWindow.dispatchEvent(new Event("pagehide"));
 
-    expect(close).toHaveBeenCalledTimes(1);
+    expect(onStop).not.toHaveBeenCalled();
   });
 
   it("clones linked and inline styles into the PiP window", async () => {

--- a/web/src/components/RecordingFloatingControls.test.tsx
+++ b/web/src/components/RecordingFloatingControls.test.tsx
@@ -20,13 +20,7 @@ function createPictureInPictureWindow() {
     dispatchEvent: eventTarget.dispatchEvent.bind(eventTarget),
   } as unknown as Window;
 
-  const requestWindow = vi.fn().mockResolvedValue(pipWindow);
-  Object.defineProperty(window, "documentPictureInPicture", {
-    value: { requestWindow },
-    configurable: true,
-  });
-
-  return { pipWindow, requestWindow, close };
+  return { pipWindow, close };
 }
 
 const baseProps = {
@@ -42,18 +36,16 @@ const baseProps = {
 
 describe("RecordingFloatingControls", () => {
   afterEach(() => {
-    delete (window as unknown as { documentPictureInPicture?: unknown })
-      .documentPictureInPicture;
     vi.clearAllMocks();
   });
 
   it("renders timer, camera preview, Pause, and Stop inside the PiP window", async () => {
-    const { pipWindow, requestWindow } = createPictureInPictureWindow();
+    const { pipWindow } = createPictureInPictureWindow();
 
-    render(<RecordingFloatingControls {...baseProps} />);
+    render(<RecordingFloatingControls {...baseProps} pipWindow={pipWindow} />);
 
     await waitFor(() => {
-      expect(requestWindow).toHaveBeenCalledWith({ width: 280, height: 220 });
+      expect(pipWindow.document.body.querySelector("#root")).not.toBeNull();
     });
     const pipBody = within(pipWindow.document.body);
     expect(pipBody.getByText("1:15")).toBeTruthy();
@@ -70,7 +62,7 @@ describe("RecordingFloatingControls", () => {
     const { pipWindow } = createPictureInPictureWindow();
     const onStop = vi.fn();
 
-    render(<RecordingFloatingControls {...baseProps} onStop={onStop} />);
+    render(<RecordingFloatingControls {...baseProps} pipWindow={pipWindow} onStop={onStop} />);
 
     await waitFor(() => {
       expect(pipWindow.document.body.querySelector("button")).not.toBeNull();
@@ -87,7 +79,7 @@ describe("RecordingFloatingControls", () => {
     const { pipWindow } = createPictureInPictureWindow();
     const onStop = vi.fn();
 
-    render(<RecordingFloatingControls {...baseProps} onStop={onStop} />);
+    render(<RecordingFloatingControls {...baseProps} pipWindow={pipWindow} onStop={onStop} />);
 
     await waitFor(() => {
       expect(pipWindow.document.body.querySelector("#root")).not.toBeNull();
@@ -100,7 +92,7 @@ describe("RecordingFloatingControls", () => {
   it("closes the PiP window on unmount", async () => {
     const { pipWindow, close } = createPictureInPictureWindow();
 
-    const { unmount } = render(<RecordingFloatingControls {...baseProps} />);
+    const { unmount } = render(<RecordingFloatingControls {...baseProps} pipWindow={pipWindow} />);
 
     await waitFor(() => {
       expect(pipWindow.document.body.querySelector("#root")).not.toBeNull();

--- a/web/src/components/RecordingFloatingControls.test.tsx
+++ b/web/src/components/RecordingFloatingControls.test.tsx
@@ -1,0 +1,112 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { render, waitFor, within } from "@testing-library/react";
+import { RecordingFloatingControls } from "./RecordingFloatingControls";
+
+class MockMediaStream {
+  getTracks = vi.fn().mockReturnValue([]);
+}
+
+globalThis.MediaStream = MockMediaStream as unknown as typeof MediaStream;
+
+function createPictureInPictureWindow() {
+  const pipDocument = document.implementation.createHTMLDocument("pip");
+  const eventTarget = new EventTarget();
+  const close = vi.fn();
+  const pipWindow = {
+    document: pipDocument,
+    close,
+    addEventListener: eventTarget.addEventListener.bind(eventTarget),
+    removeEventListener: eventTarget.removeEventListener.bind(eventTarget),
+    dispatchEvent: eventTarget.dispatchEvent.bind(eventTarget),
+  } as unknown as Window;
+
+  const requestWindow = vi.fn().mockResolvedValue(pipWindow);
+  Object.defineProperty(window, "documentPictureInPicture", {
+    value: { requestWindow },
+    configurable: true,
+  });
+
+  return { pipWindow, requestWindow, close };
+}
+
+const baseProps = {
+  webcamStream: new MediaStream(),
+  webcamEnabled: true,
+  duration: 75,
+  isPaused: false,
+  remaining: null as number | null,
+  onPause: vi.fn(),
+  onResume: vi.fn(),
+  onStop: vi.fn(),
+};
+
+describe("RecordingFloatingControls", () => {
+  afterEach(() => {
+    delete (window as unknown as { documentPictureInPicture?: unknown })
+      .documentPictureInPicture;
+    vi.clearAllMocks();
+  });
+
+  it("renders timer, camera preview, Pause, and Stop inside the PiP window", async () => {
+    const { pipWindow, requestWindow } = createPictureInPictureWindow();
+
+    render(<RecordingFloatingControls {...baseProps} />);
+
+    await waitFor(() => {
+      expect(requestWindow).toHaveBeenCalledWith({ width: 280, height: 220 });
+    });
+    const pipBody = within(pipWindow.document.body);
+    expect(pipBody.getByText("1:15")).toBeTruthy();
+    expect(
+      pipWindow.document.body.querySelector('[aria-label="Pause recording"]'),
+    ).not.toBeNull();
+    expect(
+      pipWindow.document.body.querySelector('[aria-label="Stop recording"]'),
+    ).not.toBeNull();
+    expect(pipWindow.document.body.querySelector("video")).not.toBeNull();
+  });
+
+  it("invokes onStop when Stop is clicked in the PiP window", async () => {
+    const { pipWindow } = createPictureInPictureWindow();
+    const onStop = vi.fn();
+
+    render(<RecordingFloatingControls {...baseProps} onStop={onStop} />);
+
+    await waitFor(() => {
+      expect(pipWindow.document.body.querySelector("button")).not.toBeNull();
+    });
+    const stopButton = pipWindow.document.body.querySelector(
+      '[aria-label="Stop recording"]',
+    ) as HTMLButtonElement;
+    stopButton.click();
+
+    expect(onStop).toHaveBeenCalledTimes(1);
+  });
+
+  it("invokes onStop when the PiP window fires pagehide", async () => {
+    const { pipWindow } = createPictureInPictureWindow();
+    const onStop = vi.fn();
+
+    render(<RecordingFloatingControls {...baseProps} onStop={onStop} />);
+
+    await waitFor(() => {
+      expect(pipWindow.document.body.querySelector("#root")).not.toBeNull();
+    });
+    pipWindow.dispatchEvent(new Event("pagehide"));
+
+    expect(onStop).toHaveBeenCalledTimes(1);
+  });
+
+  it("closes the PiP window on unmount", async () => {
+    const { pipWindow, close } = createPictureInPictureWindow();
+
+    const { unmount } = render(<RecordingFloatingControls {...baseProps} />);
+
+    await waitFor(() => {
+      expect(pipWindow.document.body.querySelector("#root")).not.toBeNull();
+    });
+    unmount();
+
+    expect(close).toHaveBeenCalledTimes(1);
+  });
+});

--- a/web/src/components/RecordingFloatingControls.tsx
+++ b/web/src/components/RecordingFloatingControls.tsx
@@ -3,7 +3,6 @@ import { createPortal } from "react-dom";
 import { formatDuration } from "../utils/format";
 
 interface RecordingFloatingControlsProps {
-  pipWindow?: Window | null;
   webcamStream: MediaStream | null;
   webcamEnabled: boolean;
   duration: number;
@@ -27,7 +26,6 @@ interface FloatingPanelProps {
 }
 
 export function RecordingFloatingControls({
-  pipWindow,
   webcamStream,
   webcamEnabled,
   duration,
@@ -51,7 +49,7 @@ export function RecordingFloatingControls({
     let handlePageHide: (() => void) | null = null;
 
     async function openPictureInPictureWindow() {
-      activePipWindow = pipWindow ?? await requestPictureInPictureWindow();
+      activePipWindow = await requestPictureInPictureWindow();
       if (!activePipWindow) {
         onUnavailable?.();
         return;
@@ -66,7 +64,7 @@ export function RecordingFloatingControls({
 
       const root = activePipWindow.document.createElement("div");
       root.id = "root";
-      activePipWindow.document.body.replaceChildren(root);
+      activePipWindow.document.body.appendChild(root);
 
       handlePageHide = () => onStopRef.current();
       activePipWindow.addEventListener("pagehide", handlePageHide);
@@ -82,7 +80,7 @@ export function RecordingFloatingControls({
       }
       activePipWindow?.close();
     };
-  }, [onUnavailable, pipWindow]);
+  }, [onUnavailable]);
 
   if (!portalRoot) return null;
 

--- a/web/src/components/RecordingFloatingControls.tsx
+++ b/web/src/components/RecordingFloatingControls.tsx
@@ -56,7 +56,6 @@ export function RecordingFloatingControls({
 
     return () => {
       pipWindow.removeEventListener("pagehide", handlePageHide);
-      pipWindow.close();
     };
   }, [pipWindow]);
 

--- a/web/src/components/RecordingFloatingControls.tsx
+++ b/web/src/components/RecordingFloatingControls.tsx
@@ -3,6 +3,7 @@ import { createPortal } from "react-dom";
 import { formatDuration } from "../utils/format";
 
 interface RecordingFloatingControlsProps {
+  pipWindow: Window;
   webcamStream: MediaStream | null;
   webcamEnabled: boolean;
   duration: number;
@@ -11,7 +12,6 @@ interface RecordingFloatingControlsProps {
   onPause: () => void;
   onResume: () => void;
   onStop: () => void;
-  onUnavailable?: () => void;
 }
 
 interface FloatingPanelProps {
@@ -26,6 +26,7 @@ interface FloatingPanelProps {
 }
 
 export function RecordingFloatingControls({
+  pipWindow,
   webcamStream,
   webcamEnabled,
   duration,
@@ -34,7 +35,6 @@ export function RecordingFloatingControls({
   onPause,
   onResume,
   onStop,
-  onUnavailable,
 }: RecordingFloatingControlsProps) {
   const [portalRoot, setPortalRoot] = useState<HTMLElement | null>(null);
   const onStopRef = useRef(onStop);
@@ -44,43 +44,21 @@ export function RecordingFloatingControls({
   }, [onStop]);
 
   useEffect(() => {
-    let cancelled = false;
-    let activePipWindow: Window | null = null;
-    let handlePageHide: (() => void) | null = null;
+    cloneStylesheetsInto(pipWindow.document);
 
-    async function openPictureInPictureWindow() {
-      activePipWindow = await requestPictureInPictureWindow();
-      if (!activePipWindow) {
-        onUnavailable?.();
-        return;
-      }
+    const root = pipWindow.document.createElement("div");
+    root.id = "root";
+    pipWindow.document.body.appendChild(root);
 
-      if (cancelled) {
-        activePipWindow.close();
-        return;
-      }
-
-      cloneStylesheetsInto(activePipWindow.document);
-
-      const root = activePipWindow.document.createElement("div");
-      root.id = "root";
-      activePipWindow.document.body.appendChild(root);
-
-      handlePageHide = () => onStopRef.current();
-      activePipWindow.addEventListener("pagehide", handlePageHide);
-      setPortalRoot(root);
-    }
-
-    void openPictureInPictureWindow();
+    const handlePageHide = () => onStopRef.current();
+    pipWindow.addEventListener("pagehide", handlePageHide);
+    setPortalRoot(root);
 
     return () => {
-      cancelled = true;
-      if (activePipWindow && handlePageHide) {
-        activePipWindow.removeEventListener("pagehide", handlePageHide);
-      }
-      activePipWindow?.close();
+      pipWindow.removeEventListener("pagehide", handlePageHide);
+      pipWindow.close();
     };
-  }, [onUnavailable]);
+  }, [pipWindow]);
 
   if (!portalRoot) return null;
 
@@ -97,20 +75,6 @@ export function RecordingFloatingControls({
     />,
     portalRoot,
   );
-}
-
-async function requestPictureInPictureWindow(): Promise<Window | null> {
-  const documentPictureInPicture = window.documentPictureInPicture;
-  if (!documentPictureInPicture) return null;
-
-  try {
-    return await documentPictureInPicture.requestWindow({
-      width: 280,
-      height: 220,
-    });
-  } catch {
-    return null;
-  }
 }
 
 function cloneStylesheetsInto(pipDocument: Document) {

--- a/web/src/components/RecordingFloatingControls.tsx
+++ b/web/src/components/RecordingFloatingControls.tsx
@@ -1,0 +1,201 @@
+import { useEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+import { formatDuration } from "../utils/format";
+
+interface RecordingFloatingControlsProps {
+  pipWindow?: Window | null;
+  webcamStream: MediaStream | null;
+  webcamEnabled: boolean;
+  duration: number;
+  isPaused: boolean;
+  remaining: number | null;
+  onPause: () => void;
+  onResume: () => void;
+  onStop: () => void;
+  onUnavailable?: () => void;
+}
+
+interface FloatingPanelProps {
+  webcamStream: MediaStream | null;
+  webcamEnabled: boolean;
+  duration: number;
+  isPaused: boolean;
+  remaining: number | null;
+  onPause: () => void;
+  onResume: () => void;
+  onStop: () => void;
+}
+
+export function RecordingFloatingControls({
+  pipWindow,
+  webcamStream,
+  webcamEnabled,
+  duration,
+  isPaused,
+  remaining,
+  onPause,
+  onResume,
+  onStop,
+  onUnavailable,
+}: RecordingFloatingControlsProps) {
+  const [portalRoot, setPortalRoot] = useState<HTMLElement | null>(null);
+  const onStopRef = useRef(onStop);
+
+  useEffect(() => {
+    onStopRef.current = onStop;
+  }, [onStop]);
+
+  useEffect(() => {
+    let cancelled = false;
+    let activePipWindow: Window | null = null;
+    let handlePageHide: (() => void) | null = null;
+
+    async function openPictureInPictureWindow() {
+      activePipWindow = pipWindow ?? await requestPictureInPictureWindow();
+      if (!activePipWindow) {
+        onUnavailable?.();
+        return;
+      }
+
+      if (cancelled) {
+        activePipWindow.close();
+        return;
+      }
+
+      cloneStylesheetsInto(activePipWindow.document);
+
+      const root = activePipWindow.document.createElement("div");
+      root.id = "root";
+      activePipWindow.document.body.replaceChildren(root);
+
+      handlePageHide = () => onStopRef.current();
+      activePipWindow.addEventListener("pagehide", handlePageHide);
+      setPortalRoot(root);
+    }
+
+    void openPictureInPictureWindow();
+
+    return () => {
+      cancelled = true;
+      if (activePipWindow && handlePageHide) {
+        activePipWindow.removeEventListener("pagehide", handlePageHide);
+      }
+      activePipWindow?.close();
+    };
+  }, [onUnavailable, pipWindow]);
+
+  if (!portalRoot) return null;
+
+  return createPortal(
+    <FloatingPanel
+      webcamStream={webcamStream}
+      webcamEnabled={webcamEnabled}
+      duration={duration}
+      isPaused={isPaused}
+      remaining={remaining}
+      onPause={onPause}
+      onResume={onResume}
+      onStop={onStop}
+    />,
+    portalRoot,
+  );
+}
+
+async function requestPictureInPictureWindow(): Promise<Window | null> {
+  const documentPictureInPicture = window.documentPictureInPicture;
+  if (!documentPictureInPicture) return null;
+
+  try {
+    return await documentPictureInPicture.requestWindow({
+      width: 280,
+      height: 220,
+    });
+  } catch {
+    return null;
+  }
+}
+
+function cloneStylesheetsInto(pipDocument: Document) {
+  document
+    .querySelectorAll<HTMLLinkElement>('link[rel="stylesheet"]')
+    .forEach((link) => {
+      pipDocument.head.appendChild(link.cloneNode(true));
+    });
+}
+
+function FloatingPanel({
+  webcamStream,
+  webcamEnabled,
+  duration,
+  isPaused,
+  remaining,
+  onPause,
+  onResume,
+  onStop,
+}: FloatingPanelProps) {
+  const videoRef = useRef<HTMLVideoElement | null>(null);
+
+  useEffect(() => {
+    if (!videoRef.current) return;
+    videoRef.current.srcObject = webcamEnabled ? webcamStream : null;
+  }, [webcamEnabled, webcamStream]);
+
+  return (
+    <div className="recording-floating-panel" role="status" aria-live="polite">
+      {webcamEnabled && (
+        <video
+          ref={videoRef}
+          autoPlay
+          muted
+          playsInline
+          className="recording-floating-panel__video"
+        />
+      )}
+
+      <div className="recording-floating-panel__timer">
+        <span
+          className={`recording-dot ${
+            isPaused ? "recording-dot--paused" : "recording-dot--active"
+          }`}
+        />
+        <span>{formatDuration(duration)}</span>
+        {isPaused && <span className="recording-remaining">(Paused)</span>}
+        {!isPaused && remaining !== null && (
+          <span className="recording-remaining">
+            ({formatDuration(remaining)} remaining)
+          </span>
+        )}
+      </div>
+
+      <div className="recording-floating-panel__actions">
+        {isPaused ? (
+          <button
+            type="button"
+            onClick={onResume}
+            aria-label="Resume recording"
+            className="btn-resume"
+          >
+            Resume
+          </button>
+        ) : (
+          <button
+            type="button"
+            onClick={onPause}
+            aria-label="Pause recording"
+            className="btn-pause"
+          >
+            Pause
+          </button>
+        )}
+        <button
+          type="button"
+          onClick={onStop}
+          aria-label="Stop recording"
+          className="btn-stop"
+        >
+          Stop
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/RecordingFloatingControls.tsx
+++ b/web/src/components/RecordingFloatingControls.tsx
@@ -79,9 +79,11 @@ export function RecordingFloatingControls({
 
 function cloneStylesheetsInto(pipDocument: Document) {
   document
-    .querySelectorAll<HTMLLinkElement>('link[rel="stylesheet"]')
-    .forEach((link) => {
-      pipDocument.head.appendChild(link.cloneNode(true));
+    .querySelectorAll<HTMLLinkElement | HTMLStyleElement>(
+      'link[rel="stylesheet"], style',
+    )
+    .forEach((styleNode) => {
+      pipDocument.head.appendChild(styleNode.cloneNode(true));
     });
 }
 

--- a/web/src/components/RecordingHeader.test.tsx
+++ b/web/src/components/RecordingHeader.test.tsx
@@ -1,0 +1,54 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { RecordingHeader } from "./RecordingHeader";
+
+const baseProps = {
+  duration: 12,
+  isPaused: false,
+  remaining: null as number | null,
+  drawMode: false,
+  drawColor: "#ff0000",
+  lineWidth: 4,
+  onPause: vi.fn(),
+  onResume: vi.fn(),
+  onStop: vi.fn(),
+  onToggleDraw: vi.fn(),
+  onClearCanvas: vi.fn(),
+  onSetDrawColor: vi.fn(),
+  onSetLineWidth: vi.fn(),
+};
+
+describe("RecordingHeader", () => {
+  it("renders timer and Pause + Stop while active", () => {
+    render(<RecordingHeader {...baseProps} />);
+    expect(screen.getByText("0:12")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Pause recording" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Stop recording" })).toBeInTheDocument();
+  });
+
+  it("renders Resume when paused", () => {
+    render(<RecordingHeader {...baseProps} isPaused />);
+    expect(screen.getByRole("button", { name: "Resume recording" })).toBeInTheDocument();
+    expect(screen.getByText("(Paused)")).toBeInTheDocument();
+  });
+
+  it("renders remaining time when provided and not paused", () => {
+    render(<RecordingHeader {...baseProps} remaining={45} />);
+    expect(screen.getByText("(0:45 remaining)")).toBeInTheDocument();
+  });
+
+  it("invokes onStop when Stop is clicked", async () => {
+    const onStop = vi.fn();
+    render(<RecordingHeader {...baseProps} onStop={onStop} />);
+    await userEvent.click(screen.getByRole("button", { name: "Stop recording" }));
+    expect(onStop).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows draw color picker, clear, and thickness when drawMode is on", () => {
+    render(<RecordingHeader {...baseProps} drawMode />);
+    expect(screen.getByLabelText("Drawing color")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Clear drawing" })).toBeInTheDocument();
+    expect(screen.getByTestId("thickness-selector")).toBeInTheDocument();
+  });
+});

--- a/web/src/components/RecordingHeader.tsx
+++ b/web/src/components/RecordingHeader.tsx
@@ -1,0 +1,160 @@
+import { formatDuration } from "../utils/format";
+
+interface RecordingHeaderProps {
+  duration: number;
+  isPaused: boolean;
+  remaining: number | null;
+  drawMode: boolean;
+  drawColor: string;
+  lineWidth: number;
+  onPause: () => void;
+  onResume: () => void;
+  onStop: () => void;
+  onToggleDraw: () => void;
+  onClearCanvas: () => void;
+  onSetDrawColor: (color: string) => void;
+  onSetLineWidth: (width: number) => void;
+}
+
+export function RecordingHeader({
+  duration,
+  isPaused,
+  remaining,
+  drawMode,
+  drawColor,
+  lineWidth,
+  onPause,
+  onResume,
+  onStop,
+  onToggleDraw,
+  onClearCanvas,
+  onSetDrawColor,
+  onSetLineWidth,
+}: RecordingHeaderProps) {
+  return (
+    <div className="recording-header" role="status" aria-live="polite">
+      <div
+        className={`recording-indicator ${
+          isPaused ? "recording-indicator--paused" : "recording-indicator--active"
+        }`}
+      >
+        <div
+          className={`recording-dot ${
+            isPaused ? "recording-dot--paused" : "recording-dot--active"
+          }`}
+        />
+        {formatDuration(duration)}
+        {isPaused && <span className="recording-remaining">(Paused)</span>}
+        {!isPaused && remaining !== null && (
+          <span className="recording-remaining">
+            ({formatDuration(remaining)} remaining)
+          </span>
+        )}
+      </div>
+
+      <button
+        onClick={onToggleDraw}
+        aria-label={drawMode ? "Disable drawing" : "Enable drawing"}
+        data-testid="draw-toggle"
+        className={`btn-draw${drawMode ? " btn-draw--active" : ""}`}
+      >
+        Draw
+      </button>
+
+      {drawMode && (
+        <input
+          type="color"
+          value={drawColor}
+          onChange={(e) => onSetDrawColor(e.target.value)}
+          aria-label="Drawing color"
+          data-testid="color-picker"
+          style={{
+            width: 36,
+            height: 36,
+            border: "1px solid var(--color-border)",
+            borderRadius: 8,
+            padding: 2,
+            background: "transparent",
+            cursor: "pointer",
+          }}
+        />
+      )}
+
+      {drawMode && (
+        <button
+          onClick={onClearCanvas}
+          aria-label="Clear drawing"
+          data-testid="clear-drawing"
+          className="btn-pause"
+        >
+          Clear
+        </button>
+      )}
+
+      {drawMode && (
+        <div
+          style={{ display: "flex", gap: 4, alignItems: "center" }}
+          data-testid="thickness-selector"
+        >
+          {[2, 4, 8].map((w) => (
+            <button
+              key={w}
+              onClick={() => onSetLineWidth(w)}
+              aria-label={`Line width ${w}`}
+              style={{
+                width: 28,
+                height: 28,
+                borderRadius: "50%",
+                border:
+                  lineWidth === w
+                    ? "2px solid var(--color-accent)"
+                    : "1px solid var(--color-border)",
+                background: "transparent",
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+                cursor: "pointer",
+                padding: 0,
+              }}
+            >
+              <div
+                style={{
+                  width: w + 2,
+                  height: w + 2,
+                  borderRadius: "50%",
+                  background: "var(--color-text)",
+                }}
+              />
+            </button>
+          ))}
+        </div>
+      )}
+
+      {isPaused ? (
+        <button
+          onClick={onResume}
+          aria-label="Resume recording"
+          className="btn-resume"
+        >
+          Resume
+        </button>
+      ) : (
+        <button
+          onClick={onPause}
+          aria-label="Pause recording"
+          className="btn-pause"
+        >
+          Pause
+        </button>
+      )}
+
+      <button
+        onClick={onStop}
+        aria-label="Stop recording"
+        className="btn-stop"
+      >
+        Stop Recording
+      </button>
+    </div>
+  );
+}

--- a/web/src/hooks/useDocumentPictureInPictureWindow.ts
+++ b/web/src/hooks/useDocumentPictureInPictureWindow.ts
@@ -1,0 +1,53 @@
+import { useCallback, useRef, useState } from "react";
+
+export function useDocumentPictureInPictureWindow(supported: boolean) {
+  const [pipWindow, setPipWindow] = useState<Window | null>(null);
+  const pipWindowRef = useRef<Window | null>(null);
+  const pendingWindowRef = useRef<Promise<Window | null> | null>(null);
+  const requestIdRef = useRef(0);
+
+  const close = useCallback(() => {
+    requestIdRef.current += 1;
+    pendingWindowRef.current = null;
+    pipWindowRef.current?.close();
+    pipWindowRef.current = null;
+    setPipWindow(null);
+  }, []);
+
+  const open = useCallback(() => {
+    if (!supported) return Promise.resolve(null);
+    const dpip = window.documentPictureInPicture;
+    if (!dpip) return Promise.resolve(null);
+
+    const requestId = requestIdRef.current + 1;
+    requestIdRef.current = requestId;
+    const pendingWindow = dpip
+      .requestWindow({ width: 280, height: 220 })
+      .then((nextWindow) => {
+        if (requestIdRef.current !== requestId) {
+          nextWindow.close();
+          return null;
+        }
+        pipWindowRef.current = nextWindow;
+        setPipWindow(nextWindow);
+        return nextWindow;
+      })
+      .catch(() => {
+        if (requestIdRef.current === requestId) {
+          pipWindowRef.current = null;
+          setPipWindow(null);
+        }
+        return null;
+      });
+    pendingWindowRef.current = pendingWindow;
+    return pendingWindow;
+  }, [supported]);
+
+  const waitForOpen = useCallback(async () => {
+    if (pendingWindowRef.current) {
+      await pendingWindowRef.current;
+    }
+  }, []);
+
+  return { pipWindow, open, close, waitForOpen };
+}

--- a/web/src/hooks/useDocumentPictureInPictureWindow.ts
+++ b/web/src/hooks/useDocumentPictureInPictureWindow.ts
@@ -38,6 +38,11 @@ export function useDocumentPictureInPictureWindow(supported: boolean) {
           setPipWindow(null);
         }
         return null;
+      })
+      .finally(() => {
+        if (pendingWindowRef.current === pendingWindow) {
+          pendingWindowRef.current = null;
+        }
       });
     pendingWindowRef.current = pendingWindow;
     return pendingWindow;

--- a/web/src/hooks/useRecording.ts
+++ b/web/src/hooks/useRecording.ts
@@ -32,6 +32,7 @@ export function useRecording(
   maxDurationSeconds: number,
   onCountdownComplete: () => void,
   onMaxDurationReached: () => void,
+  autoCountdown = true,
 ): UseRecordingResult {
   const [state, setStateRaw] = useState<RecordingState>("idle");
   const [elapsed, setElapsed] = useState(0);
@@ -77,7 +78,7 @@ export function useRecording(
   }, [stopTimer]);
 
   useEffect(() => {
-    if (state !== "countdown") return;
+    if (state !== "countdown" || !autoCountdown) return;
     countdownTimerRef.current = setInterval(() => {
       setCountdown((prev) => {
         if (prev <= 1) {
@@ -88,7 +89,7 @@ export function useRecording(
       });
     }, 1000);
     return () => clearInterval(countdownTimerRef.current);
-  }, [state]);
+  }, [autoCountdown, state]);
 
   useEffect(() => {
     if (

--- a/web/src/hooks/useRecording.ts
+++ b/web/src/hooks/useRecording.ts
@@ -32,7 +32,6 @@ export function useRecording(
   maxDurationSeconds: number,
   onCountdownComplete: () => void,
   onMaxDurationReached: () => void,
-  autoCountdown = true,
 ): UseRecordingResult {
   const [state, setStateRaw] = useState<RecordingState>("idle");
   const [elapsed, setElapsed] = useState(0);
@@ -78,7 +77,7 @@ export function useRecording(
   }, [stopTimer]);
 
   useEffect(() => {
-    if (state !== "countdown" || !autoCountdown) return;
+    if (state !== "countdown") return;
     countdownTimerRef.current = setInterval(() => {
       setCountdown((prev) => {
         if (prev <= 1) {
@@ -89,7 +88,7 @@ export function useRecording(
       });
     }, 1000);
     return () => clearInterval(countdownTimerRef.current);
-  }, [autoCountdown, state]);
+  }, [state]);
 
   useEffect(() => {
     if (

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -1841,6 +1841,18 @@ textarea.form-input {
   justify-content: center;
 }
 
+.recording-tier2-banner {
+  max-width: 480px;
+  width: 100%;
+  padding: 10px 14px;
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+  background: var(--color-surface);
+  color: var(--color-text-secondary);
+  font-size: 14px;
+  text-align: center;
+}
+
 .btn-pause {
   background: transparent;
   color: var(--color-text);
@@ -1921,6 +1933,49 @@ textarea.form-input {
 
 .btn-stop:active {
   transform: scale(0.97);
+}
+
+.recording-floating-panel {
+  box-sizing: border-box;
+  min-height: 100vh;
+  padding: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  align-items: stretch;
+  justify-content: center;
+  background: var(--color-bg, #ffffff);
+  color: var(--color-text, #111827);
+  font-family: inherit;
+}
+
+.recording-floating-panel__video {
+  width: 100%;
+  aspect-ratio: 4 / 3;
+  border-radius: 8px;
+  border: 2px solid var(--color-accent);
+  object-fit: cover;
+  background: var(--color-bg-tertiary, #f3f4f6);
+}
+
+.recording-floating-panel__timer {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  font-weight: 600;
+  font-size: 14px;
+  color: var(--color-error);
+}
+
+.recording-floating-panel__actions {
+  display: flex;
+  gap: 8px;
+}
+
+.recording-floating-panel__actions > button {
+  flex: 1;
+  padding-inline: 12px;
 }
 
 /* Record page — Share state */

--- a/web/src/types/document-pip.d.ts
+++ b/web/src/types/document-pip.d.ts
@@ -1,0 +1,14 @@
+interface DocumentPictureInPictureOptions {
+  width?: number;
+  height?: number;
+  disallowReturnToOpener?: boolean;
+}
+
+interface DocumentPictureInPicture {
+  requestWindow(options?: DocumentPictureInPictureOptions): Promise<Window>;
+  readonly window: Window | null;
+}
+
+interface Window {
+  readonly documentPictureInPicture?: DocumentPictureInPicture;
+}

--- a/web/src/utils/browserCapabilities.test.ts
+++ b/web/src/utils/browserCapabilities.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { supportsDocumentPictureInPicture } from "./browserCapabilities";
+
+describe("supportsDocumentPictureInPicture", () => {
+  const original = (window as unknown as { documentPictureInPicture?: unknown })
+    .documentPictureInPicture;
+
+  afterEach(() => {
+    if (original === undefined) {
+      delete (window as unknown as { documentPictureInPicture?: unknown })
+        .documentPictureInPicture;
+    } else {
+      (window as unknown as { documentPictureInPicture?: unknown })
+        .documentPictureInPicture = original;
+    }
+  });
+
+  it("returns true when documentPictureInPicture is on window", () => {
+    (window as unknown as { documentPictureInPicture?: unknown })
+      .documentPictureInPicture = { requestWindow: () => Promise.resolve({}) };
+    expect(supportsDocumentPictureInPicture()).toBe(true);
+  });
+
+  it("returns false when documentPictureInPicture is missing", () => {
+    delete (window as unknown as { documentPictureInPicture?: unknown })
+      .documentPictureInPicture;
+    expect(supportsDocumentPictureInPicture()).toBe(false);
+  });
+});

--- a/web/src/utils/browserCapabilities.ts
+++ b/web/src/utils/browserCapabilities.ts
@@ -1,0 +1,3 @@
+export function supportsDocumentPictureInPicture(): boolean {
+  return typeof window !== "undefined" && "documentPictureInPicture" in window;
+}


### PR DESCRIPTION
## Summary
- add Chromium Document Picture-in-Picture recorder controls with camera preview, pause/resume, stop, and close-to-stop behavior
- hide the in-page recording header for Tier-1 once floating controls open; keep Firefox/Safari header with one-time Chrome banner
- keep Doc PiP activation safe by requiring the countdown overlay click before opening the floating window
- add unit coverage and a Playwright spec for the PiP stop path
- stabilize e2e API login hydration so full suite can run without refresh-token races

Closes #136

## Tests
- cd web && pnpm typecheck
- cd web && pnpm test
- cd web && pnpm build
- cd web && pnpm exec playwright test --config e2e/playwright.config.ts recording-floating-controls.spec.ts
- cd web && pnpm exec playwright test --config e2e/playwright.config.ts workspace.spec.ts
- cd web && pnpm e2e
- go test ./cmd/sendrec
- git diff --check