### PR TITLE
fix(e2e): enable PLAN_BADGE_ENABLED for workspace tests

### DIFF
--- a/docker-compose.e2e.yml
+++ b/docker-compose.e2e.yml
@@ -16,6 +16,7 @@ services:
       - MAX_UPLOAD_BYTES=524288000
       - AWS_REQUEST_CHECKSUM_CALCULATION=when_required
       - AWS_RESPONSE_CHECKSUM_VALIDATION=when_required
+      - PLAN_BADGE_ENABLED=true
     depends_on:
       postgres:
         condition: service_healthy


### PR DESCRIPTION
v1.88.0 made the plan badge opt-in (default off). The e2e workspace test asserts the "Free" badge is visible — set `PLAN_BADGE_ENABLED=true` in the e2e compose so it stays consistent with the test intent.

## Test plan
- [ ] CI e2e job passes