### PR TITLE
fix(retention): respect Auto-delete: Off + extend from current expiry

### DIFF
--- a/internal/docs/openapi.yaml
+++ b/internal/docs/openapi.yaml
@@ -2648,7 +2648,7 @@ paths:
     post:
       tags: [Videos]
       summary: Extend share link expiry
-      description: Resets the share expiry to now plus 7 days. Rate limited to 2 requests per second with a burst of 10.
+      description: Adds 7 days to the current share expiry. Returns 400 if the link has no expiry set. Rate limited to 2 requests per second with a burst of 10.
       operationId: extendShareLink
       security:
         - bearerAuth: []
@@ -2661,6 +2661,12 @@ paths:
       responses:
         "204":
           description: Share link extended
+        "400":
+          description: Link does not expire
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
         "401":
           description: Unauthorized
           content:

--- a/internal/video/video_settings.go
+++ b/internal/video/video_settings.go
@@ -272,7 +272,7 @@ func (h *Handler) Extend(w http.ResponseWriter, r *http.Request) {
 
 	_, updateArgs := orgVideoFilter(r.Context(), videoID, nil, "AND status != 'deleted'")
 	tag, err := h.db.Exec(r.Context(),
-		`UPDATE videos SET share_expires_at = now() + INTERVAL '7 days', updated_at = now()
+		`UPDATE videos SET share_expires_at = share_expires_at + INTERVAL '7 days', updated_at = now()
 		 WHERE `+where, updateArgs...,
 	)
 	if err != nil {

--- a/internal/video/video_settings_test.go
+++ b/internal/video/video_settings_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/go-chi/chi/v5"
 	pgx "github.com/jackc/pgx/v5"
@@ -40,6 +41,40 @@ func TestTogglePin_PinsVideo(t *testing.T) {
 	}
 	if !resp["pinned"] {
 		t.Errorf("expected pinned=true, got %v", resp["pinned"])
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet pgxmock expectations: %v", err)
+	}
+}
+
+func TestExtend_AddsSevenDaysToCurrentExpiry(t *testing.T) {
+	mock, err := pgxmock.NewPool()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer mock.Close()
+
+	handler := NewHandler(mock, nil, testBaseURL, 0, 0, 0, 0, testJWTSecret, false)
+
+	currentExpiry := time.Now().Add(30 * 24 * time.Hour)
+
+	mock.ExpectQuery(`SELECT share_expires_at FROM videos WHERE`).
+		WithArgs("vid-1", testUserID).
+		WillReturnRows(pgxmock.NewRows([]string{"share_expires_at"}).AddRow(&currentExpiry))
+
+	mock.ExpectExec(`UPDATE videos SET share_expires_at = share_expires_at \+ INTERVAL '7 days', updated_at = now\(\)`).
+		WithArgs("vid-1", testUserID).
+		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+
+	r := chi.NewRouter()
+	r.With(newAuthMiddleware()).Post("/api/videos/{id}/extend", handler.Extend)
+
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, authenticatedRequest(t, http.MethodPost, "/api/videos/vid-1/extend", nil))
+
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("expected status %d, got %d: %s", http.StatusNoContent, rec.Code, rec.Body.String())
 	}
 
 	if err := mock.ExpectationsWereMet(); err != nil {

--- a/migrations/000058_drop_share_expires_at_default.down.sql
+++ b/migrations/000058_drop_share_expires_at_default.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE videos ALTER COLUMN share_expires_at SET DEFAULT now() + INTERVAL '7 days';

--- a/migrations/000058_drop_share_expires_at_default.up.sql
+++ b/migrations/000058_drop_share_expires_at_default.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE videos ALTER COLUMN share_expires_at DROP DEFAULT;


### PR DESCRIPTION
## Summary
- Closes #146
- `videos.share_expires_at` had a column default of `now() + INTERVAL '7 days'` left over from migration 000003. Inserts in `video_crud.go` never set the column → every new video silently got a 7-day expiry, ignoring the workspace `Auto-delete: Off` setting
- Migration 000058 drops the default. New uploads → NULL → never expires unless owner opts in via UI
- `Extend` was `share_expires_at = now() + INTERVAL '7 days'`. If current expiry was already > 7d out, the button looked like a no-op (issue #146). Changed to `share_expires_at = share_expires_at + INTERVAL '7 days'`

## Behavior
- Existing rows are untouched — owners with default-7d expiries must click "Remove expiry" if they want them cleared
- "Set expiry" button still defaults to `now() + 7d` (user explicitly clicked it)
- "Extend" now visibly moves the date forward by 7d regardless of how far out it already is

## Test plan
- [x] New `TestExtend_AddsSevenDaysToCurrentExpiry` — asserts new SQL
- [x] All existing `video_settings_test.go` and `video_test.go` extend tests still pass (loose regex)
- [x] `go test ./internal/video/` clean

## Not verified
- Manual browser flow on self-host (upload with `retention_days = 0`, confirm Library shows "Never expires") — needs reviewer or follow-up