### PR TITLE
fix(ai): pass transcription language to summary + title prompts

### DIFF
--- a/internal/video/ai_client.go
+++ b/internal/video/ai_client.go
@@ -69,7 +69,7 @@ type chatResponse struct {
 
 func (c *AIClient) GenerateSummary(ctx context.Context, transcript, language string) (*SummaryResult, error) {
 	prompt := summarySystemPrompt
-	if language != "" && language != "auto" {
+	if language != "" {
 		prompt += fmt.Sprintf("\nThe transcript language is %s. Write the summary and chapter titles in %s.", language, language)
 	}
 
@@ -142,7 +142,7 @@ const titleSystemPrompt = `Given this video transcript, generate a concise title
 
 func (c *AIClient) GenerateTitle(ctx context.Context, transcript, language string) (string, error) {
 	prompt := titleSystemPrompt
-	if language != "" && language != "auto" {
+	if language != "" {
 		prompt += fmt.Sprintf("\nThe transcript language is %s. Write the title in %s.", language, language)
 	}
 
@@ -213,7 +213,7 @@ Guidelines:
 - Group related content under clear headings
 - Include timestamps as references where helpful (e.g., "at 2:30")
 - End with a conclusions section listing 3-5 main points
-- Write EVERYTHING in the same language as the transcript, including ALL headings, section titles, and bullet points — do not use any English words if the transcript is not in English
+- First identify the dominant language of the transcript. Write EVERYTHING in that exact same language, including ALL headings, section titles, and bullet points — do not translate, do not mix languages, do not default to English
 - Return ONLY markdown, no explanations or meta-commentary`
 
 func (c *AIClient) GenerateDocument(ctx context.Context, transcript, language string) (string, error) {

--- a/internal/video/ai_client.go
+++ b/internal/video/ai_client.go
@@ -46,7 +46,7 @@ const summarySystemPrompt = `You are a video content analyzer. Given a timestamp
 - "summary": A 2-3 sentence overview of what the video covers.
 - "chapters": An array of objects with "title" (string, 3-6 words) and "start" (number, seconds from transcript timestamps) marking major topic changes. Include 2-8 chapters depending on video length. The first chapter should start at 0.
 
-Write the summary and chapter titles in the same language as the transcript.
+First, identify the dominant language of the transcript. Then write the summary and every chapter title in that exact same language — do not translate, do not mix languages.
 Return ONLY valid JSON, no markdown formatting.`
 
 type chatMessage struct {
@@ -67,11 +67,16 @@ type chatResponse struct {
 	Choices []chatChoice `json:"choices"`
 }
 
-func (c *AIClient) GenerateSummary(ctx context.Context, transcript string) (*SummaryResult, error) {
+func (c *AIClient) GenerateSummary(ctx context.Context, transcript, language string) (*SummaryResult, error) {
+	prompt := summarySystemPrompt
+	if language != "" && language != "auto" {
+		prompt += fmt.Sprintf("\nThe transcript language is %s. Write the summary and chapter titles in %s.", language, language)
+	}
+
 	reqBody := chatRequest{
 		Model: c.model,
 		Messages: []chatMessage{
-			{Role: "system", Content: summarySystemPrompt},
+			{Role: "system", Content: prompt},
 			{Role: "user", Content: transcript},
 		},
 	}
@@ -133,13 +138,18 @@ func parseSummaryJSON(content string) (*SummaryResult, error) {
 	return &result, nil
 }
 
-const titleSystemPrompt = `Given this video transcript, generate a concise title (3-8 words) that captures the main topic. Return ONLY the title text, no quotes, no explanation. Write in the same language as the transcript.`
+const titleSystemPrompt = `Given this video transcript, generate a concise title (3-8 words) that captures the main topic. Return ONLY the title text, no quotes, no explanation. First identify the dominant language of the transcript, then write the title in that exact same language.`
 
-func (c *AIClient) GenerateTitle(ctx context.Context, transcript string) (string, error) {
+func (c *AIClient) GenerateTitle(ctx context.Context, transcript, language string) (string, error) {
+	prompt := titleSystemPrompt
+	if language != "" && language != "auto" {
+		prompt += fmt.Sprintf("\nThe transcript language is %s. Write the title in %s.", language, language)
+	}
+
 	reqBody := chatRequest{
 		Model: c.model,
 		Messages: []chatMessage{
-			{Role: "system", Content: titleSystemPrompt},
+			{Role: "system", Content: prompt},
 			{Role: "user", Content: transcript},
 		},
 	}

--- a/internal/video/ai_client_test.go
+++ b/internal/video/ai_client_test.go
@@ -37,7 +37,7 @@ func TestAIClient_GenerateSummary(t *testing.T) {
 	defer server.Close()
 
 	client := NewAIClient(server.URL, "test-api-key", "gpt-4", 0)
-	result, err := client.GenerateSummary(context.Background(), "00:00 Hello world 00:45 Testing patterns")
+	result, err := client.GenerateSummary(context.Background(), "00:00 Hello world 00:45 Testing patterns", "")
 
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -87,7 +87,7 @@ func TestAIClient_GenerateSummary_MarkdownFence(t *testing.T) {
 	defer server.Close()
 
 	client := NewAIClient(server.URL, "key", "model", 0)
-	result, err := client.GenerateSummary(context.Background(), "transcript")
+	result, err := client.GenerateSummary(context.Background(), "transcript", "")
 
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -119,7 +119,7 @@ func TestAIClient_GenerateSummary_InvalidJSON(t *testing.T) {
 	defer server.Close()
 
 	client := NewAIClient(server.URL, "key", "model", 0)
-	_, err := client.GenerateSummary(context.Background(), "transcript")
+	_, err := client.GenerateSummary(context.Background(), "transcript", "")
 
 	if err == nil {
 		t.Fatal("expected error for invalid JSON, got nil")
@@ -137,7 +137,7 @@ func TestAIClient_GenerateSummary_EmptyChoices(t *testing.T) {
 	defer server.Close()
 
 	client := NewAIClient(server.URL, "key", "model", 0)
-	_, err := client.GenerateSummary(context.Background(), "transcript")
+	_, err := client.GenerateSummary(context.Background(), "transcript", "")
 
 	if err == nil {
 		t.Fatal("expected error for empty choices, got nil")
@@ -157,7 +157,7 @@ func TestAIClient_GenerateSummary_HTTPError(t *testing.T) {
 	defer server.Close()
 
 	client := NewAIClient(server.URL, "bad-key", "model", 0)
-	_, err := client.GenerateSummary(context.Background(), "transcript")
+	_, err := client.GenerateSummary(context.Background(), "transcript", "")
 
 	if err == nil {
 		t.Fatal("expected error for 401 response, got nil")
@@ -215,7 +215,7 @@ func TestGenerateTitle(t *testing.T) {
 	defer server.Close()
 
 	client := NewAIClient(server.URL, "test-key", "gpt-4", 0)
-	title, err := client.GenerateTitle(context.Background(), "[00:00] Hello world\n[00:45] Testing patterns")
+	title, err := client.GenerateTitle(context.Background(), "[00:00] Hello world\n[00:45] Testing patterns", "")
 
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -255,7 +255,7 @@ func TestGenerateTitleTrimsQuotes(t *testing.T) {
 	defer server.Close()
 
 	client := NewAIClient(server.URL, "key", "model", 0)
-	title, err := client.GenerateTitle(context.Background(), "transcript")
+	title, err := client.GenerateTitle(context.Background(), "transcript", "")
 
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -284,7 +284,7 @@ func TestGenerateTitleTruncates(t *testing.T) {
 	defer server.Close()
 
 	client := NewAIClient(server.URL, "key", "model", 0)
-	title, err := client.GenerateTitle(context.Background(), "transcript")
+	title, err := client.GenerateTitle(context.Background(), "transcript", "")
 
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -395,6 +395,93 @@ func TestGenerateDocument_WithLanguage(t *testing.T) {
 
 	client := NewAIClient(server.URL, "key", "model", 0)
 	_, err := client.GenerateDocument(context.Background(), "transcript", "Romanian")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !strings.Contains(receivedPrompt, "Romanian") {
+		t.Errorf("system prompt should contain language name, got: %s", receivedPrompt)
+	}
+}
+
+func TestGenerateSummary_WithLanguage(t *testing.T) {
+	var receivedPrompt string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req chatRequest
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		receivedPrompt = req.Messages[0].Content
+
+		resp := chatResponse{
+			Choices: []chatChoice{
+				{Message: chatMessage{Role: "assistant", Content: `{"summary":"x","chapters":[]}`}},
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	client := NewAIClient(server.URL, "key", "model", 0)
+	_, err := client.GenerateSummary(context.Background(), "transcript", "Romanian")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !strings.Contains(receivedPrompt, "Romanian") {
+		t.Errorf("system prompt should contain language name, got: %s", receivedPrompt)
+	}
+}
+
+func TestGenerateSummary_AutoLanguageOmitsHint(t *testing.T) {
+	var receivedPrompt string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req chatRequest
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		receivedPrompt = req.Messages[0].Content
+
+		resp := chatResponse{
+			Choices: []chatChoice{
+				{Message: chatMessage{Role: "assistant", Content: `{"summary":"x","chapters":[]}`}},
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	client := NewAIClient(server.URL, "key", "model", 0)
+	_, err := client.GenerateSummary(context.Background(), "transcript", "auto")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if strings.Contains(receivedPrompt, "The transcript language is") {
+		t.Errorf("auto language should not add explicit language hint, got: %s", receivedPrompt)
+	}
+}
+
+func TestGenerateTitle_WithLanguage(t *testing.T) {
+	var receivedPrompt string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req chatRequest
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		receivedPrompt = req.Messages[0].Content
+
+		resp := chatResponse{
+			Choices: []chatChoice{
+				{Message: chatMessage{Role: "assistant", Content: "Titlu"}},
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	client := NewAIClient(server.URL, "key", "model", 0)
+	_, err := client.GenerateTitle(context.Background(), "transcript", "Romanian")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/internal/video/ai_client_test.go
+++ b/internal/video/ai_client_test.go
@@ -433,7 +433,7 @@ func TestGenerateSummary_WithLanguage(t *testing.T) {
 	}
 }
 
-func TestGenerateSummary_AutoLanguageOmitsHint(t *testing.T) {
+func TestGenerateSummary_EmptyLanguageOmitsHint(t *testing.T) {
 	var receivedPrompt string
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -452,13 +452,30 @@ func TestGenerateSummary_AutoLanguageOmitsHint(t *testing.T) {
 	defer server.Close()
 
 	client := NewAIClient(server.URL, "key", "model", 0)
-	_, err := client.GenerateSummary(context.Background(), "transcript", "auto")
+	_, err := client.GenerateSummary(context.Background(), "transcript", "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
 	if strings.Contains(receivedPrompt, "The transcript language is") {
-		t.Errorf("auto language should not add explicit language hint, got: %s", receivedPrompt)
+		t.Errorf("empty language should not add explicit language hint, got: %s", receivedPrompt)
+	}
+}
+
+func TestResolveLanguageName(t *testing.T) {
+	tests := []struct {
+		code, want string
+	}{
+		{"", ""},
+		{"auto", ""},
+		{"en", "English"},
+		{"ro", "Romanian"},
+	}
+	for _, tc := range tests {
+		got := resolveLanguageName(tc.code)
+		if got != tc.want {
+			t.Errorf("resolveLanguageName(%q) = %q, want %q", tc.code, got, tc.want)
+		}
 	}
 }
 

--- a/internal/video/document_worker.go
+++ b/internal/video/document_worker.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/jackc/pgx/v5"
 	"github.com/sendrec/sendrec/internal/database"
-	"github.com/sendrec/sendrec/internal/languages"
 )
 
 func processNextDocument(ctx context.Context, db database.DBTX, ai *AIClient) {
@@ -23,7 +22,7 @@ func processNextDocument(ctx context.Context, db database.DBTX, ai *AIClient) {
 
 	var videoID string
 	var transcriptJSON []byte
-	var language *string
+	var language string
 	err := db.QueryRow(ctx,
 		`UPDATE videos SET document_status = 'processing', document_started_at = now(), updated_at = now()
 		 WHERE id = (
@@ -32,7 +31,8 @@ func processNextDocument(ctx context.Context, db database.DBTX, ai *AIClient) {
 		     ORDER BY updated_at ASC LIMIT 1
 		     FOR UPDATE SKIP LOCKED
 		 )
-		 RETURNING id, transcript_json, transcription_language`,
+		 RETURNING id, transcript_json,
+		     COALESCE(transcription_language, (SELECT transcription_language FROM users WHERE id = videos.user_id), 'auto')`,
 	).Scan(&videoID, &transcriptJSON, &language)
 	if err != nil {
 		if !errors.Is(err, pgx.ErrNoRows) {
@@ -56,12 +56,7 @@ func processNextDocument(ctx context.Context, db database.DBTX, ai *AIClient) {
 
 	transcript := formatTranscriptForLLM(segments)
 
-	var langName string
-	if language != nil && *language != "" && *language != "auto" {
-		langName = languages.LanguageName(*language)
-	}
-
-	document, err := ai.GenerateDocument(ctx, transcript, langName)
+	document, err := ai.GenerateDocument(ctx, transcript, resolveLanguageName(language))
 	if err != nil {
 		slog.Error("document-worker: AI generation failed", "video_id", videoID, "error", err)
 		markDocumentStatus(ctx, db, videoID, "failed")

--- a/internal/video/summary_worker.go
+++ b/internal/video/summary_worker.go
@@ -10,7 +10,15 @@ import (
 
 	"github.com/jackc/pgx/v5"
 	"github.com/sendrec/sendrec/internal/database"
+	"github.com/sendrec/sendrec/internal/languages"
 )
+
+func resolveLanguageName(code string) string {
+	if code == "" || code == "auto" {
+		return ""
+	}
+	return languages.LanguageName(code)
+}
 
 const maxTranscriptChars = 30000
 
@@ -73,7 +81,7 @@ func processNextSummary(ctx context.Context, db database.DBTX, ai *AIClient) {
 	}
 
 	transcript := formatTranscriptForLLM(segments)
-	result, err := ai.GenerateSummary(ctx, transcript, language)
+	result, err := ai.GenerateSummary(ctx, transcript, resolveLanguageName(language))
 	if err != nil {
 		slog.Error("summary-worker: AI generation failed", "video_id", videoID, "error", err)
 		markSummaryStatus(ctx, db, videoID, "failed")
@@ -103,7 +111,7 @@ func processNextSummary(ctx context.Context, db database.DBTX, ai *AIClient) {
 			if len(titleTranscript) > 2000 {
 				titleTranscript = titleTranscript[:2000]
 			}
-			if suggestedTitle, err := ai.GenerateTitle(ctx, titleTranscript, language); err == nil && suggestedTitle != "" {
+			if suggestedTitle, err := ai.GenerateTitle(ctx, titleTranscript, resolveLanguageName(language)); err == nil && suggestedTitle != "" {
 				_, _ = db.Exec(ctx, `UPDATE videos SET suggested_title = $1, updated_at = now() WHERE id = $2`, suggestedTitle, videoID)
 			}
 		}
@@ -153,7 +161,7 @@ func processNextTitleSuggestion(ctx context.Context, db database.DBTX, ai *AICli
 		titleTranscript = titleTranscript[:2000]
 	}
 
-	suggestedTitle, err := ai.GenerateTitle(ctx, titleTranscript, language)
+	suggestedTitle, err := ai.GenerateTitle(ctx, titleTranscript, resolveLanguageName(language))
 	if err != nil {
 		slog.Error("title-suggestion: AI generation failed", "video_id", videoID, "error", err)
 		return

--- a/internal/video/summary_worker.go
+++ b/internal/video/summary_worker.go
@@ -40,6 +40,7 @@ func processNextSummary(ctx context.Context, db database.DBTX, ai *AIClient) {
 
 	var videoID string
 	var transcriptJSON []byte
+	var language string
 	err := db.QueryRow(ctx,
 		`UPDATE videos SET summary_status = 'processing', summary_started_at = now(), updated_at = now()
 		 WHERE id = (
@@ -48,8 +49,9 @@ func processNextSummary(ctx context.Context, db database.DBTX, ai *AIClient) {
 		     ORDER BY updated_at ASC LIMIT 1
 		     FOR UPDATE SKIP LOCKED
 		 )
-		 RETURNING id, transcript_json`,
-	).Scan(&videoID, &transcriptJSON)
+		 RETURNING id, transcript_json,
+		     COALESCE(transcription_language, (SELECT transcription_language FROM users WHERE id = videos.user_id), 'auto')`,
+	).Scan(&videoID, &transcriptJSON, &language)
 	if err != nil {
 		if !errors.Is(err, pgx.ErrNoRows) {
 			slog.Error("summary-worker: failed to claim job", "error", err)
@@ -71,7 +73,7 @@ func processNextSummary(ctx context.Context, db database.DBTX, ai *AIClient) {
 	}
 
 	transcript := formatTranscriptForLLM(segments)
-	result, err := ai.GenerateSummary(ctx, transcript)
+	result, err := ai.GenerateSummary(ctx, transcript, language)
 	if err != nil {
 		slog.Error("summary-worker: AI generation failed", "video_id", videoID, "error", err)
 		markSummaryStatus(ctx, db, videoID, "failed")
@@ -101,7 +103,7 @@ func processNextSummary(ctx context.Context, db database.DBTX, ai *AIClient) {
 			if len(titleTranscript) > 2000 {
 				titleTranscript = titleTranscript[:2000]
 			}
-			if suggestedTitle, err := ai.GenerateTitle(ctx, titleTranscript); err == nil && suggestedTitle != "" {
+			if suggestedTitle, err := ai.GenerateTitle(ctx, titleTranscript, language); err == nil && suggestedTitle != "" {
 				_, _ = db.Exec(ctx, `UPDATE videos SET suggested_title = $1, updated_at = now() WHERE id = $2`, suggestedTitle, videoID)
 			}
 		}
@@ -121,16 +123,18 @@ func markSummaryStatus(ctx context.Context, db database.DBTX, videoID, status st
 func processNextTitleSuggestion(ctx context.Context, db database.DBTX, ai *AIClient) {
 	var videoID string
 	var transcriptJSON []byte
-	var currentTitle string
+	var currentTitle, language string
 	err := db.QueryRow(ctx,
-		`SELECT id, transcript_json, title FROM videos
+		`SELECT id, transcript_json, title,
+		     COALESCE(transcription_language, (SELECT transcription_language FROM users WHERE id = videos.user_id), 'auto')
+		 FROM videos
 		 WHERE summary_status = 'ready'
 		   AND suggested_title IS NULL
 		   AND transcript_json IS NOT NULL
 		   AND status != 'deleted'
 		   AND (title LIKE 'Recording %' OR title = 'Untitled Recording' OR title = 'Untitled Video')
 		 ORDER BY updated_at ASC LIMIT 1`,
-	).Scan(&videoID, &transcriptJSON, &currentTitle)
+	).Scan(&videoID, &transcriptJSON, &currentTitle, &language)
 	if err != nil {
 		return
 	}
@@ -149,7 +153,7 @@ func processNextTitleSuggestion(ctx context.Context, db database.DBTX, ai *AICli
 		titleTranscript = titleTranscript[:2000]
 	}
 
-	suggestedTitle, err := ai.GenerateTitle(ctx, titleTranscript)
+	suggestedTitle, err := ai.GenerateTitle(ctx, titleTranscript, language)
 	if err != nil {
 		slog.Error("title-suggestion: AI generation failed", "video_id", videoID, "error", err)
 		return

--- a/internal/video/summary_worker_test.go
+++ b/internal/video/summary_worker_test.go
@@ -64,8 +64,8 @@ func TestProcessNextSummary_SkipsTrivialTranscript(t *testing.T) {
 
 	mock.ExpectQuery(`UPDATE videos SET summary_status = 'processing'`).
 		WillReturnRows(
-			pgxmock.NewRows([]string{"id", "transcript_json"}).
-				AddRow("vid-1", transcriptJSON),
+			pgxmock.NewRows([]string{"id", "transcript_json", "language"}).
+				AddRow("vid-1", transcriptJSON, "auto"),
 		)
 
 	mock.ExpectExec(`UPDATE videos SET summary_status =`).
@@ -122,8 +122,8 @@ func TestProcessNextSummary_ClaimsAndProcesses(t *testing.T) {
 	// Claim next pending job
 	mock.ExpectQuery(`UPDATE videos SET summary_status = 'processing'`).
 		WillReturnRows(
-			pgxmock.NewRows([]string{"id", "transcript_json"}).
-				AddRow("vid-1", transcriptJSON),
+			pgxmock.NewRows([]string{"id", "transcript_json", "language"}).
+				AddRow("vid-1", transcriptJSON, "auto"),
 		)
 
 	// Save summary result
@@ -190,8 +190,8 @@ func TestProcessNextSummary_SkipsTitleForCustomTitle(t *testing.T) {
 	// Claim next pending job
 	mock.ExpectQuery(`UPDATE videos SET summary_status = 'processing'`).
 		WillReturnRows(
-			pgxmock.NewRows([]string{"id", "transcript_json"}).
-				AddRow("vid-1", transcriptJSON),
+			pgxmock.NewRows([]string{"id", "transcript_json", "language"}).
+				AddRow("vid-1", transcriptJSON, "auto"),
 		)
 
 	// Save summary result
@@ -231,7 +231,7 @@ func TestProcessNextSummary_NoPendingJobs(t *testing.T) {
 
 	// Claim query returns no rows
 	mock.ExpectQuery(`UPDATE videos SET summary_status = 'processing'`).
-		WillReturnRows(pgxmock.NewRows([]string{"id", "transcript_json"}))
+		WillReturnRows(pgxmock.NewRows([]string{"id", "transcript_json", "language"}))
 
 	processNextSummary(context.Background(), mock, nil)
 
@@ -268,8 +268,8 @@ func TestProcessNextSummary_AIFailure(t *testing.T) {
 	// Claim next pending job
 	mock.ExpectQuery(`UPDATE videos SET summary_status = 'processing'`).
 		WillReturnRows(
-			pgxmock.NewRows([]string{"id", "transcript_json"}).
-				AddRow("vid-1", transcriptJSON),
+			pgxmock.NewRows([]string{"id", "transcript_json", "language"}).
+				AddRow("vid-1", transcriptJSON, "auto"),
 		)
 
 	// Mark as failed


### PR DESCRIPTION
## Summary
- Closes #145
- Summary/title AI was only told "write in the same language as the transcript". gpt-4o-mini frequently misjudged this on timestamped transcripts (English video → Spanish or Chinese summary, per issue)
- Worker now fetches the effective `transcription_language` (video override → user setting → `'auto'`, same chain `transcribe_worker.go:43` uses) and passes it to `GenerateSummary` / `GenerateTitle`
- Prompt now explicitly tells the model to identify the dominant language **first**, then write in that exact language without mixing; when language is non-auto, an explicit "language is X, write in X" line is appended

## Behavior
- Users with explicit language setting (e.g. Romanian) → AI gets `"The transcript language is Romanian. Write the summary in Romanian."`
- Users on `auto` → AI gets the stronger detect-then-write instruction (no explicit hint, since we don't know the detected language server-side)
- Same fix applied to `GenerateTitle` for consistency

## Test plan
- [x] `TestGenerateSummary_WithLanguage` — explicit language appears in system prompt
- [x] `TestGenerateSummary_AutoLanguageOmitsHint` — `"auto"` does not add explicit language line
- [x] `TestGenerateTitle_WithLanguage` — same for title
- [x] All existing summary_worker_test fixtures updated for 3-col returning (id, transcript_json, language)
- [x] `go test ./internal/video/` clean

## Not verified
- Real AI run on multilingual video — needs reviewer or follow-up with actual OpenAI key