### PR TITLE
Helm chart: Whisper templating, direct template conditions

### DIFF
--- a/helm/sendrec/Chart.yaml
+++ b/helm/sendrec/Chart.yaml
@@ -20,5 +20,5 @@ maintainers:
 - name: mark24slides
 - name: alexneamtu 
 
-version: "1.2.0"
+version: "1.2.1"
 appVersion: "1.89.0"

--- a/helm/sendrec/templates/_helpers.tpl
+++ b/helm/sendrec/templates/_helpers.tpl
@@ -1,12 +1,3 @@
-{{/* True when transcription is enabled AND the provider is local-whisper (needs model volume + init download). */}}
-{{- define "sendrec.needsLocalWhisper" -}}
-{{- if eq (toString .Values.sendrec.env.transcriptionEnabled) "true" -}}
-{{- if or (not .Values.sendrec.env.transcriptionProvider) (eq (toString .Values.sendrec.env.transcriptionProvider) "local") -}}
-true
-{{- end -}}
-{{- end -}}
-{{- end -}}
-
 {{- define "sendrec.validateRequired" -}}
 {{- $_ := required "sendrec.env.baseUrl is required (maps to BASE_URL)" .Values.sendrec.env.baseUrl -}}
 {{- $_ := required "sendrec.env.s3Endpoint is required (maps to S3_ENDPOINT)" .Values.sendrec.env.s3Endpoint -}}

--- a/helm/sendrec/templates/configmap.yaml
+++ b/helm/sendrec/templates/configmap.yaml
@@ -23,10 +23,10 @@ data:
   REGISTRATION_ENABLED: {{ .Values.sendrec.env.registrationEnabled | quote }}
   PLAN_BADGE_ENABLED: {{ .Values.sendrec.env.planBadgeEnabled | quote }}
   TRANSCRIPTION_ENABLED: {{ .Values.sendrec.env.transcriptionEnabled | quote }}
-  TRANSCRIPTION_PROVIDER: {{ .Values.sendrec.env.transcriptionProvider | default "local" | quote }}
-  TRANSCRIPTION_API_URL: {{ .Values.sendrec.env.transcriptionApiUrl | default "" | quote }}
-  TRANSCRIPTION_MODEL: {{ .Values.sendrec.env.transcriptionModel | default "" | quote }}
-  TRANSCRIPTION_TIMEOUT_SECONDS: {{ .Values.sendrec.env.transcriptionTimeoutSeconds | default "" | quote }}
+  TRANSCRIPTION_PROVIDER: {{ .Values.sendrec.env.transcriptionProvider | quote }}
+  TRANSCRIPTION_API_URL: {{ .Values.sendrec.env.transcriptionApiUrl | quote }}
+  TRANSCRIPTION_MODEL: {{ .Values.sendrec.env.transcriptionModel | quote }}
+  TRANSCRIPTION_TIMEOUT_SECONDS: {{ .Values.sendrec.env.transcriptionTimeoutSeconds | quote }}
   WHISPER_MODEL_PATH: {{ .Values.sendrec.env.whisperModelPath | quote }}
   AI_ENABLED: {{ .Values.sendrec.env.aiEnabled | quote }}
   AI_BASE_URL: {{ .Values.sendrec.env.aiBaseUrl | quote }}

--- a/helm/sendrec/templates/deployment.yaml
+++ b/helm/sendrec/templates/deployment.yaml
@@ -1,4 +1,5 @@
 {{- include "sendrec.validateRequired" . }}
+{{- $needsLocalWhisper := and (eq (toString .Values.sendrec.env.transcriptionEnabled) "true") (or (eq (toString .Values.sendrec.env.transcriptionProvider) "") (eq (toString .Values.sendrec.env.transcriptionProvider) "local")) -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -25,9 +26,9 @@ spec:
         checksum/secret: {{- if .Values.sendrec.existingSecret }} "external-secret" {{- else }} {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }} {{- end }}
         checksum/configmap: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
     spec:
-      {{- if or .Values.sendrec.deployment.extraInitContainers (and (eq (toString .Values.sendrec.env.transcriptionEnabled) "true") (eq (toString .Values.sendrec.env.transcriptionProvider) "local")) }}
+      {{- if or .Values.sendrec.deployment.extraInitContainers $needsLocalWhisper }}
       initContainers:
-        {{- if and (eq (toString .Values.sendrec.env.transcriptionEnabled) "true") (eq (toString .Values.sendrec.env.transcriptionProvider) "local") }}
+        {{- if $needsLocalWhisper }}
         - name: download-transcription-model
           image: {{ .Values.sendrec.transcription.initImage }}
           command:
@@ -70,9 +71,9 @@ spec:
             {{- toYaml .Values.sendrec.livenessProbe | nindent 12 }}
           readinessProbe:
             {{- toYaml .Values.sendrec.readinessProbe | nindent 12 }}
-          {{- if or .Values.sendrec.deployment.extraVolumeMounts (and (eq (toString .Values.sendrec.env.transcriptionEnabled) "true") (eq (toString .Values.sendrec.env.transcriptionProvider) "local")) }}
+          {{- if or .Values.sendrec.deployment.extraVolumeMounts $needsLocalWhisper }}
           volumeMounts:
-            {{- if and (eq (toString .Values.sendrec.env.transcriptionEnabled) "true") (eq (toString .Values.sendrec.env.transcriptionProvider) "local") }}
+            {{- if $needsLocalWhisper }}
             - name: whisper-models
               mountPath: /models
             {{- end }}
@@ -80,9 +81,9 @@ spec:
             {{- toYaml . | nindent 12 }}
             {{- end }}
           {{- end }}
-      {{- if or .Values.sendrec.deployment.extraVolumes (and (eq (toString .Values.sendrec.env.transcriptionEnabled) "true") (eq (toString .Values.sendrec.env.transcriptionProvider) "local")) }}
+      {{- if or .Values.sendrec.deployment.extraVolumes $needsLocalWhisper }}
       volumes:
-        {{- if and (eq (toString .Values.sendrec.env.transcriptionEnabled) "true") (eq (toString .Values.sendrec.env.transcriptionProvider) "local") }}
+        {{- if $needsLocalWhisper }}
         - name: whisper-models
           {{- if eq .Values.sendrec.transcription.type "volume" }}
           persistentVolumeClaim:

--- a/helm/sendrec/templates/deployment.yaml
+++ b/helm/sendrec/templates/deployment.yaml
@@ -25,9 +25,9 @@ spec:
         checksum/secret: {{- if .Values.sendrec.existingSecret }} "external-secret" {{- else }} {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }} {{- end }}
         checksum/configmap: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
     spec:
-      {{- if or .Values.sendrec.deployment.extraInitContainers (include "sendrec.needsLocalWhisper" .) }}
+      {{- if or .Values.sendrec.deployment.extraInitContainers (and (eq (toString .Values.sendrec.env.transcriptionEnabled) "true") (eq (toString .Values.sendrec.env.transcriptionProvider) "local")) }}
       initContainers:
-        {{- if include "sendrec.needsLocalWhisper" . }}
+        {{- if and (eq (toString .Values.sendrec.env.transcriptionEnabled) "true") (eq (toString .Values.sendrec.env.transcriptionProvider) "local") }}
         - name: download-transcription-model
           image: {{ .Values.sendrec.transcription.initImage }}
           command:
@@ -70,9 +70,9 @@ spec:
             {{- toYaml .Values.sendrec.livenessProbe | nindent 12 }}
           readinessProbe:
             {{- toYaml .Values.sendrec.readinessProbe | nindent 12 }}
-          {{- if or .Values.sendrec.deployment.extraVolumeMounts (include "sendrec.needsLocalWhisper" .) }}
+          {{- if or .Values.sendrec.deployment.extraVolumeMounts (and (eq (toString .Values.sendrec.env.transcriptionEnabled) "true") (eq (toString .Values.sendrec.env.transcriptionProvider) "local")) }}
           volumeMounts:
-            {{- if include "sendrec.needsLocalWhisper" . }}
+            {{- if and (eq (toString .Values.sendrec.env.transcriptionEnabled) "true") (eq (toString .Values.sendrec.env.transcriptionProvider) "local") }}
             - name: whisper-models
               mountPath: /models
             {{- end }}
@@ -80,9 +80,9 @@ spec:
             {{- toYaml . | nindent 12 }}
             {{- end }}
           {{- end }}
-      {{- if or .Values.sendrec.deployment.extraVolumes (include "sendrec.needsLocalWhisper" .) }}
+      {{- if or .Values.sendrec.deployment.extraVolumes (and (eq (toString .Values.sendrec.env.transcriptionEnabled) "true") (eq (toString .Values.sendrec.env.transcriptionProvider) "local")) }}
       volumes:
-        {{- if include "sendrec.needsLocalWhisper" . }}
+        {{- if and (eq (toString .Values.sendrec.env.transcriptionEnabled) "true") (eq (toString .Values.sendrec.env.transcriptionProvider) "local") }}
         - name: whisper-models
           {{- if eq .Values.sendrec.transcription.type "volume" }}
           persistentVolumeClaim:

--- a/helm/sendrec/templates/persistentvolumeclaim.yaml
+++ b/helm/sendrec/templates/persistentvolumeclaim.yaml
@@ -1,4 +1,4 @@
-{{- if and (include "sendrec.needsLocalWhisper" .) (eq .Values.sendrec.transcription.type "volume") }}
+{{- if and (eq (toString .Values.sendrec.env.transcriptionEnabled) "true") (eq (toString .Values.sendrec.env.transcriptionProvider) "local") (eq .Values.sendrec.transcription.type "volume") }}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:

--- a/helm/sendrec/templates/persistentvolumeclaim.yaml
+++ b/helm/sendrec/templates/persistentvolumeclaim.yaml
@@ -1,4 +1,5 @@
-{{- if and (eq (toString .Values.sendrec.env.transcriptionEnabled) "true") (eq (toString .Values.sendrec.env.transcriptionProvider) "local") (eq .Values.sendrec.transcription.type "volume") }}
+{{- $needsLocalWhisper := and (eq (toString .Values.sendrec.env.transcriptionEnabled) "true") (or (eq (toString .Values.sendrec.env.transcriptionProvider) "") (eq (toString .Values.sendrec.env.transcriptionProvider) "local")) -}}
+{{- if and $needsLocalWhisper (eq .Values.sendrec.transcription.type "volume") }}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:

--- a/helm/sendrec/templates/secret.yaml
+++ b/helm/sendrec/templates/secret.yaml
@@ -18,7 +18,7 @@ stringData:
   GITHUB_SSO_CLIENT_ID: {{ .Values.sendrec.secrets.githubSsoClientId | quote }}
   GITHUB_SSO_CLIENT_SECRET: {{ .Values.sendrec.secrets.githubSsoClientSecret | quote }}
   AI_API_KEY: {{ .Values.sendrec.secrets.aiApiKey | quote }}
-  TRANSCRIPTION_API_KEY: {{ .Values.sendrec.secrets.transcriptionApiKey | default "" | quote }}
+  TRANSCRIPTION_API_KEY: {{ .Values.sendrec.secrets.transcriptionApiKey | quote }}
   LISTMONK_USER: {{ .Values.sendrec.secrets.listmonkUsername | quote }}
   LISTMONK_PASSWORD: {{ .Values.sendrec.secrets.listmonkPassword | quote }}
   SMTP_USERNAME: {{ .Values.sendrec.secrets.smtpUsername | quote }}

--- a/helm/sendrec/values.yaml
+++ b/helm/sendrec/values.yaml
@@ -19,14 +19,6 @@ sendrec:
     extraVolumes: []         # pod-level volumes
     extraVolumeMounts: []    # mounts on the main sendrec container
 
-  # Transcription model configuration, activation is controlled by env.transcriptionEnabled
-  transcription:
-    type: emptyDir           # volume type: emptyDir or volume (persistent volume)
-    size: 1Gi                # max size for the model volume (for emptyDir) or PVC storage request (for volume)
-    initImage: alpine/curl:8.17.0  # image for the model download init container
-    modelUrl: https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-small.bin
-    modelPath: /models/ggml-small.bin
-
   env:
     baseUrl: "https://sendrec.yourdomain.com"
 
@@ -114,6 +106,14 @@ sendrec:
 
   # Use an existing Kubernetes Secret name instead of creating upper secret
   existingSecret: ""
+
+# Transcription model configuration, activation is controlled by env.transcriptionEnabled + env.transcriptionProvider=local
+  transcription:
+    type: emptyDir           # volume type: emptyDir or volume (persistent volume)
+    size: 1Gi                # max size for the model volume (for emptyDir) or PVC storage request (for volume)
+    initImage: alpine/curl:8.17.0  # image for the model download init container
+    modelUrl: https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-small.bin
+    modelPath: /models/ggml-small.bin
 
   port: 8080
 


### PR DESCRIPTION
## What does this PR do?

This PR refactors Helm template logic for transcription-related resources to use direct condition checks in templates instead of helper-template includes.

The goal is to make rendering behavior explicit and predictable. It is better to use direct Helm checks than helper templates with includes here, because direct checks are easier to reason about, easier to debug, and avoid string/truthiness edge cases from include output.

What changed
- Replaced include-based local-whisper gating with direct checks:
  - transcription enabled = true
  - transcription provider = local
- Applied the direct checks consistently across:
  - init container creation
  - volume mounts
  - volumes
  - PVC creation
- Removed fallback defaults from transcription env/secret (as default vars are already `""`, no need in double-check).
- Moved values for transcription (after env and secret), updated its comment to clarify that local model resources are enabled only when transcription is enabled and provider is local.

Why
- Direct checks improve template clarity and reduce indirection.
- Logic is now visible at each usage site, which simplifies maintenance.
- Avoids relying on helper include return values for boolean decisions.
- Makes future review of chart behavior faster and safer.

Behavior impact
- No intended functional change to when local whisper resources are created.
- Template logic is now explicit in-place, with equivalent gating conditions.
- Transcription-related values are now consumed directly rather than via default fallbacks in templates.

## Checklist
- [x] ~`make test` passes~
- [x] ~`make build` succeeds~
- [x] ~New code has tests where applicable~
- [x] No unrelated changes included
