### PR TITLE
fix(player): render captions in a custom overlay above the controls

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -49,12 +49,19 @@ jobs:
           COOLIFY_SERVER_UUID: ${{ secrets.COOLIFY_SERVER_UUID }}
           COOLIFY_DESTINATION_UUID: ${{ secrets.COOLIFY_DESTINATION_UUID }}
           COOLIFY_SENDREC_STAGING_UUID: ${{ secrets.COOLIFY_SENDREC_STAGING_UUID }}
+          CF_ACCESS_CLIENT_ID: ${{ secrets.CF_ACCESS_CLIENT_ID }}
+          CF_ACCESS_CLIENT_SECRET: ${{ secrets.CF_ACCESS_CLIENT_SECRET }}
         run: |
           APP_NAME="sendrec-pr-${{ env.PR_NUMBER }}"
 
-          # Check if app already exists
-          EXISTING=$(curl -sf "$COOLIFY_API_URL/applications" \
-            -H "Authorization: Bearer $COOLIFY_API_TOKEN" | \
+          # Cloudflare Access fronts the Coolify API; every call must carry the
+          # service-token headers or it is redirected to an HTML login page.
+          CF_HDR=(-H "CF-Access-Client-Id: $CF_ACCESS_CLIENT_ID" -H "CF-Access-Client-Secret: $CF_ACCESS_CLIENT_SECRET")
+
+          # Check if app already exists. -fsS makes curl fail loudly (non-empty
+          # stderr, no silent empty body that would crash the json parser).
+          EXISTING=$(curl -fsS "$COOLIFY_API_URL/applications" \
+            -H "Authorization: Bearer $COOLIFY_API_TOKEN" "${CF_HDR[@]}" | \
             python3 -c "
           import json, sys
           apps = json.load(sys.stdin)
@@ -69,16 +76,16 @@ jobs:
             echo "Found existing app: $EXISTING"
 
             # Update branch
-            curl -sf -X PATCH "$COOLIFY_API_URL/applications/$EXISTING" \
-              -H "Authorization: Bearer $COOLIFY_API_TOKEN" \
+            curl -fsS -X PATCH "$COOLIFY_API_URL/applications/$EXISTING" \
+              -H "Authorization: Bearer $COOLIFY_API_TOKEN" "${CF_HDR[@]}" \
               -H "Content-Type: application/json" \
               -d "{\"git_branch\": \"${{ github.head_ref }}\"}"
           else
             echo "Creating new preview app: $APP_NAME"
 
             # Create app
-            UUID=$(curl -sf -X POST "$COOLIFY_API_URL/applications/private-github-app" \
-              -H "Authorization: Bearer $COOLIFY_API_TOKEN" \
+            UUID=$(curl -fsS -X POST "$COOLIFY_API_URL/applications/private-github-app" \
+              -H "Authorization: Bearer $COOLIFY_API_TOKEN" "${CF_HDR[@]}" \
               -H "Content-Type: application/json" \
               -d "{
                 \"project_uuid\": \"$COOLIFY_PROJECT_UUID\",
@@ -99,8 +106,8 @@ jobs:
             echo "Created app: $UUID"
 
             # Configure dockerfile location and model volume
-            curl -sf -X PATCH "$COOLIFY_API_URL/applications/$UUID" \
-              -H "Authorization: Bearer $COOLIFY_API_TOKEN" \
+            curl -fsS -X PATCH "$COOLIFY_API_URL/applications/$UUID" \
+              -H "Authorization: Bearer $COOLIFY_API_TOKEN" "${CF_HDR[@]}" \
               -H "Content-Type: application/json" \
               -d '{"dockerfile_location": "/Dockerfile", "custom_docker_run_options": "-v /opt/sendrec/models:/models:ro"}'
 
@@ -113,7 +120,13 @@ jobs:
           STAGING = "$COOLIFY_SENDREC_STAGING_UUID"
           APP = "$UUID"
           DOMAIN = "${{ env.PREVIEW_DOMAIN }}"
-          headers = {"Authorization": f"Bearer {TOKEN}", "Content-Type": "application/json", "User-Agent": "github-actions"}
+          headers = {
+              "Authorization": f"Bearer {TOKEN}",
+              "Content-Type": "application/json",
+              "User-Agent": "github-actions",
+              "CF-Access-Client-Id": "$CF_ACCESS_CLIENT_ID",
+              "CF-Access-Client-Secret": "$CF_ACCESS_CLIENT_SECRET",
+          }
 
           # Fetch staging env vars
           req = urllib.request.Request(f"{API}/applications/{STAGING}/envs", headers=headers)
@@ -136,8 +149,10 @@ jobs:
 
       - name: Deploy preview via Coolify
         run: |
-          curl -sf -X GET "${{ secrets.COOLIFY_API_URL }}/deploy?uuid=${{ steps.app.outputs.uuid }}&force=true" \
-            -H "Authorization: Bearer ${{ secrets.COOLIFY_API_TOKEN }}"
+          curl -fsS -X GET "${{ secrets.COOLIFY_API_URL }}/deploy?uuid=${{ steps.app.outputs.uuid }}&force=true" \
+            -H "Authorization: Bearer ${{ secrets.COOLIFY_API_TOKEN }}" \
+            -H "CF-Access-Client-Id: ${{ secrets.CF_ACCESS_CLIENT_ID }}" \
+            -H "CF-Access-Client-Secret: ${{ secrets.CF_ACCESS_CLIENT_SECRET }}"
 
       - name: Comment PR with preview URL
         uses: actions/github-script@v7
@@ -183,11 +198,15 @@ jobs:
         env:
           COOLIFY_API_URL: ${{ secrets.COOLIFY_API_URL }}
           COOLIFY_API_TOKEN: ${{ secrets.COOLIFY_API_TOKEN }}
+          CF_ACCESS_CLIENT_ID: ${{ secrets.CF_ACCESS_CLIENT_ID }}
+          CF_ACCESS_CLIENT_SECRET: ${{ secrets.CF_ACCESS_CLIENT_SECRET }}
         run: |
           APP_NAME="sendrec-pr-${{ env.PR_NUMBER }}"
 
-          UUID=$(curl -sf "$COOLIFY_API_URL/applications" \
-            -H "Authorization: Bearer $COOLIFY_API_TOKEN" | \
+          CF_HDR=(-H "CF-Access-Client-Id: $CF_ACCESS_CLIENT_ID" -H "CF-Access-Client-Secret: $CF_ACCESS_CLIENT_SECRET")
+
+          UUID=$(curl -fsS "$COOLIFY_API_URL/applications" \
+            -H "Authorization: Bearer $COOLIFY_API_TOKEN" "${CF_HDR[@]}" | \
             python3 -c "
           import json, sys
           apps = json.load(sys.stdin)
@@ -199,8 +218,8 @@ jobs:
 
           if [ -n "$UUID" ]; then
             echo "Deleting preview app: $UUID ($APP_NAME)"
-            curl -sf -X DELETE "$COOLIFY_API_URL/applications/$UUID" \
-              -H "Authorization: Bearer $COOLIFY_API_TOKEN"
+            curl -fsS -X DELETE "$COOLIFY_API_URL/applications/$UUID" \
+              -H "Authorization: Bearer $COOLIFY_API_TOKEN" "${CF_HDR[@]}"
           else
             echo "No preview app found for $APP_NAME"
           fi

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ COPY web/ .
 RUN pnpm build
 
 # Stage 2: Build Go binary
-FROM golang:1.26.3-alpine AS backend
+FROM golang:1.26.4-alpine AS backend
 WORKDIR /app
 COPY go.mod go.sum ./
 RUN go mod download

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/sendrec/sendrec
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.41.1
@@ -10,7 +10,7 @@ require (
 	github.com/coreos/go-oidc/v3 v3.17.0
 	github.com/crewjam/saml v0.5.1
 	github.com/go-chi/chi/v5 v5.2.5
-	github.com/go-jose/go-jose/v4 v4.1.3
+	github.com/go-jose/go-jose/v4 v4.1.4
 	github.com/golang-jwt/jwt/v5 v5.3.1
 	github.com/golang-migrate/migrate/v4 v4.19.1
 	github.com/jackc/pgx/v5 v5.8.0

--- a/go.sum
+++ b/go.sum
@@ -67,8 +67,8 @@ github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/go-chi/chi/v5 v5.2.5 h1:Eg4myHZBjyvJmAFjFvWgrqDTXFyOzjj7YIm3L3mu6Ug=
 github.com/go-chi/chi/v5 v5.2.5/go.mod h1:X7Gx4mteadT3eDOMTsXzmI4/rwUpOwBHLpAfupzFJP0=
-github.com/go-jose/go-jose/v4 v4.1.3 h1:CVLmWDhDVRa6Mi/IgCgaopNosCaHz7zrMeF9MlZRkrs=
-github.com/go-jose/go-jose/v4 v4.1.3/go.mod h1:x4oUasVrzR7071A4TnHLGSPpNOm2a21K9Kf04k1rs08=
+github.com/go-jose/go-jose/v4 v4.1.4 h1:moDMcTHmvE6Groj34emNPLs/qtYXRVcd6S7NHbHz3kA=
+github.com/go-jose/go-jose/v4 v4.1.4/go.mod h1:x4oUasVrzR7071A4TnHLGSPpNOm2a21K9Kf04k1rs08=
 github.com/go-logr/logr v1.4.3 h1:CjnDlHq8ikf6E492q6eKboGOC0T8CDaOvkHCIg8idEI=
 github.com/go-logr/logr v1.4.3/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
 github.com/go-logr/stdr v1.2.2 h1:hSWxHoqTgW2S2qGc0LTAI563KZ5YKYRhT3MFKZMbjag=

--- a/internal/video/embed_page_test.go
+++ b/internal/video/embed_page_test.go
@@ -146,6 +146,8 @@ func TestEmbedPage_Success_RendersVideoPlayer(t *testing.T) {
 		"video source":  `src="https://s3.example.com/video.webm"`,
 		"watch link":    `/watch/` + shareToken,
 		"watch on text": "Watch on",
+		"caption overlay": `id="caption-overlay"`,
+		"caption render":  "function bindCaptions()",
 	}
 	for name, want := range checks {
 		if !strings.Contains(body, want) {

--- a/internal/video/player_shared.go
+++ b/internal/video/player_shared.go
@@ -93,6 +93,31 @@ const playerCSS = `
             transition: opacity 0.3s;
         }
         .player-controls.hidden { opacity: 0; pointer-events: none; }
+        .caption-overlay {
+            position: absolute;
+            left: 0;
+            right: 0;
+            /* Must stay >= the .player-controls bar height (~60px) so captions clear it. */
+            bottom: 64px;
+            z-index: 2;
+            display: flex;
+            justify-content: center;
+            pointer-events: none;
+            padding: 0 5%;
+            text-align: center;
+            transition: bottom 0.3s;
+        }
+        .caption-overlay.controls-hidden { bottom: 24px; }
+        .caption-overlay:empty { display: none; }
+        .caption-overlay span {
+            background: rgba(0, 0, 0, 0.75);
+            color: #fff;
+            padding: 2px 8px;
+            border-radius: 4px;
+            font-size: clamp(14px, 2.5vw, 22px);
+            line-height: 1.35;
+            white-space: pre-line;
+        }
         .ctrl-btn {
             background: none;
             border: none;
@@ -357,6 +382,7 @@ const playerControlsHTML = `
                 </div>
                 <div class="player-spinner" id="player-spinner"></div>
                 <div class="player-error" id="player-error"><div class="player-error-icon">&#9888;</div>Video failed to load</div>
+                <div class="caption-overlay" id="caption-overlay" aria-live="polite"></div>
                 <div class="player-controls" id="player-controls">
                     <button class="ctrl-btn" id="play-btn" aria-label="Play">&#9654;</button>
                     <span class="time-display" id="time-current">0:00</span>
@@ -700,14 +726,66 @@ const playerJS = `
         updatePlayBtn();
         updateMuteBtn();
 
-        // iOS Safari: fall back to native controls.
-        // Custom controls have touch/playback issues on iOS; native controls work reliably.
+        // Captions: render cues into a custom overlay instead of native <track> display.
+        // Native cues anchor to the bottom of the video content box, which on a letterboxed
+        // (e.g. 4:3) source lands behind the controls bar and gets clipped. Owning the render
+        // lets us position captions above the controls, consistently across Chrome/Firefox.
         var isIOS = /iPad|iPhone|iPod/.test(navigator.userAgent) ||
                     (navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1);
+        var captionOverlay = document.getElementById('caption-overlay');
+        var subTrack = null;
+        function escapeHtml(s) {
+            return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+        }
+        function renderCues() {
+            if (!subTrack || !captionOverlay) return;
+            var html = '', cues = subTrack.activeCues;
+            for (var j = 0; cues && j < cues.length; j++) {
+                html += '<span>' + escapeHtml(cues[j].text) + '</span>';
+            }
+            captionOverlay.innerHTML = html;
+        }
+        function bindCaptions() {
+            if (subTrack) { subTrack.removeEventListener('cuechange', renderCues); subTrack = null; }
+            if (captionOverlay) captionOverlay.innerHTML = '';
+            for (var i = 0; i < player.textTracks.length; i++) {
+                var t = player.textTracks[i];
+                if (t.kind === 'subtitles' || t.kind === 'captions') { subTrack = t; break; }
+            }
+            if (subTrack) {
+                subTrack.mode = 'hidden';
+                subTrack.addEventListener('cuechange', renderCues);
+                renderCues();
+            }
+        }
+        bindCaptions();
+
+        // Keep captions clear of the controls bar: drop them when the bar auto-hides.
+        function syncCaptionOffset() {
+            if (!captionOverlay) return;
+            captionOverlay.classList.toggle('controls-hidden', controls.classList.contains('hidden'));
+        }
+        if (typeof MutationObserver !== 'undefined') {
+            new MutationObserver(syncCaptionOffset).observe(controls, { attributes: true, attributeFilter: ['class'] });
+        }
+
+        // Picture-in-Picture strips page CSS, so let the browser draw native cues there.
+        player.addEventListener('enterpictureinpicture', function() {
+            if (subTrack) subTrack.mode = 'showing';
+            if (captionOverlay) captionOverlay.innerHTML = '';
+        });
+        player.addEventListener('leavepictureinpicture', function() {
+            if (subTrack && !isIOS) { subTrack.mode = 'hidden'; renderCues(); }
+        });
+
+        // iOS Safari: fall back to native controls.
+        // Custom controls have touch/playback issues on iOS; native controls work reliably.
         if (isIOS) {
             player.setAttribute('controls', '');
             controls.style.display = 'none';
             overlay.style.display = 'none';
+            if (subTrack) subTrack.mode = 'showing';
+            if (captionOverlay) captionOverlay.style.display = 'none';
         }
 `
 
@@ -845,6 +923,7 @@ const playlistJS = `
 
             player.src = v.videoUrl;
             player.load();
+            bindCaptions();
             player.play().catch(function() {});
             listItems.forEach(function(li) {
                 li.classList.toggle('active', parseInt(li.getAttribute('data-index'), 10) === index);

--- a/internal/video/watch_page.go
+++ b/internal/video/watch_page.go
@@ -138,6 +138,8 @@ var watchPageTemplate = template.Must(template.New("watch").Funcs(watchFuncs).Pa
         }
         video {
             width: 100%;
+            height: 100%;
+            object-fit: contain;
             display: block;
             background: #000;
         }

--- a/internal/video/watch_page_test.go
+++ b/internal/video/watch_page_test.go
@@ -189,6 +189,12 @@ func TestWatchPage_Success_RendersVideoPlayer(t *testing.T) {
 		"spinner":         "player-spinner",
 		"error overlay":   "player-error",
 		"seek tooltip":    "seek-time-tooltip",
+		"caption overlay": `id="caption-overlay"`,
+		"caption css":     ".caption-overlay",
+		"caption render":  "function bindCaptions()",
+		"cue listener":    "'cuechange'",
+		"hidden track":    "subTrack.mode = 'hidden'",
+		"object-fit":      "object-fit: contain",
 	}
 	for name, want := range checks {
 		if !strings.Contains(body, want) {


### PR DESCRIPTION
## Summary
- Closes #155
- Native `<track>` cues anchor to the bottom of the video content box. On a letterboxed (e.g. 4:3) source the video box overflows the 16:9 container and the cue band lands **behind the custom controls bar** (`z-index:3`) and is clipped by `overflow:hidden` — captions render under/behind the controls in Chrome and Firefox, in-page and fullscreen. PiP was unaffected (it strips page CSS).
- **The reporter's 4:3-source theory is a red herring** — the video pixels render fine everywhere; it's a caption *positioning* + page-layout bug. 4:3 is the trigger (taller box → worse clip), not the cause.

## Fix
- Stop using native cue rendering on the custom-controls players: set the subtitle track `mode='hidden'` and render `activeCues` into a dedicated `.caption-overlay` div (`z-index:2`, above video, below controls) via the `cuechange` event. Pure TextTrack API → identical in Chrome and Firefox; `::cue` can't reliably reposition cues cross-browser, so we own the render instead.
- Captions sit clear of the controls bar and follow the auto-hide (drop to `bottom:24px` when controls fade).
- `object-fit:contain` + `height:100%` on the watch-page video so 4:3 letterboxes inside the container instead of overflow-clipping — consistent with the embed player.
- PiP toggles the track back to native `showing`; iOS keeps native controls + native captions.
- Shared in `player_shared.go` → watch + embed both fixed from one code path; playlist machinery runs but no-ops (no `<track>` there yet).

## No data change
`segmentsToVTT` is **untouched** — no VTT change, no re-transcode, no S3 backfill. Downloadable VTT and the transcript panel are unaffected. (This is why the overlay approach was chosen over baking `line:` cue settings into the VTT.)

## Test plan
- [x] Render assertions: `.caption-overlay` div + CSS + `bindCaptions`/`cuechange`/`mode='hidden'` JS present on watch & embed; `object-fit: contain` on watch video
- [x] VTT golden test unchanged (proves data layer untouched)
- [x] `go test ./internal/video/` + `go vet` clean

## Manual browser check (not automatable here — please verify)
- [ ] 4:3 source, in-page, **Chrome + Firefox** — captions above controls, never clipped
- [ ] Same, fullscreen, Chrome + Firefox
- [ ] PiP enter/leave (Chrome) — native cues in PiP window, overlay restored on leave
- [ ] Controls auto-hide drops captions to `bottom:24px`
- [ ] 16:9 source unchanged; no-`<track>` video has no overlay

## Known limitation
WebVTT inline tags (`<b>`, `<i>`, `<v Speaker>`) now render literally — transcription output is plain text, so no current impact. Security-safe direction (literal > interpreted).

---
Researched, designed, implemented, and adversarially verified via a 4-phase multi-agent workflow.