### PR TITLE
ci(deploy-preview): surface fork-skip via job summary, not PR comment

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -17,32 +17,17 @@ env:
 
 jobs:
   skip-fork:
+    # Fork PRs run with a read-only GITHUB_TOKEN, so we cannot comment back.
+    # Surface the skip via the job summary instead; the CI status already
+    # tells contributors a maintainer must deploy the preview manually.
     if: >-
       github.event.action != 'closed' &&
       github.event.pull_request.head.repo.full_name != github.repository
     runs-on: ubuntu-latest
-    permissions:
-      pull-requests: write
     steps:
-      - name: Comment that preview is skipped
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const prNumber = context.payload.pull_request.number;
-            const body = 'Preview deploy skipped: PR is from a fork. A maintainer can deploy a preview manually after review.\n<!-- coolify-preview-skipped -->';
-            const { data: comments } = await github.rest.issues.listComments({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: prNumber,
-            });
-            const existing = comments.find(c => c.body.includes('<!-- coolify-preview-skipped -->'));
-            if (existing) return;
-            await github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: prNumber,
-              body,
-            });
+      - name: Note that preview is skipped
+        run: |
+          echo "Preview deploy skipped: PR is from a fork. A maintainer can deploy a preview manually after review." >> "$GITHUB_STEP_SUMMARY"
 
   deploy:
     if: >-


### PR DESCRIPTION
## Summary

Follow-up to #153. Fork PRs run with a read-only `GITHUB_TOKEN`, so the `github-script` step in the `skip-fork` job failed with `HttpError: Resource not accessible by integration` when trying to post a comment. Write the message to `GITHUB_STEP_SUMMARY` instead; the CI status already signals the skip to contributors.

## Test plan

- [x] Re-run the failed run on PR #152 — expect `skip-fork` to succeed and write to job summary
- [x] Open a same-repo branch PR — expect `deploy` job to run as before