### PR TITLE
ci+test: gate preview deploy on fork PRs, block real sendmail in tests

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -16,9 +16,38 @@ env:
   PREVIEW_DOMAIN: pr-${{ github.event.pull_request.number }}.app.sendrec.eu
 
 jobs:
+  skip-fork:
+    if: >-
+      github.event.action != 'closed' &&
+      github.event.pull_request.head.repo.full_name != github.repository
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Comment that preview is skipped
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const prNumber = context.payload.pull_request.number;
+            const body = 'Preview deploy skipped: PR is from a fork. A maintainer can deploy a preview manually after review.\n<!-- coolify-preview-skipped -->';
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+            });
+            const existing = comments.find(c => c.body.includes('<!-- coolify-preview-skipped -->'));
+            if (existing) return;
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+              body,
+            });
+
   deploy:
     if: >-
       github.event.action != 'closed' &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
       github.event.pull_request.author_association != 'NONE' &&
       github.event.pull_request.author_association != 'FIRST_TIMER' &&
       github.event.pull_request.author_association != 'FIRST_TIME_CONTRIBUTOR'
@@ -158,6 +187,7 @@ jobs:
   teardown:
     if: >-
       github.event.action == 'closed' &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
       github.event.pull_request.author_association != 'NONE' &&
       github.event.pull_request.author_association != 'FIRST_TIMER' &&
       github.event.pull_request.author_association != 'FIRST_TIME_CONTRIBUTOR'

--- a/internal/email/email_test.go
+++ b/internal/email/email_test.go
@@ -6,9 +6,20 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"strings"
 	"testing"
 )
+
+// TestMain blanks PATH for the whole package so no test can ever invoke the
+// real sendmail(8) binary on a dev machine. Tests that need the sendmail
+// fallback path simulate availability via the unexported sendmailAvailable
+// flag; the actual exec.LookPath inside sendViaSendmail then fails and the
+// fallback returns nil gracefully.
+func TestMain(m *testing.M) {
+	_ = os.Setenv("PATH", "")
+	os.Exit(m.Run())
+}
 
 func TestSendPasswordReset_Success(t *testing.T) {
 	var receivedBody txRequest
@@ -61,8 +72,6 @@ func TestSendPasswordReset_Success(t *testing.T) {
 }
 
 func TestSendPasswordReset_ServerError_FallsBackToSendmail(t *testing.T) {
-	t.Setenv("PATH", "") // prevent real sendmail from being invoked
-
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/api/subscribers" {
 			w.WriteHeader(http.StatusOK)
@@ -1149,9 +1158,9 @@ func TestSendmail_FallbackWhenNoListmonk(t *testing.T) {
 		SendmailEnabled: true,
 	})
 
-	// Without Listmonk, sendmail fallback is attempted.
-	// If sendmail is not available, it gracefully returns nil.
-	// If sendmail IS available (macOS), it sends the email.
+	// Without Listmonk, sendmail fallback is attempted; PATH is blanked in
+	// TestMain so the exec.LookPath inside sendViaSendmail fails and the
+	// fallback returns nil gracefully.
 	err := client.SendPasswordReset(context.Background(),
 		"alice@example.com", "Alice", "https://example.com/reset")
 	if err != nil {


### PR DESCRIPTION
## Summary

- **CI:** PR #152 preview deploy failed because fork PRs do not receive `environment: staging` secrets, so the Coolify API curl returned an empty body and the python `json.load` raised `Expecting value: line 1 column 1`. Gate `deploy` and `teardown` on `head.repo == base.repo`, and add a `skip-fork` job that comments on fork PRs explaining a maintainer must deploy the preview manually.
- **Tests:** A few tests in `internal/email` force `sendmailAvailable=true` to exercise the fallback path. On a dev machine with sendmail on PATH this dispatched real mail into the local `/var/mail` spool. Blank PATH in `TestMain` so `exec.LookPath` inside `sendViaSendmail` always fails and the fallback returns nil gracefully across the whole package.

## Test plan

- [ ] Re-run failed run on PR #152 — expect `deploy` job to be skipped and a comment posted by `skip-fork`
- [ ] Open a same-repo branch PR — expect `deploy` job to run as before
- [ ] `go test ./internal/email/...` passes
- [ ] After running email tests on macOS, `mail -e` exits non-zero (spool empty)