### PR TITLE
Helm chart upgrade: Transcript model and init logs

### DIFF
--- a/helm/sendrec/Chart.yaml
+++ b/helm/sendrec/Chart.yaml
@@ -20,5 +20,5 @@ maintainers:
 - name: mark24slides
 - name: alexneamtu 
 
-version: "1.0.0"
+version: "1.1.0"
 appVersion: "1.88.0"

--- a/helm/sendrec/templates/_helpers.tpl
+++ b/helm/sendrec/templates/_helpers.tpl
@@ -1,7 +1,6 @@
 {{- define "sendrec.validateRequired" -}}
 {{- $_ := required "sendrec.env.baseUrl is required (maps to BASE_URL)" .Values.sendrec.env.baseUrl -}}
 {{- $_ := required "sendrec.env.s3Endpoint is required (maps to S3_ENDPOINT)" .Values.sendrec.env.s3Endpoint -}}
-{{- $_ := required "sendrec.env.s3PublicEndpoint is required (maps to S3_PUBLIC_ENDPOINT)" .Values.sendrec.env.s3PublicEndpoint -}}
 {{- $_ := required "sendrec.env.s3Bucket is required (maps to S3_BUCKET)" .Values.sendrec.env.s3Bucket -}}
 {{- if not .Values.sendrec.existingSecret -}}
 {{- $_ := required "sendrec.secrets.databaseUrl is required unless sendrec.existingSecret is set" .Values.sendrec.secrets.databaseUrl -}}

--- a/helm/sendrec/templates/deployment.yaml
+++ b/helm/sendrec/templates/deployment.yaml
@@ -28,14 +28,19 @@ spec:
       {{- if or .Values.sendrec.deployment.extraInitContainers (eq (toString .Values.sendrec.env.transcriptionEnabled) "true") }}
       initContainers:
         {{- if eq (toString .Values.sendrec.env.transcriptionEnabled) "true" }}
-        - name: download-whisper-model
+        - name: download-transcription-model
           image: {{ .Values.sendrec.transcription.initImage }}
           command:
             - sh
             - -c
             - |
-              curl -L -o {{ .Values.sendrec.transcription.modelPath }} \
-                {{ .Values.sendrec.transcription.modelUrl }}
+              if [ -f {{ .Values.sendrec.transcription.modelPath }} ]; then
+                echo "Transcription model already present at {{ .Values.sendrec.transcription.modelPath }}, skipping download."
+              else
+                curl -L -o {{ .Values.sendrec.transcription.modelPath }} \
+                  {{ .Values.sendrec.transcription.modelUrl }}
+                echo "Transcription model downloaded to {{ .Values.sendrec.transcription.modelPath }}."
+              fi
           volumeMounts:
             - name: whisper-models
               mountPath: /models

--- a/helm/sendrec/values.yaml
+++ b/helm/sendrec/values.yaml
@@ -32,7 +32,7 @@ sendrec:
 
     # Storage (S3-compatible)
     s3Endpoint: "" # e.g. https://s3.amazonaws.com or https://<your-minio-endpoint>
-    s3PublicEndpoint: "" # e.g. https://cdn.yourdomain.com, used for generating public URLs to videos
+    s3PublicEndpoint: "" # e.g. https://s3.amazonaws.com, used for generating public URLs to videos
     s3Bucket: "" # e.g. your-bucket-name
     s3Region: "" # e.g. us-east-1
     awsRequestChecksumCalculation: "when_required"


### PR DESCRIPTION
## What does this PR do?

Upgraded and validated changes to the sendrec helm chart:
- Made sendrec.env.s3PublicEndpoint optional in Helm validation.
- Updated transcription init container to:
  - detect existing model file at configured path
  - skip curl when model is already present
  - log whether model was reused or downloaded
- Renamed init container from download-whisper-model to download-transcription-model.
- Aligned s3PublicEndpoint comment/example in values with the self-hosting guide.
- Bumped Helm chart version to 1.1.0.

Self-hosting docs describe S3_PUBLIC_ENDPOINT as optional (fallback to S3_ENDPOINT).
Persistent model volumes should avoid downloading whisper model on every rollout/restart (would be very helpful if used PV).
Better init logs improve operability and troubleshooting.

## How to test

No app code changes applied.

## Checklist

- [x] ~`make test` passes~
- [x] ~`make build` succeeds~
- [x] New code has tests where applicable
- [x] No unrelated changes included
