### PR TITLE
feat: upload Teams/Zoom VTT transcripts

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/go-jose/go-jose/v4 v4.1.4
 	github.com/golang-jwt/jwt/v5 v5.3.1
 	github.com/golang-migrate/migrate/v4 v4.19.1
-	github.com/jackc/pgx/v5 v5.8.0
+	github.com/jackc/pgx/v5 v5.9.2
 	github.com/mssola/useragent v1.0.0
 	github.com/oschwald/maxminddb-golang v1.13.1
 	github.com/pashagolub/pgxmock/v4 v4.9.0

--- a/go.sum
+++ b/go.sum
@@ -87,8 +87,8 @@ github.com/jackc/pgpassfile v1.0.0 h1:/6Hmqy13Ss2zCq62VdNG8tM1wchn8zjSGOBJ6icpsI
 github.com/jackc/pgpassfile v1.0.0/go.mod h1:CEx0iS5ambNFdcRtxPj5JhEz+xB6uRky5eyVu/W2HEg=
 github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 h1:iCEnooe7UlwOQYpKFhBabPMi4aNAfoODPEFNiAnClxo=
 github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761/go.mod h1:5TJZWKEWniPve33vlWYSoGYefn3gLQRzjfDlhSJ9ZKM=
-github.com/jackc/pgx/v5 v5.8.0 h1:TYPDoleBBme0xGSAX3/+NujXXtpZn9HBONkQC7IEZSo=
-github.com/jackc/pgx/v5 v5.8.0/go.mod h1:QVeDInX2m9VyzvNeiCJVjCkNFqzsNb43204HshNSZKw=
+github.com/jackc/pgx/v5 v5.9.2 h1:3ZhOzMWnR4yJ+RW1XImIPsD1aNSz4T4fyP7zlQb56hw=
+github.com/jackc/pgx/v5 v5.9.2/go.mod h1:mal1tBGAFfLHvZzaYh77YS/eC6IX9OWbRV1QIIM0Jn4=
 github.com/jackc/puddle/v2 v2.2.2 h1:PR8nw+E/1w0GLuRFSmiioY6UooMp6KJv0/61nB7icHo=
 github.com/jackc/puddle/v2 v2.2.2/go.mod h1:vriiEXHvEE654aYKXXjOvZM39qJ0q+azkZFrfEOc3H4=
 github.com/jonboulle/clockwork v0.5.0 h1:Hyh9A8u51kptdkR+cqRpT1EebBwTn1oK9YfGYbdFz6I=

--- a/internal/docs/docs_test.go
+++ b/internal/docs/docs_test.go
@@ -69,6 +69,7 @@ func TestSpecContainsAllEndpoints(t *testing.T) {
 		"/api/videos/{id}/download",
 		"/api/videos/{id}/trim",
 		"/api/videos/{id}/retranscribe",
+		"/api/videos/{id}/transcript",
 		"/api/videos/{id}/password",
 		"/api/videos/{id}/comment-mode",
 		"/api/videos/{id}/comments",

--- a/internal/docs/openapi.yaml
+++ b/internal/docs/openapi.yaml
@@ -2798,6 +2798,70 @@ paths:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
 
+  /api/videos/{id}/transcript:
+    post:
+      tags: [Videos]
+      summary: Upload a VTT transcript
+      description: Upload a pre-made WebVTT transcript (Teams/Zoom) to replace the existing one. Rate limited to 2 requests per second with a burst of 10.
+      operationId: uploadTranscript
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              properties:
+                file:
+                  type: string
+                  format: binary
+                  description: WebVTT file (max 5 MB)
+              required:
+                - file
+      responses:
+        "200":
+          description: Transcript uploaded successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  segments:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/TranscriptSegment"
+        "400":
+          description: Invalid file or request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "404":
+          description: Video not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+
   /api/videos/{id}/password:
     put:
       tags: [Videos]

--- a/internal/docs/openapi.yaml
+++ b/internal/docs/openapi.yaml
@@ -734,6 +734,9 @@ components:
           format: double
         text:
           type: string
+        speaker:
+          type: string
+          description: Speaker name, if present in the source transcript
 
     AnalyticsSummary:
       type: object

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -399,7 +399,6 @@ func (s *Server) routes() {
 				r.Get("/{id}/analytics", s.videoHandler.Analytics)
 				r.Get("/{id}/analytics/export", s.videoHandler.AnalyticsExport)
 				r.Get("/{id}/branding", s.videoHandler.GetVideoBranding)
-				r.Get("/{id}/transcript", s.videoHandler.GetTranscript)
 
 				// Write routes (viewer blocked)
 				r.Group(func(r chi.Router) {
@@ -441,16 +440,22 @@ func (s *Server) routes() {
 			})
 		})
 
-		// Separate route group: transcript uploads need a larger body-size cap
-		// than the rest of /api/videos, so it can't share that group's
-		// maxBodySize(64KB) middleware.
+		// Separate mounted subrouter: GET and POST /api/videos/{id}/transcript
+		// live together here so neither is shadowed by the other (a Route()
+		// subtree mounted at a path that collides with a sibling route
+		// registered inside the /api/videos group wins the routing decision
+		// for ALL methods at that path, 405-ing the sibling). Mounting both
+		// verbs in one subrouter also lets the POST route use a larger
+		// body-size cap without the /api/videos group's 64KB maxBodySize
+		// double-wrapping it (chi's With() adds middleware on top of,
+		// not instead of, the enclosing group's middleware).
 		s.router.Route("/api/videos/{id}/transcript", func(r chi.Router) {
 			r.Use(videoLimiter.Middleware)
-			r.Use(maxBodySize(video.MaxTranscriptUploadBytes + 1024))
 			r.Use(s.authHandler.Middleware)
 			r.Use(organization.Middleware(s.db))
-			r.Use(organization.RequireWriter)
-			r.Post("/", s.videoHandler.UploadTranscript)
+			r.Get("/", s.videoHandler.GetTranscript)
+			r.With(maxBodySize(video.MaxTranscriptUploadBytes+1024), organization.RequireWriter).
+				Post("/", s.videoHandler.UploadTranscript)
 		})
 
 		s.router.Route("/api/analytics", func(r chi.Router) {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -414,6 +414,7 @@ func (s *Server) routes() {
 					r.Post("/{id}/extend", s.videoHandler.Extend)
 					r.Post("/{id}/trim", s.videoHandler.Trim)
 					r.Post("/{id}/retranscribe", s.videoHandler.Retranscribe)
+					r.Post("/{id}/transcript", s.videoHandler.UploadTranscript)
 					r.Put("/{id}/password", s.videoHandler.SetPassword)
 					r.Put("/{id}/comment-mode", s.videoHandler.SetCommentMode)
 					r.Delete("/{id}/comments/{commentId}", s.videoHandler.DeleteComment)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -414,7 +414,6 @@ func (s *Server) routes() {
 					r.Post("/{id}/extend", s.videoHandler.Extend)
 					r.Post("/{id}/trim", s.videoHandler.Trim)
 					r.Post("/{id}/retranscribe", s.videoHandler.Retranscribe)
-					r.Post("/{id}/transcript", s.videoHandler.UploadTranscript)
 					r.Put("/{id}/password", s.videoHandler.SetPassword)
 					r.Put("/{id}/comment-mode", s.videoHandler.SetCommentMode)
 					r.Delete("/{id}/comments/{commentId}", s.videoHandler.DeleteComment)
@@ -440,6 +439,18 @@ func (s *Server) routes() {
 					}
 				})
 			})
+		})
+
+		// Separate route group: transcript uploads need a larger body-size cap
+		// than the rest of /api/videos, so it can't share that group's
+		// maxBodySize(64KB) middleware.
+		s.router.Route("/api/videos/{id}/transcript", func(r chi.Router) {
+			r.Use(videoLimiter.Middleware)
+			r.Use(maxBodySize(video.MaxTranscriptUploadBytes + 1024))
+			r.Use(s.authHandler.Middleware)
+			r.Use(organization.Middleware(s.db))
+			r.Use(organization.RequireWriter)
+			r.Post("/", s.videoHandler.UploadTranscript)
 		})
 
 		s.router.Route("/api/analytics", func(r chi.Router) {

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -14,6 +14,7 @@ import (
 	"testing/fstest"
 	"time"
 
+	pgx "github.com/jackc/pgx/v5"
 	"github.com/pashagolub/pgxmock/v4"
 	"github.com/sendrec/sendrec/internal/auth"
 	"github.com/sendrec/sendrec/internal/server"
@@ -358,6 +359,65 @@ func TestVideoListRouteRequiresAuth(t *testing.T) {
 	}
 	if rec.Code != http.StatusUnauthorized {
 		t.Errorf("expected 401 for unauthenticated video list, got %d", rec.Code)
+	}
+}
+
+func TestTranscriptRoutesDoNotShadow(t *testing.T) {
+	srv, mock := newServerWithDB(t)
+
+	token, err := auth.GenerateAccessToken("test-secret", "user-1")
+	if err != nil {
+		t.Fatalf("failed to generate access token: %v", err)
+	}
+
+	// GET must reach GetTranscript, not be shadowed by a separate Route
+	// subtree registered for POST under the same path.
+	mock.ExpectQuery(`SELECT transcript_status, transcript_json FROM videos WHERE id = \$1 AND user_id = \$2 AND organization_id IS NULL AND status != 'deleted'`).
+		WithArgs("video-1", "user-1").
+		WillReturnError(pgx.ErrNoRows)
+
+	getReq := httptest.NewRequest(http.MethodGet, "/api/videos/video-1/transcript", nil)
+	getReq.Header.Set("Authorization", "Bearer "+token)
+	getRec := httptest.NewRecorder()
+	srv.ServeHTTP(getRec, getReq)
+
+	if getRec.Code == http.StatusMethodNotAllowed {
+		t.Fatalf("GET /api/videos/{id}/transcript returned 405: shadowed by the POST-only route subtree")
+	}
+	if getRec.Code == http.StatusNotFound && strings.Contains(getRec.Body.String(), "404 page not found") {
+		t.Fatalf("GET /api/videos/{id}/transcript did not route to a handler at all: %d %s", getRec.Code, getRec.Body.String())
+	}
+
+	// POST must still reach UploadTranscript.
+	var buf bytes.Buffer
+	mw := multipart.NewWriter(&buf)
+	part, err := mw.CreateFormFile("file", "transcript.vtt")
+	if err != nil {
+		t.Fatalf("failed to create form file: %v", err)
+	}
+	if _, err := part.Write([]byte("not a vtt")); err != nil {
+		t.Fatalf("failed to write form file content: %v", err)
+	}
+	if err := mw.Close(); err != nil {
+		t.Fatalf("failed to close multipart writer: %v", err)
+	}
+
+	mock.ExpectQuery(`SELECT user_id, share_token FROM videos WHERE id = \$1 AND user_id = \$2 AND organization_id IS NULL AND status = 'ready'`).
+		WithArgs("video-1", "user-1").
+		WillReturnRows(pgxmock.NewRows([]string{"user_id", "share_token"}).AddRow("user-1", "tok"))
+
+	postReq := httptest.NewRequest(http.MethodPost, "/api/videos/video-1/transcript", &buf)
+	postReq.Header.Set("Content-Type", mw.FormDataContentType())
+	postReq.Header.Set("Authorization", "Bearer "+token)
+	postRec := httptest.NewRecorder()
+	srv.ServeHTTP(postRec, postReq)
+
+	if postRec.Code != http.StatusBadRequest || !strings.Contains(postRec.Body.String(), "invalid WebVTT file") {
+		t.Fatalf("expected POST to reach UploadTranscript (400 invalid WebVTT file), got %d %s", postRec.Code, postRec.Body.String())
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet pgxmock expectations: %v", err)
 	}
 }
 

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -1,10 +1,12 @@
 package server_test
 
 import (
+	"bytes"
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"errors"
+	"mime/multipart"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -13,6 +15,7 @@ import (
 	"time"
 
 	"github.com/pashagolub/pgxmock/v4"
+	"github.com/sendrec/sendrec/internal/auth"
 	"github.com/sendrec/sendrec/internal/server"
 )
 
@@ -355,6 +358,58 @@ func TestVideoListRouteRequiresAuth(t *testing.T) {
 	}
 	if rec.Code != http.StatusUnauthorized {
 		t.Errorf("expected 401 for unauthenticated video list, got %d", rec.Code)
+	}
+}
+
+func TestUploadTranscriptRouteAcceptsBodyOverGenericLimit(t *testing.T) {
+	srv, mock := newServerWithDB(t)
+
+	// The /api/videos group caps bodies at 64KB for every other route, but
+	// transcript uploads are allowed up to 5MB. A body comfortably over 64KB
+	// (well under 5MB) must reach the handler, not fail at the transport
+	// layer with "request body too large".
+	body := strings.Repeat("a", 200*1024)
+
+	var buf bytes.Buffer
+	mw := multipart.NewWriter(&buf)
+	part, err := mw.CreateFormFile("file", "transcript.vtt")
+	if err != nil {
+		t.Fatalf("failed to create form file: %v", err)
+	}
+	if _, err := part.Write([]byte(body)); err != nil {
+		t.Fatalf("failed to write form file content: %v", err)
+	}
+	if err := mw.Close(); err != nil {
+		t.Fatalf("failed to close multipart writer: %v", err)
+	}
+
+	token, err := auth.GenerateAccessToken("test-secret", "user-1")
+	if err != nil {
+		t.Fatalf("failed to generate access token: %v", err)
+	}
+
+	mock.ExpectQuery(`SELECT user_id, share_token FROM videos WHERE id = \$1 AND user_id = \$2 AND organization_id IS NULL AND status = 'ready'`).
+		WithArgs("video-1", "user-1").
+		WillReturnRows(pgxmock.NewRows([]string{"user_id", "share_token"}).AddRow("user-1", "tok"))
+
+	req := httptest.NewRequest(http.MethodPost, "/api/videos/video-1/transcript", &buf)
+	req.Header.Set("Content-Type", mw.FormDataContentType())
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if strings.Contains(rec.Body.String(), "request body too large") {
+		t.Fatalf("body was rejected by the generic 64KB limit instead of reaching the handler: %d %s", rec.Code, rec.Body.String())
+	}
+	// Body isn't valid WebVTT, so the handler should get past the size
+	// check and reject it with 400 "invalid WebVTT file", not fail earlier
+	// at the transport layer with a body-too-large error.
+	if rec.Code != http.StatusBadRequest || !strings.Contains(rec.Body.String(), "invalid WebVTT file") {
+		t.Fatalf("expected 400 invalid WebVTT file (proving the body was fully read), got %d %s", rec.Code, rec.Body.String())
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("expected handler to reach ownership query, proving body was not truncated: %v", err)
 	}
 }
 

--- a/internal/video/player_shared.go
+++ b/internal/video/player_shared.go
@@ -737,11 +737,24 @@ const playerJS = `
         function escapeHtml(s) {
             return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
         }
+        function cueParts(raw) {
+            // VTTCue.text is the raw payload including voice/span markup; pull
+            // the speaker out of a leading <v Name> tag and strip remaining tags.
+            var speaker = '', text = raw;
+            var v = /^<v\s+([^>]*)>/.exec(text);
+            if (v) { speaker = v[1]; text = text.slice(v[0].length); }
+            text = text.replace(/<\/?[^>]*>/g, '');
+            return { speaker: speaker, text: text };
+        }
         function renderCues() {
             if (!subTrack || !captionOverlay) return;
             var html = '', cues = subTrack.activeCues;
             for (var j = 0; cues && j < cues.length; j++) {
-                html += '<span>' + escapeHtml(cues[j].text) + '</span>';
+                var p = cueParts(cues[j].text);
+                var inner = p.speaker
+                    ? '<b>' + escapeHtml(p.speaker) + ':</b> ' + escapeHtml(p.text)
+                    : escapeHtml(p.text);
+                html += '<span>' + inner + '</span>';
             }
             captionOverlay.innerHTML = html;
         }

--- a/internal/video/transcribe.go
+++ b/internal/video/transcribe.go
@@ -93,6 +93,11 @@ func segmentsToVTT(segments []TranscriptSegment) string {
 		b.WriteString(" --> ")
 		b.WriteString(formatVTTTimestamp(seg.End))
 		b.WriteString("\n")
+		if seg.Speaker != "" {
+			b.WriteString("<v ")
+			b.WriteString(seg.Speaker)
+			b.WriteString(">")
+		}
 		b.WriteString(seg.Text)
 		b.WriteString("\n\n")
 	}

--- a/internal/video/transcribe.go
+++ b/internal/video/transcribe.go
@@ -14,9 +14,10 @@ import (
 )
 
 type TranscriptSegment struct {
-	Start float64 `json:"start"`
-	End   float64 `json:"end"`
-	Text  string  `json:"text"`
+	Start   float64 `json:"start"`
+	End     float64 `json:"end"`
+	Text    string  `json:"text"`
+	Speaker string  `json:"speaker,omitempty"`
 }
 
 func transcriptFileKey(userID, shareToken string) string {

--- a/internal/video/transcribe_vtt_test.go
+++ b/internal/video/transcribe_vtt_test.go
@@ -35,3 +35,16 @@ func TestSegmentsToVTT(t *testing.T) {
 		t.Errorf("segmentsToVTT mismatch:\ngot:  %q\nwant: %q", got, want)
 	}
 }
+
+func TestSegmentsToVTT_WithSpeaker(t *testing.T) {
+	got := segmentsToVTT([]TranscriptSegment{
+		{Start: 0, End: 1.5, Text: "Hello world", Speaker: "Alice"},
+		{Start: 1.5, End: 3, Text: "No speaker here"},
+	})
+	want := "WEBVTT\n\n" +
+		"00:00:00.000 --> 00:00:01.500\n<v Alice>Hello world\n\n" +
+		"00:00:01.500 --> 00:00:03.000\nNo speaker here\n\n"
+	if got != want {
+		t.Errorf("got:\n%q\nwant:\n%q", got, want)
+	}
+}

--- a/internal/video/video_query.go
+++ b/internal/video/video_query.go
@@ -269,8 +269,8 @@ func (h *Handler) List(w http.ResponseWriter, r *http.Request) {
 		args = append(args, "%"+escaped+"%")
 		baseQuery += fmt.Sprintf(` AND (v.title ILIKE $%d OR EXISTS (
 			SELECT 1 FROM jsonb_array_elements(v.transcript_json) seg
-			WHERE seg->>'text' ILIKE $%d
-		))`, paramIdx, paramIdx)
+			WHERE seg->>'text' ILIKE $%d OR seg->>'speaker' ILIKE $%d
+		))`, paramIdx, paramIdx, paramIdx)
 		paramIdx++
 	}
 

--- a/internal/video/video_query_test.go
+++ b/internal/video/video_query_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/jackc/pgx/v5"
@@ -137,5 +138,39 @@ func TestGetTranscript_NullSegments(t *testing.T) {
 
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Errorf("unmet pgxmock expectations: %v", err)
+	}
+}
+
+func TestList_SearchBySpeaker(t *testing.T) {
+	mock, err := pgxmock.NewPool()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer mock.Close()
+
+	handler := NewHandler(mock, &mockStorage{}, testBaseURL, 0, 0, 0, 0, testJWTSecret, false)
+
+	createdAt := time.Date(2026, 2, 5, 10, 30, 0, 0, time.UTC)
+	shareExpiresAt := createdAt.Add(7 * 24 * time.Hour)
+
+	mock.ExpectQuery(`SELECT v.id, v.title`).
+		WithArgs(testUserID, "%Alice%", 50, 0).
+		WillReturnRows(pgxmock.NewRows([]string{"id", "title", "status", "duration", "share_token", "created_at", "share_expires_at", "view_count", "unique_view_count", "thumbnail_key", "share_password", "comment_mode", "comment_count", "transcript_status", "view_notification", "download_enabled", "cta_text", "cta_url", "email_gate_enabled", "summary_status", "document_status", "suggested_title", "folder_id", "transcription_language", "noise_reduction", "pinned", "tags_json", "playlists_json"}).
+			AddRow("video-1", "Interview with Alice", "ready", 300, "tok123", createdAt, &shareExpiresAt, int64(5), int64(3), (*string)(nil), (*string)(nil), "disabled", int64(0), "ready", (*string)(nil), true, (*string)(nil), (*string)(nil), false, "none", "none", (*string)(nil), (*string)(nil), (*string)(nil), false, false, "[]", "[]"),
+		)
+
+	r := chi.NewRouter()
+	r.With(newAuthMiddleware()).Get("/api/videos", handler.List)
+
+	req := authenticatedRequest(t, http.MethodGet, "/api/videos?q=Alice", nil)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d: %s", http.StatusOK, rec.Code, rec.Body.String())
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet expectations: %v", err)
 	}
 }

--- a/internal/video/video_query_test.go
+++ b/internal/video/video_query_test.go
@@ -153,10 +153,14 @@ func TestList_SearchBySpeaker(t *testing.T) {
 	createdAt := time.Date(2026, 2, 5, 10, 30, 0, 0, time.UTC)
 	shareExpiresAt := createdAt.Add(7 * 24 * time.Hour)
 
-	mock.ExpectQuery(`SELECT v.id, v.title`).
+	// Title deliberately does NOT contain the search term "Alice": this row
+	// can only come back if the WHERE clause actually matches on
+	// seg->>'speaker', not on title or seg->>'text'. The query regexp also
+	// pins the speaker predicate itself so the test fails if it's removed.
+	mock.ExpectQuery(`SELECT v\.id, v\.title.*seg->>'speaker' ILIKE \$2`).
 		WithArgs(testUserID, "%Alice%", 50, 0).
 		WillReturnRows(pgxmock.NewRows([]string{"id", "title", "status", "duration", "share_token", "created_at", "share_expires_at", "view_count", "unique_view_count", "thumbnail_key", "share_password", "comment_mode", "comment_count", "transcript_status", "view_notification", "download_enabled", "cta_text", "cta_url", "email_gate_enabled", "summary_status", "document_status", "suggested_title", "folder_id", "transcription_language", "noise_reduction", "pinned", "tags_json", "playlists_json"}).
-			AddRow("video-1", "Interview with Alice", "ready", 300, "tok123", createdAt, &shareExpiresAt, int64(5), int64(3), (*string)(nil), (*string)(nil), "disabled", int64(0), "ready", (*string)(nil), true, (*string)(nil), (*string)(nil), false, "none", "none", (*string)(nil), (*string)(nil), (*string)(nil), false, false, "[]", "[]"),
+			AddRow("video-1", "Q3 Planning", "ready", 300, "tok123", createdAt, &shareExpiresAt, int64(5), int64(3), (*string)(nil), (*string)(nil), "disabled", int64(0), "ready", (*string)(nil), true, (*string)(nil), (*string)(nil), false, "none", "none", (*string)(nil), (*string)(nil), (*string)(nil), false, false, "[]", "[]"),
 		)
 
 	r := chi.NewRouter()

--- a/internal/video/video_settings.go
+++ b/internal/video/video_settings.go
@@ -3,6 +3,7 @@ package video
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"os"
@@ -390,6 +391,11 @@ func (h *Handler) UploadTranscript(w http.ResponseWriter, r *http.Request) {
 	r.Body = http.MaxBytesReader(w, r.Body, MaxTranscriptUploadBytes+1024)
 	file, _, err := r.FormFile("file")
 	if err != nil {
+		var maxBytesErr *http.MaxBytesError
+		if errors.As(err, &maxBytesErr) {
+			httputil.WriteError(w, http.StatusRequestEntityTooLarge, "transcript file too large")
+			return
+		}
 		httputil.WriteError(w, http.StatusBadRequest, "missing transcript file")
 		return
 	}
@@ -401,7 +407,7 @@ func (h *Handler) UploadTranscript(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if len(raw) > MaxTranscriptUploadBytes {
-		httputil.WriteError(w, http.StatusBadRequest, "transcript file too large")
+		httputil.WriteError(w, http.StatusRequestEntityTooLarge, "transcript file too large")
 		return
 	}
 

--- a/internal/video/video_settings.go
+++ b/internal/video/video_settings.go
@@ -373,7 +373,7 @@ func (h *Handler) DismissTitle(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusNoContent)
 }
 
-const maxTranscriptUploadBytes = 5 << 20 // 5 MB
+const MaxTranscriptUploadBytes = 5 << 20 // 5 MB
 
 func (h *Handler) UploadTranscript(w http.ResponseWriter, r *http.Request) {
 	videoID := chi.URLParam(r, "id")
@@ -387,7 +387,7 @@ func (h *Handler) UploadTranscript(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	r.Body = http.MaxBytesReader(w, r.Body, maxTranscriptUploadBytes+1024)
+	r.Body = http.MaxBytesReader(w, r.Body, MaxTranscriptUploadBytes+1024)
 	file, _, err := r.FormFile("file")
 	if err != nil {
 		httputil.WriteError(w, http.StatusBadRequest, "missing transcript file")
@@ -395,12 +395,12 @@ func (h *Handler) UploadTranscript(w http.ResponseWriter, r *http.Request) {
 	}
 	defer func() { _ = file.Close() }()
 
-	raw, err := io.ReadAll(io.LimitReader(file, maxTranscriptUploadBytes+1))
+	raw, err := io.ReadAll(io.LimitReader(file, MaxTranscriptUploadBytes+1))
 	if err != nil {
 		httputil.WriteError(w, http.StatusBadRequest, "could not read file")
 		return
 	}
-	if len(raw) > maxTranscriptUploadBytes {
+	if len(raw) > MaxTranscriptUploadBytes {
 		httputil.WriteError(w, http.StatusBadRequest, "transcript file too large")
 		return
 	}

--- a/internal/video/video_settings.go
+++ b/internal/video/video_settings.go
@@ -1,8 +1,11 @@
 package video
 
 import (
+	"context"
 	"encoding/json"
+	"io"
 	"net/http"
+	"os"
 	"strings"
 	"time"
 
@@ -368,4 +371,88 @@ func (h *Handler) DismissTitle(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	w.WriteHeader(http.StatusNoContent)
+}
+
+const maxTranscriptUploadBytes = 5 << 20 // 5 MB
+
+func (h *Handler) UploadTranscript(w http.ResponseWriter, r *http.Request) {
+	videoID := chi.URLParam(r, "id")
+
+	where, args := orgVideoFilter(r.Context(), videoID, nil, "AND status = 'ready'")
+	var userID, shareToken string
+	if err := h.db.QueryRow(r.Context(),
+		`SELECT user_id, share_token FROM videos WHERE `+where, args...,
+	).Scan(&userID, &shareToken); err != nil {
+		httputil.WriteError(w, http.StatusNotFound, "video not found")
+		return
+	}
+
+	r.Body = http.MaxBytesReader(w, r.Body, maxTranscriptUploadBytes+1024)
+	file, _, err := r.FormFile("file")
+	if err != nil {
+		httputil.WriteError(w, http.StatusBadRequest, "missing transcript file")
+		return
+	}
+	defer func() { _ = file.Close() }()
+
+	raw, err := io.ReadAll(io.LimitReader(file, maxTranscriptUploadBytes+1))
+	if err != nil {
+		httputil.WriteError(w, http.StatusBadRequest, "could not read file")
+		return
+	}
+	if len(raw) > maxTranscriptUploadBytes {
+		httputil.WriteError(w, http.StatusBadRequest, "transcript file too large")
+		return
+	}
+
+	segments, err := parseVTT(raw)
+	if err != nil {
+		httputil.WriteError(w, http.StatusBadRequest, "invalid WebVTT file")
+		return
+	}
+	segments = mergeSegments(segments)
+
+	transcriptKey := transcriptFileKey(userID, shareToken)
+	if err := h.uploadTranscriptVTT(r.Context(), transcriptKey, segmentsToVTT(segments)); err != nil {
+		httputil.WriteError(w, http.StatusInternalServerError, "could not store transcript")
+		return
+	}
+
+	segmentsJSON, err := json.Marshal(segments)
+	if err != nil {
+		httputil.WriteError(w, http.StatusInternalServerError, "could not encode transcript")
+		return
+	}
+
+	updWhere, updArgs := orgVideoFilter(r.Context(), videoID,
+		[]any{transcriptKey, string(segmentsJSON)}, "")
+	if _, err := h.db.Exec(r.Context(),
+		`UPDATE videos SET transcript_key = $1, transcript_json = $2, transcript_status = 'ready', transcript_started_at = NULL, updated_at = now() WHERE `+updWhere,
+		updArgs...,
+	); err != nil {
+		httputil.WriteError(w, http.StatusInternalServerError, "could not update transcript")
+		return
+	}
+
+	httputil.WriteJSON(w, http.StatusOK, map[string]any{"segments": segments})
+}
+
+// uploadTranscriptVTT writes the VTT to a temp file and uploads it, mirroring
+// how processTranscription and trim store artifacts (ObjectStorage exposes
+// only UploadFile, not a bytes upload).
+func (h *Handler) uploadTranscriptVTT(ctx context.Context, key, vtt string) error {
+	tmp, err := os.CreateTemp("", "sendrec-upload-vtt-*.vtt")
+	if err != nil {
+		return err
+	}
+	tmpPath := tmp.Name()
+	defer func() { _ = os.Remove(tmpPath) }()
+	if _, err := tmp.WriteString(vtt); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	return h.storage.UploadFile(ctx, key, tmpPath, "text/vtt")
 }

--- a/internal/video/video_test.go
+++ b/internal/video/video_test.go
@@ -7023,10 +7023,14 @@ func TestUploadTranscript_RejectsOversized(t *testing.T) {
 		WithArgs(videoID, testUserID).
 		WillReturnRows(pgxmock.NewRows([]string{"user_id", "share_token"}).AddRow(testUserID, shareToken))
 
-	oversized := make([]byte, MaxTranscriptUploadBytes+1)
-	for i := range oversized {
-		oversized[i] = 'a'
+	// Syntactically-plausible VTT, padded past the size limit with more cues:
+	// the rejection must be attributable to SIZE, not to invalid-VTT.
+	var vtt strings.Builder
+	vtt.WriteString("WEBVTT\n\n")
+	for vtt.Len() <= MaxTranscriptUploadBytes {
+		vtt.WriteString("00:00:00.000 --> 00:00:01.000\nHello\n\n")
 	}
+	oversized := []byte(vtt.String())
 
 	r := chi.NewRouter()
 	r.With(newAuthMiddleware()).Post("/api/videos/{id}/transcript", handler.UploadTranscript)
@@ -7036,8 +7040,62 @@ func TestUploadTranscript_RejectsOversized(t *testing.T) {
 
 	r.ServeHTTP(rec, req)
 
-	if rec.Code != http.StatusBadRequest {
-		t.Fatalf("expected status %d, got %d: %s", http.StatusBadRequest, rec.Code, rec.Body.String())
+	if rec.Code != http.StatusRequestEntityTooLarge {
+		t.Fatalf("expected status %d, got %d: %s", http.StatusRequestEntityTooLarge, rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "transcript file too large") {
+		t.Fatalf("expected size-specific error message, got: %s", rec.Body.String())
+	}
+
+	if storage.uploadFileCallCount != 0 {
+		t.Errorf("expected storage.UploadFile not called, got %d calls", storage.uploadFileCallCount)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet pgxmock expectations: %v", err)
+	}
+}
+
+func TestUploadTranscript_RejectsOversized_OverRouteCeiling(t *testing.T) {
+	mock, err := pgxmock.NewPool()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer mock.Close()
+
+	storage := &mockStorage{}
+	handler := NewHandler(mock, storage, testBaseURL, 0, 0, 0, 0, testJWTSecret, false)
+	videoID := "video-126"
+	shareToken := "tok4"
+
+	mock.ExpectQuery(`SELECT user_id, share_token FROM videos WHERE id = \$1 AND user_id = \$2 AND organization_id IS NULL AND status = 'ready'`).
+		WithArgs(videoID, testUserID).
+		WillReturnRows(pgxmock.NewRows([]string{"user_id", "share_token"}).AddRow(testUserID, shareToken))
+
+	// A body large enough to exceed the handler's own MaxBytesReader ceiling
+	// (MaxTranscriptUploadBytes+1024), not just the post-read size check.
+	// FormFile itself must fail in this case; the handler must still report
+	// the size-specific error, not "missing transcript file".
+	var vtt strings.Builder
+	vtt.WriteString("WEBVTT\n\n")
+	for vtt.Len() <= MaxTranscriptUploadBytes+4096 {
+		vtt.WriteString("00:00:00.000 --> 00:00:01.000\nHello\n\n")
+	}
+	oversized := []byte(vtt.String())
+
+	r := chi.NewRouter()
+	r.With(newAuthMiddleware()).Post("/api/videos/{id}/transcript", handler.UploadTranscript)
+
+	rec := httptest.NewRecorder()
+	req := authenticatedMultipartRequest(t, "/api/videos/"+videoID+"/transcript", "file", "transcript.vtt", oversized)
+
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusRequestEntityTooLarge {
+		t.Fatalf("expected status %d, got %d: %s", http.StatusRequestEntityTooLarge, rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "transcript file too large") {
+		t.Fatalf("expected size-specific error message, got: %s", rec.Body.String())
 	}
 
 	if storage.uploadFileCallCount != 0 {

--- a/internal/video/video_test.go
+++ b/internal/video/video_test.go
@@ -6831,3 +6831,38 @@ func TestLimits_ViewerExcludedFromMemberCount(t *testing.T) {
 		t.Errorf("unmet pgxmock expectations: %v", err)
 	}
 }
+
+// --- UploadTranscript Tests ---
+
+func TestUploadTranscript_NotFound(t *testing.T) {
+	mock, err := pgxmock.NewPool()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer mock.Close()
+
+	storage := &mockStorage{}
+	handler := NewHandler(mock, storage, testBaseURL, 0, 0, 0, 0, testJWTSecret, false)
+	videoID := "video-999"
+
+	// Mock SELECT returns no rows
+	mock.ExpectQuery(`SELECT user_id, share_token FROM videos WHERE id = \$1 AND user_id = \$2 AND organization_id IS NULL AND status = 'ready'`).
+		WithArgs(videoID, testUserID).
+		WillReturnError(pgx.ErrNoRows)
+
+	r := chi.NewRouter()
+	r.With(newAuthMiddleware()).Post("/api/videos/{id}/transcript", handler.UploadTranscript)
+
+	rec := httptest.NewRecorder()
+	req := authenticatedRequest(t, http.MethodPost, "/api/videos/"+videoID+"/transcript", nil)
+
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet expectations: %v", err)
+	}
+}

--- a/internal/video/video_test.go
+++ b/internal/video/video_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"mime/multipart"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -36,6 +37,9 @@ type mockStorage struct {
 	headErr                error
 	downloadToFileErr      error
 	uploadFileErr          error
+	uploadFileCallCount    int
+	uploadFileKeys         []string
+	uploadFileContentTypes []string
 }
 
 func (m *mockStorage) GenerateUploadURL(_ context.Context, key string, _ string, _ int64, _ time.Duration) (string, error) {
@@ -81,7 +85,10 @@ func (m *mockStorage) DownloadToFile(_ context.Context, _ string, _ string) erro
 	return m.downloadToFileErr
 }
 
-func (m *mockStorage) UploadFile(_ context.Context, _ string, _ string, _ string) error {
+func (m *mockStorage) UploadFile(_ context.Context, key string, _ string, contentType string) error {
+	m.uploadFileCallCount++
+	m.uploadFileKeys = append(m.uploadFileKeys, key)
+	m.uploadFileContentTypes = append(m.uploadFileContentTypes, contentType)
 	return m.uploadFileErr
 }
 
@@ -107,6 +114,33 @@ func authenticatedRequest(t *testing.T, method, target string, body []byte) *htt
 
 func newAuthMiddleware() func(http.Handler) http.Handler {
 	return auth.NewHandler(nil, testJWTSecret, false).Middleware
+}
+
+// authenticatedMultipartRequest builds an authenticated POST with a single
+// "file" form field, mirroring authenticatedRequest for multipart uploads.
+func authenticatedMultipartRequest(t *testing.T, target, fieldName, fileName string, content []byte) *http.Request {
+	t.Helper()
+	var buf bytes.Buffer
+	mw := multipart.NewWriter(&buf)
+	part, err := mw.CreateFormFile(fieldName, fileName)
+	if err != nil {
+		t.Fatalf("failed to create form file: %v", err)
+	}
+	if _, err := part.Write(content); err != nil {
+		t.Fatalf("failed to write form file content: %v", err)
+	}
+	if err := mw.Close(); err != nil {
+		t.Fatalf("failed to close multipart writer: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, target, &buf)
+	req.Header.Set("Content-Type", mw.FormDataContentType())
+	token, err := auth.GenerateAccessToken(testJWTSecret, testUserID)
+	if err != nil {
+		t.Fatalf("failed to generate access token: %v", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	return req
 }
 
 func parseErrorResponse(t *testing.T, body []byte) string {
@@ -6864,5 +6898,153 @@ func TestUploadTranscript_NotFound(t *testing.T) {
 
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Errorf("unmet expectations: %v", err)
+	}
+}
+
+func TestUploadTranscript_HappyPath(t *testing.T) {
+	mock, err := pgxmock.NewPool()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer mock.Close()
+
+	storage := &mockStorage{}
+	handler := NewHandler(mock, storage, testBaseURL, 0, 0, 0, 0, testJWTSecret, false)
+	videoID := "video-123"
+	shareToken := "tok"
+
+	mock.ExpectQuery(`SELECT user_id, share_token FROM videos WHERE id = \$1 AND user_id = \$2 AND organization_id IS NULL AND status = 'ready'`).
+		WithArgs(videoID, testUserID).
+		WillReturnRows(pgxmock.NewRows([]string{"user_id", "share_token"}).AddRow(testUserID, shareToken))
+
+	segmentsJSON, err := json.Marshal([]TranscriptSegment{{Start: 0, End: 1, Text: "hi", Speaker: "Alice"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	mock.ExpectExec(`UPDATE videos SET transcript_key = \$1, transcript_json = \$2, transcript_status = 'ready', transcript_started_at = NULL, updated_at = now\(\) WHERE id = \$3 AND user_id = \$4 AND organization_id IS NULL`).
+		WithArgs("recordings/"+testUserID+"/"+shareToken+".vtt", string(segmentsJSON), videoID, testUserID).
+		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+
+	vtt := "WEBVTT\n\n1\n00:00:00.000 --> 00:00:01.000\nAlice: hi\n\n"
+
+	r := chi.NewRouter()
+	r.With(newAuthMiddleware()).Post("/api/videos/{id}/transcript", handler.UploadTranscript)
+
+	rec := httptest.NewRecorder()
+	req := authenticatedMultipartRequest(t, "/api/videos/"+videoID+"/transcript", "file", "transcript.vtt", []byte(vtt))
+
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d: %s", http.StatusOK, rec.Code, rec.Body.String())
+	}
+
+	var resp struct {
+		Segments []TranscriptSegment `json:"segments"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to parse response: %v", err)
+	}
+	if len(resp.Segments) != 1 {
+		t.Fatalf("expected 1 segment, got %d", len(resp.Segments))
+	}
+	if resp.Segments[0].Speaker != "Alice" {
+		t.Errorf("expected speaker %q, got %q", "Alice", resp.Segments[0].Speaker)
+	}
+	if resp.Segments[0].Text != "hi" {
+		t.Errorf("expected text %q, got %q", "hi", resp.Segments[0].Text)
+	}
+
+	if storage.uploadFileCallCount != 1 {
+		t.Errorf("expected storage.UploadFile called once, got %d", storage.uploadFileCallCount)
+	}
+	if len(storage.uploadFileKeys) == 1 && storage.uploadFileKeys[0] != "recordings/"+testUserID+"/"+shareToken+".vtt" {
+		t.Errorf("unexpected upload key: %s", storage.uploadFileKeys[0])
+	}
+	if len(storage.uploadFileContentTypes) == 1 && storage.uploadFileContentTypes[0] != "text/vtt" {
+		t.Errorf("unexpected content type: %s", storage.uploadFileContentTypes[0])
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet pgxmock expectations: %v", err)
+	}
+}
+
+func TestUploadTranscript_RejectsNonVTT(t *testing.T) {
+	mock, err := pgxmock.NewPool()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer mock.Close()
+
+	storage := &mockStorage{}
+	handler := NewHandler(mock, storage, testBaseURL, 0, 0, 0, 0, testJWTSecret, false)
+	videoID := "video-124"
+	shareToken := "tok2"
+
+	mock.ExpectQuery(`SELECT user_id, share_token FROM videos WHERE id = \$1 AND user_id = \$2 AND organization_id IS NULL AND status = 'ready'`).
+		WithArgs(videoID, testUserID).
+		WillReturnRows(pgxmock.NewRows([]string{"user_id", "share_token"}).AddRow(testUserID, shareToken))
+
+	r := chi.NewRouter()
+	r.With(newAuthMiddleware()).Post("/api/videos/{id}/transcript", handler.UploadTranscript)
+
+	rec := httptest.NewRecorder()
+	req := authenticatedMultipartRequest(t, "/api/videos/"+videoID+"/transcript", "file", "transcript.txt", []byte("not a vtt"))
+
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected status %d, got %d: %s", http.StatusBadRequest, rec.Code, rec.Body.String())
+	}
+
+	if storage.uploadFileCallCount != 0 {
+		t.Errorf("expected storage.UploadFile not called, got %d calls", storage.uploadFileCallCount)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet pgxmock expectations: %v", err)
+	}
+}
+
+func TestUploadTranscript_RejectsOversized(t *testing.T) {
+	mock, err := pgxmock.NewPool()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer mock.Close()
+
+	storage := &mockStorage{}
+	handler := NewHandler(mock, storage, testBaseURL, 0, 0, 0, 0, testJWTSecret, false)
+	videoID := "video-125"
+	shareToken := "tok3"
+
+	mock.ExpectQuery(`SELECT user_id, share_token FROM videos WHERE id = \$1 AND user_id = \$2 AND organization_id IS NULL AND status = 'ready'`).
+		WithArgs(videoID, testUserID).
+		WillReturnRows(pgxmock.NewRows([]string{"user_id", "share_token"}).AddRow(testUserID, shareToken))
+
+	oversized := make([]byte, MaxTranscriptUploadBytes+1)
+	for i := range oversized {
+		oversized[i] = 'a'
+	}
+
+	r := chi.NewRouter()
+	r.With(newAuthMiddleware()).Post("/api/videos/{id}/transcript", handler.UploadTranscript)
+
+	rec := httptest.NewRecorder()
+	req := authenticatedMultipartRequest(t, "/api/videos/"+videoID+"/transcript", "file", "transcript.vtt", oversized)
+
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected status %d, got %d: %s", http.StatusBadRequest, rec.Code, rec.Body.String())
+	}
+
+	if storage.uploadFileCallCount != 0 {
+		t.Errorf("expected storage.UploadFile not called, got %d calls", storage.uploadFileCallCount)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet pgxmock expectations: %v", err)
 	}
 }

--- a/internal/video/vtt_parse.go
+++ b/internal/video/vtt_parse.go
@@ -67,8 +67,12 @@ func parseVTT(raw []byte) ([]TranscriptSegment, error) {
 		speaker, cleaned := extractSpeaker(payload)
 		cleaned = vttSpanTagRe.ReplaceAllString(cleaned, "")
 		cleaned = html.UnescapeString(cleaned)
+		cleaned = strings.TrimSpace(cleaned)
+		if cleaned == "" {
+			continue
+		}
 		segments = append(segments, TranscriptSegment{
-			Start: start, End: end, Text: strings.TrimSpace(cleaned), Speaker: speaker,
+			Start: start, End: end, Text: cleaned, Speaker: speaker,
 		})
 	}
 

--- a/internal/video/vtt_parse.go
+++ b/internal/video/vtt_parse.go
@@ -19,7 +19,6 @@ var (
 // identifiers, HTML entities, and voice/span tags.
 func parseVTT(raw []byte) ([]TranscriptSegment, error) {
 	text := string(raw)
-	// Remove UTF-8 BOM if present
 	const bom = "\xef\xbb\xbf"
 	text = strings.TrimPrefix(text, bom)
 	text = strings.ReplaceAll(text, "\r\n", "\n")
@@ -41,7 +40,6 @@ func parseVTT(raw []byte) ([]TranscriptSegment, error) {
 		if len(lines) == 0 {
 			continue
 		}
-		// Skip the header block and NOTE/STYLE/REGION blocks.
 		first := strings.TrimSpace(lines[0])
 		if strings.HasPrefix(first, "WEBVTT") || strings.HasPrefix(first, "NOTE") ||
 			strings.HasPrefix(first, "STYLE") || strings.HasPrefix(first, "REGION") {
@@ -66,8 +64,11 @@ func parseVTT(raw []byte) ([]TranscriptSegment, error) {
 		}
 		speaker, cleaned := extractSpeaker(payload)
 		speaker = sanitizeSpeaker(speaker)
-		cleaned = vttSpanTagRe.ReplaceAllString(cleaned, "")
+		// Unescape entities before stripping tags so entity-encoded markup
+		// (e.g. &lt;v X&gt;) is stripped rather than resurrected into live VTT
+		// markup in the re-rendered output.
 		cleaned = html.UnescapeString(cleaned)
+		cleaned = vttSpanTagRe.ReplaceAllString(cleaned, "")
 		cleaned = strings.TrimSpace(cleaned)
 		if cleaned == "" {
 			continue
@@ -112,15 +113,22 @@ func parseVTTTimestamp(s string) (float64, bool) {
 	}
 	hms := strings.Split(s[:dot], ":")
 	var h, m, sec int
+	var errH, errM, errS error
 	switch len(hms) {
 	case 3:
-		h, _ = strconv.Atoi(hms[0])
-		m, _ = strconv.Atoi(hms[1])
-		sec, _ = strconv.Atoi(hms[2])
+		h, errH = strconv.Atoi(hms[0])
+		m, errM = strconv.Atoi(hms[1])
+		sec, errS = strconv.Atoi(hms[2])
 	case 2:
-		m, _ = strconv.Atoi(hms[0])
-		sec, _ = strconv.Atoi(hms[1])
+		m, errM = strconv.Atoi(hms[0])
+		sec, errS = strconv.Atoi(hms[1])
 	default:
+		return 0, false
+	}
+	// Reject non-numeric components (silent Atoi zeroing would keep a cue at
+	// the wrong time), but tolerate out-of-range numeric values that real
+	// exporters occasionally emit rather than dropping the cue.
+	if errH != nil || errM != nil || errS != nil || h < 0 || m < 0 || sec < 0 {
 		return 0, false
 	}
 	return float64(h)*3600 + float64(m)*60 + float64(sec) + float64(ms)/1000, true
@@ -165,19 +173,25 @@ func extractSpeaker(text string) (speaker, cleaned string) {
 
 // mergeSegments joins consecutive cues from the same speaker when the gap
 // between them is at most maxMergeGapSeconds, extending the end time and
-// concatenating text with a single space.
+// concatenating text with a single space. Text pieces are accumulated per
+// merged group and joined once to keep this linear in total text size.
 func mergeSegments(in []TranscriptSegment) []TranscriptSegment {
 	const maxMergeGapSeconds = 2.0
 	var out []TranscriptSegment
+	var parts [][]string
 	for _, s := range in {
 		if n := len(out); n > 0 && out[n-1].Speaker == s.Speaker && s.Start-out[n-1].End <= maxMergeGapSeconds {
 			if s.End > out[n-1].End {
 				out[n-1].End = s.End
 			}
-			out[n-1].Text += " " + s.Text
+			parts[n-1] = append(parts[n-1], s.Text)
 			continue
 		}
 		out = append(out, s)
+		parts = append(parts, []string{s.Text})
+	}
+	for i := range out {
+		out[i].Text = strings.Join(parts[i], " ")
 	}
 	return out
 }

--- a/internal/video/vtt_parse.go
+++ b/internal/video/vtt_parse.go
@@ -159,7 +159,9 @@ func mergeSegments(in []TranscriptSegment) []TranscriptSegment {
 	var out []TranscriptSegment
 	for _, s := range in {
 		if n := len(out); n > 0 && out[n-1].Speaker == s.Speaker && s.Start-out[n-1].End <= maxMergeGapSeconds {
-			out[n-1].End = s.End
+			if s.End > out[n-1].End {
+				out[n-1].End = s.End
+			}
 			out[n-1].Text += " " + s.Text
 			continue
 		}

--- a/internal/video/vtt_parse.go
+++ b/internal/video/vtt_parse.go
@@ -9,9 +9,9 @@ import (
 )
 
 var (
-	vttTimingRe  = regexp.MustCompile(`^\s*(\d{2,}:)?([0-5]\d):([0-5]\d)\.(\d{3})\s*-->\s*(\d{2,}:)?([0-5]\d):([0-5]\d)\.(\d{3})`)
-	vttVoiceRe   = regexp.MustCompile(`^<v\s+([^>]+)>`)
-	vttSpanTagRe = regexp.MustCompile(`</?[a-zA-Z][^>]*>|<\d{2,}:[0-5]\d:[0-5]\d\.\d{3}>`)
+	vttVoiceRe         = regexp.MustCompile(`^<v\s+([^>]+)>`)
+	vttSpanTagRe       = regexp.MustCompile(`</?[a-zA-Z][^>]*>|<\d{2,}:[0-5]\d:[0-5]\d\.\d{3}>`)
+	leadingTimestampRe = regexp.MustCompile(`^\d{1,2}:\d{2}`)
 )
 
 // parseVTT parses a WebVTT file from Teams, Zoom, or a generic source into
@@ -50,7 +50,7 @@ func parseVTT(raw []byte) ([]TranscriptSegment, error) {
 		// A leading non-timing line is an opaque cue identifier (Teams GUID,
 		// Zoom integer). Discard it.
 		idx := 0
-		if !vttTimingRe.MatchString(lines[idx]) {
+		if _, _, ok := parseTimingLine(lines[idx]); !ok {
 			idx++
 		}
 		if idx >= len(lines) {
@@ -65,6 +65,7 @@ func parseVTT(raw []byte) ([]TranscriptSegment, error) {
 			continue
 		}
 		speaker, cleaned := extractSpeaker(payload)
+		speaker = sanitizeSpeaker(speaker)
 		cleaned = vttSpanTagRe.ReplaceAllString(cleaned, "")
 		cleaned = html.UnescapeString(cleaned)
 		cleaned = strings.TrimSpace(cleaned)
@@ -125,6 +126,17 @@ func parseVTTTimestamp(s string) (float64, bool) {
 	return float64(h)*3600 + float64(m)*60 + float64(sec) + float64(ms)/1000, true
 }
 
+// speakerSanitizer strips characters that would corrupt a re-emitted <v
+// SPEAKER> voice tag; a real display name never contains them.
+var speakerSanitizer = strings.NewReplacer("<", "", ">", "", "\n", "", "\r", "")
+
+// sanitizeSpeaker unescapes HTML entities in a speaker name (mirroring cue
+// text) and strips angle brackets/newlines so the name can't break out of
+// the <v SPEAKER> voice tag it's re-emitted into by segmentsToVTT.
+func sanitizeSpeaker(speaker string) string {
+	return speakerSanitizer.Replace(html.UnescapeString(speaker))
+}
+
 // extractSpeaker pulls a speaker name from a cue payload via a <v Name> voice
 // tag or a leading "Name: " prefix (Zoom), splitting on the first ": " only.
 func extractSpeaker(text string) (speaker, cleaned string) {
@@ -144,7 +156,7 @@ func extractSpeaker(text string) (speaker, cleaned string) {
 	}
 	if i := strings.Index(firstLine, ": "); i > 0 {
 		name := strings.TrimSpace(firstLine[:i])
-		if name != "" && !strings.ContainsAny(name, "<>") {
+		if name != "" && !strings.ContainsAny(name, "<>") && !leadingTimestampRe.MatchString(name) {
 			return name, strings.TrimSpace(firstLine[i+2:]) + rest
 		}
 	}

--- a/internal/video/vtt_parse.go
+++ b/internal/video/vtt_parse.go
@@ -1,0 +1,148 @@
+package video
+
+import (
+	"fmt"
+	"html"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+var (
+	vttTimingRe  = regexp.MustCompile(`^\s*(\d{2,}:)?([0-5]\d):([0-5]\d)\.(\d{3})\s*-->\s*(\d{2,}:)?([0-5]\d):([0-5]\d)\.(\d{3})`)
+	vttVoiceRe   = regexp.MustCompile(`^<v\s+([^>]+)>`)
+	vttSpanTagRe = regexp.MustCompile(`</?[a-zA-Z][^>]*>|<\d{2,}:[0-5]\d:[0-5]\d\.\d{3}>`)
+)
+
+// parseVTT parses a WebVTT file from Teams, Zoom, or a generic source into
+// TranscriptSegments, tolerating BOM, CRLF/CR line endings, optional cue
+// identifiers, HTML entities, and voice/span tags.
+func parseVTT(raw []byte) ([]TranscriptSegment, error) {
+	text := string(raw)
+	// Remove UTF-8 BOM if present
+	const bom = "\xef\xbb\xbf"
+	text = strings.TrimPrefix(text, bom)
+	text = strings.ReplaceAll(text, "\r\n", "\n")
+	text = strings.ReplaceAll(text, "\r", "\n")
+
+	trimmed := strings.TrimLeft(text, " \t")
+	if !strings.HasPrefix(trimmed, "WEBVTT") {
+		return nil, fmt.Errorf("not a WebVTT file: missing WEBVTT signature")
+	}
+	after := trimmed[len("WEBVTT"):]
+	if after != "" && !strings.HasPrefix(after, "\n") && !strings.HasPrefix(after, " ") && !strings.HasPrefix(after, "\t") {
+		return nil, fmt.Errorf("not a WebVTT file: malformed signature")
+	}
+
+	blocks := strings.Split(text, "\n\n")
+	var segments []TranscriptSegment
+	for _, block := range blocks {
+		lines := strings.Split(strings.Trim(block, "\n"), "\n")
+		if len(lines) == 0 {
+			continue
+		}
+		// Skip the header block and NOTE/STYLE/REGION blocks.
+		first := strings.TrimSpace(lines[0])
+		if strings.HasPrefix(first, "WEBVTT") || strings.HasPrefix(first, "NOTE") ||
+			strings.HasPrefix(first, "STYLE") || strings.HasPrefix(first, "REGION") {
+			continue
+		}
+		// A leading non-timing line is an opaque cue identifier (Teams GUID,
+		// Zoom integer). Discard it.
+		idx := 0
+		if !vttTimingRe.MatchString(lines[idx]) {
+			idx++
+		}
+		if idx >= len(lines) {
+			continue
+		}
+		start, end, ok := parseTimingLine(lines[idx])
+		if !ok {
+			continue
+		}
+		payload := strings.Join(lines[idx+1:], "\n")
+		if strings.TrimSpace(payload) == "" {
+			continue
+		}
+		speaker, cleaned := extractSpeaker(payload)
+		cleaned = vttSpanTagRe.ReplaceAllString(cleaned, "")
+		cleaned = html.UnescapeString(cleaned)
+		segments = append(segments, TranscriptSegment{
+			Start: start, End: end, Text: strings.TrimSpace(cleaned), Speaker: speaker,
+		})
+	}
+
+	if len(segments) == 0 {
+		return nil, fmt.Errorf("no cues found in WebVTT file")
+	}
+	return segments, nil
+}
+
+func parseTimingLine(line string) (start, end float64, ok bool) {
+	parts := strings.SplitN(line, "-->", 2)
+	if len(parts) != 2 {
+		return 0, 0, false
+	}
+	// The end field may carry cue settings after the timestamp; take field 0.
+	endField := strings.Fields(strings.TrimSpace(parts[1]))
+	if len(endField) == 0 {
+		return 0, 0, false
+	}
+	s, ok1 := parseVTTTimestamp(strings.TrimSpace(parts[0]))
+	e, ok2 := parseVTTTimestamp(endField[0])
+	if !ok1 || !ok2 {
+		return 0, 0, false
+	}
+	return s, e, true
+}
+
+func parseVTTTimestamp(s string) (float64, bool) {
+	dot := strings.LastIndex(s, ".")
+	if dot < 0 || len(s)-dot != 4 {
+		return 0, false
+	}
+	ms, err := strconv.Atoi(s[dot+1:])
+	if err != nil {
+		return 0, false
+	}
+	hms := strings.Split(s[:dot], ":")
+	var h, m, sec int
+	switch len(hms) {
+	case 3:
+		h, _ = strconv.Atoi(hms[0])
+		m, _ = strconv.Atoi(hms[1])
+		sec, _ = strconv.Atoi(hms[2])
+	case 2:
+		m, _ = strconv.Atoi(hms[0])
+		sec, _ = strconv.Atoi(hms[1])
+	default:
+		return 0, false
+	}
+	return float64(h)*3600 + float64(m)*60 + float64(sec) + float64(ms)/1000, true
+}
+
+// extractSpeaker pulls a speaker name from a cue payload via a <v Name> voice
+// tag or a leading "Name: " prefix (Zoom), splitting on the first ": " only.
+func extractSpeaker(text string) (speaker, cleaned string) {
+	if m := vttVoiceRe.FindStringSubmatch(text); m != nil {
+		clean := text[len(m[0]):]
+		// Strip trailing </v> if present
+		clean = strings.TrimSuffix(clean, "</v>")
+		return strings.TrimSpace(m[1]), clean
+	}
+	// Only treat a leading "Name: " on the first line as a speaker.
+	nl := strings.IndexByte(text, '\n')
+	firstLine := text
+	rest := ""
+	if nl >= 0 {
+		firstLine = text[:nl]
+		rest = text[nl:]
+	}
+	if i := strings.Index(firstLine, ": "); i > 0 {
+		name := strings.TrimSpace(firstLine[:i])
+		if name != "" && !strings.ContainsAny(name, "<>") {
+			return name, strings.TrimSpace(firstLine[i+2:]) + rest
+		}
+	}
+	return "", text
+}

--- a/internal/video/vtt_parse.go
+++ b/internal/video/vtt_parse.go
@@ -146,3 +146,20 @@ func extractSpeaker(text string) (speaker, cleaned string) {
 	}
 	return "", text
 }
+
+// mergeSegments joins consecutive cues from the same speaker when the gap
+// between them is at most maxMergeGapSeconds, extending the end time and
+// concatenating text with a single space.
+func mergeSegments(in []TranscriptSegment) []TranscriptSegment {
+	const maxMergeGapSeconds = 2.0
+	var out []TranscriptSegment
+	for _, s := range in {
+		if n := len(out); n > 0 && out[n-1].Speaker == s.Speaker && s.Start-out[n-1].End <= maxMergeGapSeconds {
+			out[n-1].End = s.End
+			out[n-1].Text += " " + s.Text
+			continue
+		}
+		out = append(out, s)
+	}
+	return out
+}

--- a/internal/video/vtt_parse_test.go
+++ b/internal/video/vtt_parse_test.go
@@ -1,6 +1,9 @@
 package video
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 func TestParseVTTTimestamp(t *testing.T) {
 	cases := []struct {
@@ -31,6 +34,7 @@ func TestExtractSpeaker(t *testing.T) {
 		{"Bob: hi there", "Bob", "hi there"},
 		{"Dr. Smith: point: two", "Dr. Smith", "point: two"}, // split first ": " only
 		{"no speaker at all", "", "no speaker at all"},
+		{"10:30 Meeting: hello", "", "10:30 Meeting: hello"}, // timestamp-shaped prefix, not a speaker
 	}
 	for _, c := range cases {
 		sp, cl := extractSpeaker(c.in)
@@ -68,6 +72,67 @@ func TestParseVTT_Zoom(t *testing.T) {
 	}
 	if len(segs) != 2 || segs[0].Speaker != "Srijani Ghosh" || segs[0].Text != "Hi!" {
 		t.Fatalf("got %+v", segs)
+	}
+}
+
+func TestParseVTT_SanitizesSpeakerAngleBrackets(t *testing.T) {
+	raw := "WEBVTT\n\n00:00:00.000 --> 00:00:01.000\n<v A<b>c>hi\n\n"
+	segs, err := parseVTT([]byte(raw))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(segs) != 1 {
+		t.Fatalf("want 1 segment, got %d: %+v", len(segs), segs)
+	}
+	if strings.ContainsAny(segs[0].Speaker, "<>") {
+		t.Errorf("speaker retained angle brackets: %q", segs[0].Speaker)
+	}
+
+	vtt := segmentsToVTT(segs)
+	if strings.Count(vtt, "<v ") != 1 {
+		t.Errorf("expected exactly one <v tag in output, got: %q", vtt)
+	}
+	// The voice tag itself must be well-formed: exactly one '<' and one '>'
+	// delimiting it, with no stray angle brackets from the speaker leaking in.
+	start := strings.Index(vtt, "<v ")
+	end := strings.Index(vtt[start:], ">")
+	if end < 0 {
+		t.Fatalf("no closing '>' found for voice tag in: %q", vtt)
+	}
+	tag := vtt[start : start+end+1]
+	if strings.Count(tag, "<") != 1 || strings.Count(tag, ">") != 1 {
+		t.Errorf("malformed voice tag: %q", tag)
+	}
+}
+
+func TestParseVTT_SanitizesEntityBearingSpeaker(t *testing.T) {
+	raw := "WEBVTT\n\n00:00:00.000 --> 00:00:01.000\n<v Q3 &amp; R&amp;D>hi\n\n"
+	segs, err := parseVTT([]byte(raw))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(segs) != 1 {
+		t.Fatalf("want 1 segment, got %d: %+v", len(segs), segs)
+	}
+	if segs[0].Speaker != "Q3 & R&D" {
+		t.Errorf("expected unescaped speaker %q, got %q", "Q3 & R&D", segs[0].Speaker)
+	}
+}
+
+func TestParseVTT_IllegalButParseableTimingNotMisclassifiedAsIdentifier(t *testing.T) {
+	// Minutes >= 60 is spec-illegal but parseTimingLine/parseVTTTimestamp
+	// accept it. The identifier-skip and the actual parse must agree on a
+	// single timing detector, or this cue is silently dropped.
+	raw := "WEBVTT\n\n00:75:00.000 --> 00:76:00.000\nHello\n\n"
+	segs, err := parseVTT([]byte(raw))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(segs) != 1 {
+		t.Fatalf("want 1 segment, got %d: %+v", len(segs), segs)
+	}
+	if segs[0].Text != "Hello" {
+		t.Errorf("got %+v", segs[0])
 	}
 }
 

--- a/internal/video/vtt_parse_test.go
+++ b/internal/video/vtt_parse_test.go
@@ -96,6 +96,19 @@ func TestParseVTT_SkipsNoteAndStyle(t *testing.T) {
 	}
 }
 
+func TestParseVTT_SkipsTagOnlyPayload(t *testing.T) {
+	raw := "WEBVTT\n\n" +
+		"00:00:00.000 --> 00:00:01.000\n<c></c>\n\n" +
+		"00:00:01.000 --> 00:00:02.000\nHello\n\n"
+	segs, err := parseVTT([]byte(raw))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(segs) != 1 || segs[0].Text != "Hello" {
+		t.Fatalf("want 1 segment with text %q, got %+v", "Hello", segs)
+	}
+}
+
 func TestParseVTT_Errors(t *testing.T) {
 	if _, err := parseVTT([]byte("not a vtt file")); err == nil {
 		t.Error("want error for missing signature")

--- a/internal/video/vtt_parse_test.go
+++ b/internal/video/vtt_parse_test.go
@@ -1,0 +1,106 @@
+package video
+
+import "testing"
+
+func TestParseVTTTimestamp(t *testing.T) {
+	cases := []struct {
+		in   string
+		want float64
+		ok   bool
+	}{
+		{"00:00:01.500", 1.5, true},
+		{"01:02:03.250", 3723.25, true},
+		{"02:03.100", 123.1, true}, // no hours
+		{"garbage", 0, false},
+		{"00:00:01", 0, false}, // missing millis
+	}
+	for _, c := range cases {
+		got, ok := parseVTTTimestamp(c.in)
+		if ok != c.ok || (ok && got != c.want) {
+			t.Errorf("parseVTTTimestamp(%q) = %v,%v want %v,%v", c.in, got, ok, c.want, c.ok)
+		}
+	}
+}
+
+func TestExtractSpeaker(t *testing.T) {
+	cases := []struct {
+		in, speaker, cleaned string
+	}{
+		{"<v Alice>Hello", "Alice", "Hello"},
+		{"<v Martha Helena>Sí</v>", "Martha Helena", "Sí"},
+		{"Bob: hi there", "Bob", "hi there"},
+		{"Dr. Smith: point: two", "Dr. Smith", "point: two"}, // split first ": " only
+		{"no speaker at all", "", "no speaker at all"},
+	}
+	for _, c := range cases {
+		sp, cl := extractSpeaker(c.in)
+		if sp != c.speaker || cl != c.cleaned {
+			t.Errorf("extractSpeaker(%q) = %q,%q want %q,%q", c.in, sp, cl, c.speaker, c.cleaned)
+		}
+	}
+}
+
+func TestParseVTT_Teams(t *testing.T) {
+	raw := "\xef\xbb\xbfWEBVTT\r\n\r\n" +
+		"96c14169-de06-4080-b9fe-f573f75eb719/91-0\r\n" +
+		"00:00:04.409 --> 00:00:09.359\r\n" +
+		"<v Alice>Q3 numbers &amp; targets</v>\r\n\r\n"
+	segs, err := parseVTT([]byte(raw))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(segs) != 1 {
+		t.Fatalf("want 1 segment, got %d", len(segs))
+	}
+	s := segs[0]
+	if s.Speaker != "Alice" || s.Text != "Q3 numbers & targets" || s.Start != 4.409 {
+		t.Errorf("got %+v", s)
+	}
+}
+
+func TestParseVTT_Zoom(t *testing.T) {
+	raw := "WEBVTT\n\n" +
+		"1\n00:00:00.050 --> 00:00:01.790\nSrijani Ghosh: Hi!\n\n" +
+		"2\n00:00:02.070 --> 00:00:04.050\nConor Healy: Get this party started.\n\n"
+	segs, err := parseVTT([]byte(raw))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(segs) != 2 || segs[0].Speaker != "Srijani Ghosh" || segs[0].Text != "Hi!" {
+		t.Fatalf("got %+v", segs)
+	}
+}
+
+func TestParseVTT_NoSpeaker(t *testing.T) {
+	raw := "WEBVTT\n\n00:01:08.000 --> 00:01:09.000\nThis doesn't.\n\n"
+	segs, err := parseVTT([]byte(raw))
+	if err != nil || len(segs) != 1 || segs[0].Speaker != "" || segs[0].Text != "This doesn't." {
+		t.Fatalf("got %+v err %v", segs, err)
+	}
+}
+
+func TestParseVTT_MultiLineCue(t *testing.T) {
+	raw := "WEBVTT\n\n00:00:00.000 --> 00:00:02.000\n<v Al>line one\nline two\n\n"
+	segs, _ := parseVTT([]byte(raw))
+	if len(segs) != 1 || segs[0].Text != "line one\nline two" {
+		t.Fatalf("got %+v", segs)
+	}
+}
+
+func TestParseVTT_SkipsNoteAndStyle(t *testing.T) {
+	raw := "WEBVTT\n\nNOTE this is a comment\n\nSTYLE\n::cue { color: white }\n\n" +
+		"00:00:00.000 --> 00:00:01.000\nHello\n\n"
+	segs, err := parseVTT([]byte(raw))
+	if err != nil || len(segs) != 1 || segs[0].Text != "Hello" {
+		t.Fatalf("got %+v err %v", segs, err)
+	}
+}
+
+func TestParseVTT_Errors(t *testing.T) {
+	if _, err := parseVTT([]byte("not a vtt file")); err == nil {
+		t.Error("want error for missing signature")
+	}
+	if _, err := parseVTT([]byte("WEBVTT\n\n")); err == nil {
+		t.Error("want error for zero cues")
+	}
+}

--- a/internal/video/vtt_parse_test.go
+++ b/internal/video/vtt_parse_test.go
@@ -15,13 +15,52 @@ func TestParseVTTTimestamp(t *testing.T) {
 		{"01:02:03.250", 3723.25, true},
 		{"02:03.100", 123.1, true}, // no hours
 		{"garbage", 0, false},
-		{"00:00:01", 0, false}, // missing millis
+		{"00:00:01", 0, false},   // missing millis
+		{"xx:30:45.250", 0, false},   // non-numeric hour must be rejected, not silently 0
+		{"00:3x:00.500", 0, false},   // non-numeric minute rejected
+		{"00:75:00.000", 4500, true}, // out-of-range but numeric: tolerated, not silently zeroed
 	}
 	for _, c := range cases {
 		got, ok := parseVTTTimestamp(c.in)
 		if ok != c.ok || (ok && got != c.want) {
 			t.Errorf("parseVTTTimestamp(%q) = %v,%v want %v,%v", c.in, got, ok, c.want, c.ok)
 		}
+	}
+}
+
+func TestParseVTT_EntityEncodedMarkupDoesNotResurrectTags(t *testing.T) {
+	// Cue text with entity-encoded markup must not become live VTT markup in
+	// the re-rendered output (caption/markup injection guard).
+	raw := "WEBVTT\n\n00:00:00.000 --> 00:00:01.000\n" +
+		"User: &lt;v Attacker&gt;spoiler&lt;/v&gt;\n\n"
+	segs, err := parseVTT([]byte(raw))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if strings.Contains(segs[0].Text, "<v") || strings.Contains(segs[0].Text, "<") {
+		t.Errorf("entity-encoded tag survived into Text: %q", segs[0].Text)
+	}
+	if strings.Contains(segmentsToVTT(segs), "<v Attacker>") {
+		t.Errorf("injected voice tag reached rendered VTT:\n%s", segmentsToVTT(segs))
+	}
+}
+
+func TestMergeSegments_LargeSameSpeakerIsLinear(t *testing.T) {
+	// Guards against O(n^2) text concatenation: a big single-speaker run must
+	// merge without pathological slowdown and preserve joined text.
+	const n = 40000
+	in := make([]TranscriptSegment, n)
+	for i := range in {
+		in[i] = TranscriptSegment{
+			Start: float64(i), End: float64(i) + 0.1, Text: "word", Speaker: "A",
+		}
+	}
+	out := mergeSegments(in)
+	if len(out) != 1 {
+		t.Fatalf("want 1 merged segment, got %d", len(out))
+	}
+	if want := n*len("word") + (n - 1); len(out[0].Text) != want {
+		t.Errorf("merged text length = %d, want %d", len(out[0].Text), want)
 	}
 }
 

--- a/internal/video/vtt_parse_test.go
+++ b/internal/video/vtt_parse_test.go
@@ -144,3 +144,20 @@ func TestMergeSegments_EmptySpeakerMerges(t *testing.T) {
 		t.Fatalf("got %+v", got)
 	}
 }
+
+func TestMergeSegments_OverlappingCueDoesNotShrinkEnd(t *testing.T) {
+	in := []TranscriptSegment{
+		{Start: 0, End: 5, Text: "long one", Speaker: "A"},
+		{Start: 1, End: 2, Text: "crosstalk", Speaker: "A"}, // overlaps, ends before prior End -> must not shrink
+	}
+	got := mergeSegments(in)
+	if len(got) != 1 {
+		t.Fatalf("want 1 merged, got %d: %+v", len(got), got)
+	}
+	if got[0].End != 5 {
+		t.Errorf("merged End regressed: got %+v", got[0])
+	}
+	if got[0].Text != "long one crosstalk" {
+		t.Errorf("merged Text wrong: %+v", got[0])
+	}
+}

--- a/internal/video/vtt_parse_test.go
+++ b/internal/video/vtt_parse_test.go
@@ -104,3 +104,30 @@ func TestParseVTT_Errors(t *testing.T) {
 		t.Error("want error for zero cues")
 	}
 }
+
+func TestMergeSegments(t *testing.T) {
+	in := []TranscriptSegment{
+		{Start: 0, End: 1, Text: "Um", Speaker: "A"},
+		{Start: 1.5, End: 2, Text: "yeah", Speaker: "A"},   // gap 0.5s, same speaker -> merge
+		{Start: 2, End: 3, Text: "ok", Speaker: "B"},       // diff speaker -> new
+		{Start: 10, End: 11, Text: "later", Speaker: "B"},  // gap 7s -> new
+	}
+	got := mergeSegments(in)
+	if len(got) != 3 {
+		t.Fatalf("want 3 merged, got %d: %+v", len(got), got)
+	}
+	if got[0].Text != "Um yeah" || got[0].End != 2 {
+		t.Errorf("first merge wrong: %+v", got[0])
+	}
+}
+
+func TestMergeSegments_EmptySpeakerMerges(t *testing.T) {
+	in := []TranscriptSegment{
+		{Start: 0, End: 1, Text: "a"},
+		{Start: 1, End: 2, Text: "b"},
+	}
+	got := mergeSegments(in)
+	if len(got) != 1 || got[0].Text != "a b" {
+		t.Fatalf("got %+v", got)
+	}
+}

--- a/internal/video/watch_page_test.go
+++ b/internal/video/watch_page_test.go
@@ -195,6 +195,7 @@ func TestWatchPage_Success_RendersVideoPlayer(t *testing.T) {
 		"cue listener":    "'cuechange'",
 		"hidden track":    "subTrack.mode = 'hidden'",
 		"object-fit":      "object-fit: contain",
+		"cue tag strip":   "function cueParts(",
 	}
 	for name, want := range checks {
 		if !strings.Contains(body, want) {

--- a/web/src/api/client.test.ts
+++ b/web/src/api/client.test.ts
@@ -93,6 +93,26 @@ describe("apiFetch", () => {
     expect(headers.get("Content-Type")).toBe("application/json");
   });
 
+  it("does not set Content-Type header when body is FormData", async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({}),
+    });
+
+    const formData = new FormData();
+    formData.append("file", new Blob(["content"]), "file.vtt");
+
+    await apiFetch("/api/test", {
+      method: "POST",
+      body: formData,
+    });
+
+    const call = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+    const headers = call[1].headers as Headers;
+    expect(headers.get("Content-Type")).toBeNull();
+  });
+
   it("sets Authorization header when access token exists", async () => {
     setAccessToken("test-token");
 

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -43,7 +43,7 @@ async function apiFetch<T>(
   options: RequestInit = {}
 ): Promise<T | undefined> {
   const headers = new Headers(options.headers);
-  if (options.body) {
+  if (options.body && !(options.body instanceof FormData)) {
     headers.set("Content-Type", "application/json");
   }
 

--- a/web/src/components/FillerRemovalModal.tsx
+++ b/web/src/components/FillerRemovalModal.tsx
@@ -2,12 +2,7 @@ import { useEffect, useRef, useState } from "react";
 import { apiFetch } from "../api/client";
 import { useFocusTrap } from "../hooks/useFocusTrap";
 import { formatDuration } from "../utils/format";
-
-interface TranscriptSegment {
-  start: number;
-  end: number;
-  text: string;
-}
+import type { TranscriptSegment } from "../types/transcript";
 
 interface FillerRemovalModalProps {
   videoId: string;

--- a/web/src/components/TrimModal.tsx
+++ b/web/src/components/TrimModal.tsx
@@ -2,12 +2,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { apiFetch } from "../api/client";
 import { useFocusTrap } from "../hooks/useFocusTrap";
 import { formatDuration } from "../utils/format";
-
-interface TranscriptSegment {
-  start: number;
-  end: number;
-  text: string;
-}
+import type { TranscriptSegment } from "../types/transcript";
 
 interface TrimModalProps {
   videoId: string;

--- a/web/src/pages/VideoDetail/TranscriptSection.test.tsx
+++ b/web/src/pages/VideoDetail/TranscriptSection.test.tsx
@@ -1,0 +1,103 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { TranscriptSection } from "./TranscriptSection";
+import type { Video } from "../../types/video";
+
+const mockApiFetch = vi.fn();
+
+vi.mock("../../api/client", () => ({
+  apiFetch: (...args: unknown[]) => mockApiFetch(...args),
+}));
+
+function makeVideo(overrides: Partial<Video> = {}): Video {
+  return {
+    id: "video-1",
+    title: "Demo",
+    shareToken: "abc123defghi",
+    status: "ready",
+    transcriptStatus: "ready",
+    summaryStatus: "none",
+    documentStatus: "none",
+    ...overrides,
+  } as Video;
+}
+
+function createVttFile(name = "captions.vtt"): File {
+  const content = "WEBVTT\n\n00:00:00.000 --> 00:00:01.000\nHello\n";
+  return new File([content], name, { type: "text/vtt" });
+}
+
+function renderSection(overrides: Partial<Video> = {}) {
+  return render(
+    <TranscriptSection
+      video={makeVideo(overrides)}
+      limits={{
+        transcriptionEnabled: true,
+        aiEnabled: true,
+      } as any}
+      isViewer={false}
+      transcriptSegments={[]}
+      retranscribeLanguage="auto"
+      onRetranscribeLanguageChange={() => {}}
+      onVideoUpdate={() => {}}
+      onTranscriptClear={() => {}}
+      onTranscriptSegmentsUpdate={() => {}}
+    />
+  );
+}
+
+describe("TranscriptSection upload", () => {
+  beforeEach(() => {
+    mockApiFetch.mockReset();
+  });
+
+  it("renders an upload transcript control", () => {
+    renderSection();
+    expect(
+      screen.getByRole("button", { name: /upload transcript/i })
+    ).toBeInTheDocument();
+  });
+
+  it("uploads a selected .vtt file via multipart POST", async () => {
+    const user = userEvent.setup();
+    mockApiFetch.mockResolvedValueOnce({
+      segments: [{ start: 0, end: 1, text: "Hello" }],
+    });
+
+    renderSection();
+
+    const file = createVttFile();
+    const input = screen.getByTestId("transcript-upload-input");
+    await user.upload(input, file);
+
+    await waitFor(() => {
+      expect(mockApiFetch).toHaveBeenCalledWith(
+        "/api/videos/video-1/transcript",
+        expect.objectContaining({
+          method: "POST",
+          body: expect.any(FormData),
+        })
+      );
+    });
+
+    const [, options] = mockApiFetch.mock.calls[0];
+    const formData = options.body as FormData;
+    expect(formData.get("file")).toBe(file);
+  });
+
+  it("shows an error toast on upload failure", async () => {
+    const user = userEvent.setup();
+    mockApiFetch.mockRejectedValueOnce(new Error("invalid WebVTT file"));
+
+    renderSection();
+
+    const file = createVttFile();
+    const input = screen.getByTestId("transcript-upload-input");
+    await user.upload(input, file);
+
+    await waitFor(() => {
+      expect(screen.getByText(/invalid WebVTT file/)).toBeInTheDocument();
+    });
+  });
+});

--- a/web/src/pages/VideoDetail/TranscriptSection.test.tsx
+++ b/web/src/pages/VideoDetail/TranscriptSection.test.tsx
@@ -137,6 +137,54 @@ describe("TranscriptSection upload", () => {
     });
   });
 
+  it("ignores an in-flight upload result after navigating to another video", async () => {
+    const user = userEvent.setup();
+    let resolveUpload!: (value: {
+      segments: { start: number; end: number; text: string }[];
+    }) => void;
+    mockApiFetch.mockReturnValueOnce(
+      new Promise((resolve) => {
+        resolveUpload = resolve;
+      })
+    );
+
+    const onTranscriptSegmentsUpdate = vi.fn();
+    const props = {
+      limits: { transcriptionEnabled: true, aiEnabled: true } as any,
+      isViewer: false,
+      transcriptSegments: [],
+      retranscribeLanguage: "auto",
+      onRetranscribeLanguageChange: () => {},
+      onVideoUpdate: () => {},
+      onTranscriptClear: () => {},
+      onTranscriptSegmentsUpdate,
+    };
+
+    const { rerender } = render(
+      <TranscriptSection video={makeVideo({ id: "video-1" })} {...props} />
+    );
+
+    await user.upload(
+      screen.getByTestId("transcript-upload-input"),
+      createVttFile()
+    );
+
+    // User navigates to a different video while the upload is still pending.
+    rerender(
+      <TranscriptSection video={makeVideo({ id: "video-2" })} {...props} />
+    );
+
+    resolveUpload({ segments: [{ start: 0, end: 1, text: "stale" }] });
+
+    await waitFor(() => {
+      expect(mockApiFetch).toHaveBeenCalledWith(
+        "/api/videos/video-1/transcript",
+        expect.anything()
+      );
+    });
+    expect(onTranscriptSegmentsUpdate).not.toHaveBeenCalled();
+  });
+
   it("hides the upload transcript button for viewers", () => {
     renderSection({}, true);
     expect(

--- a/web/src/pages/VideoDetail/TranscriptSection.test.tsx
+++ b/web/src/pages/VideoDetail/TranscriptSection.test.tsx
@@ -62,6 +62,28 @@ describe("TranscriptSection upload", () => {
     ).toBeInTheDocument();
   });
 
+  it("renders the speaker name alongside the segment text", () => {
+    render(
+      <TranscriptSection
+        video={makeVideo({ transcriptStatus: "ready" })}
+        limits={{ transcriptionEnabled: true, aiEnabled: true } as any}
+        isViewer={false}
+        transcriptSegments={[
+          { start: 0, end: 2, text: "Hello everyone", speaker: "Alice Johnson" },
+          { start: 2, end: 4, text: "No speaker here" },
+        ]}
+        retranscribeLanguage="auto"
+        onRetranscribeLanguageChange={() => {}}
+        onVideoUpdate={() => {}}
+        onTranscriptClear={() => {}}
+        onTranscriptSegmentsUpdate={() => {}}
+      />
+    );
+    expect(screen.getByText("Alice Johnson")).toBeInTheDocument();
+    expect(screen.getByText("Hello everyone")).toBeInTheDocument();
+    expect(screen.getByText("No speaker here")).toBeInTheDocument();
+  });
+
   it("uploads a selected .vtt file via multipart POST", async () => {
     const user = userEvent.setup();
     mockApiFetch.mockResolvedValueOnce({

--- a/web/src/pages/VideoDetail/TranscriptSection.test.tsx
+++ b/web/src/pages/VideoDetail/TranscriptSection.test.tsx
@@ -28,7 +28,10 @@ function createVttFile(name = "captions.vtt"): File {
   return new File([content], name, { type: "text/vtt" });
 }
 
-function renderSection(overrides: Partial<Video> = {}) {
+function renderSection(
+  overrides: Partial<Video> = {},
+  isViewer = false
+) {
   return render(
     <TranscriptSection
       video={makeVideo(overrides)}
@@ -36,7 +39,7 @@ function renderSection(overrides: Partial<Video> = {}) {
         transcriptionEnabled: true,
         aiEnabled: true,
       } as any}
-      isViewer={false}
+      isViewer={isViewer}
       transcriptSegments={[]}
       retranscribeLanguage="auto"
       onRetranscribeLanguageChange={() => {}}
@@ -99,5 +102,52 @@ describe("TranscriptSection upload", () => {
     await waitFor(() => {
       expect(screen.getByText(/invalid WebVTT file/)).toBeInTheDocument();
     });
+  });
+
+  it("disables the upload button and shows uploading state during the in-flight POST", async () => {
+    const user = userEvent.setup();
+    let resolveUpload!: (value: {
+      segments: { start: number; end: number; text: string }[];
+    }) => void;
+    mockApiFetch.mockReturnValueOnce(
+      new Promise((resolve) => {
+        resolveUpload = resolve;
+      })
+    );
+
+    renderSection();
+
+    const file = createVttFile();
+    const input = screen.getByTestId("transcript-upload-input");
+    await user.upload(input, file);
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: /uploading/i })
+      ).toBeDisabled();
+    });
+    expect(input).toBeDisabled();
+
+    resolveUpload({ segments: [] });
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: /upload transcript/i })
+      ).not.toBeDisabled();
+    });
+  });
+
+  it("hides the upload transcript button for viewers", () => {
+    renderSection({}, true);
+    expect(
+      screen.queryByRole("button", { name: /upload transcript/i })
+    ).not.toBeInTheDocument();
+  });
+
+  it("hides the upload transcript button while transcription is processing", () => {
+    renderSection({ transcriptStatus: "processing" });
+    expect(
+      screen.queryByRole("button", { name: /upload transcript/i })
+    ).not.toBeInTheDocument();
   });
 });

--- a/web/src/pages/VideoDetail/TranscriptSection.tsx
+++ b/web/src/pages/VideoDetail/TranscriptSection.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useRef, useState } from "react";
 import { apiFetch } from "../../api/client";
 import { useToast } from "../../hooks/useToast";
 import { Toast } from "../../components/Toast";
@@ -23,6 +23,7 @@ interface TranscriptSectionProps {
   onRetranscribeLanguageChange: (language: string) => void;
   onVideoUpdate: (updater: (prev: Video | null) => Video | null) => void;
   onTranscriptClear: () => void;
+  onTranscriptSegmentsUpdate: (segments: TranscriptSegment[]) => void;
 }
 
 export function TranscriptSection({
@@ -34,10 +35,12 @@ export function TranscriptSection({
   onRetranscribeLanguageChange,
   onVideoUpdate,
   onTranscriptClear,
+  onTranscriptSegmentsUpdate,
 }: TranscriptSectionProps) {
   const toast = useToast();
   const [showDocumentModal, setShowDocumentModal] = useState(false);
   const [documentContent, setDocumentContent] = useState<string | null>(null);
+  const uploadInputRef = useRef<HTMLInputElement>(null);
 
   async function retranscribe() {
     const body =
@@ -53,6 +56,34 @@ export function TranscriptSection({
     );
     onTranscriptClear();
     toast.show("Transcription queued");
+  }
+
+  async function uploadTranscript(file: File) {
+    const formData = new FormData();
+    formData.append("file", file);
+    try {
+      const data = await apiFetch<{ segments: TranscriptSegment[] }>(
+        `/api/videos/${video.id}/transcript`,
+        { method: "POST", body: formData },
+      );
+      onVideoUpdate((prev) =>
+        prev ? { ...prev, transcriptStatus: "ready" } : prev,
+      );
+      onTranscriptSegmentsUpdate(data?.segments ?? []);
+      toast.show("Transcript uploaded");
+    } catch (err) {
+      toast.show(
+        err instanceof Error ? err.message : "Failed to upload transcript",
+      );
+    }
+  }
+
+  function handleUploadInputChange(e: React.ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0];
+    e.target.value = "";
+    if (file) {
+      void uploadTranscript(file);
+    }
   }
 
   async function summarize() {
@@ -128,6 +159,20 @@ export function TranscriptSection({
                         ? "Redo transcript"
                         : "Retry transcript"}
                   </button>
+                  <button
+                    onClick={() => uploadInputRef.current?.click()}
+                    className="detail-btn"
+                  >
+                    Upload transcript
+                  </button>
+                  <input
+                    ref={uploadInputRef}
+                    type="file"
+                    accept=".vtt,text/vtt"
+                    data-testid="transcript-upload-input"
+                    onChange={handleUploadInputChange}
+                    style={{ display: "none" }}
+                  />
                 </>
               )}
           </div>

--- a/web/src/pages/VideoDetail/TranscriptSection.tsx
+++ b/web/src/pages/VideoDetail/TranscriptSection.tsx
@@ -42,6 +42,8 @@ export function TranscriptSection({
   const [documentContent, setDocumentContent] = useState<string | null>(null);
   const [uploadingTranscript, setUploadingTranscript] = useState(false);
   const uploadInputRef = useRef<HTMLInputElement>(null);
+  const currentVideoId = useRef(video.id);
+  currentVideoId.current = video.id;
 
   async function retranscribe() {
     const body =
@@ -60,25 +62,34 @@ export function TranscriptSection({
   }
 
   async function uploadTranscript(file: File) {
+    const uploadVideoId = video.id;
     const formData = new FormData();
     formData.append("file", file);
     setUploadingTranscript(true);
     try {
       const data = await apiFetch<{ segments: TranscriptSegment[] }>(
-        `/api/videos/${video.id}/transcript`,
+        `/api/videos/${uploadVideoId}/transcript`,
         { method: "POST", body: formData },
       );
+      // The user may have navigated to another video while the upload was in
+      // flight; only apply the result if this is still the shown video.
+      // The user may have navigated to another video while the upload was in
+      // flight; only apply the result if this is still the shown video.
+      if (currentVideoId.current !== uploadVideoId) return;
       onVideoUpdate((prev) =>
         prev ? { ...prev, transcriptStatus: "ready" } : prev,
       );
       onTranscriptSegmentsUpdate(data?.segments ?? []);
       toast.show("Transcript uploaded");
     } catch (err) {
+      if (currentVideoId.current !== uploadVideoId) return;
       toast.show(
         err instanceof Error ? err.message : "Failed to upload transcript",
       );
     } finally {
-      setUploadingTranscript(false);
+      if (currentVideoId.current === uploadVideoId) {
+        setUploadingTranscript(false);
+      }
     }
   }
 

--- a/web/src/pages/VideoDetail/TranscriptSection.tsx
+++ b/web/src/pages/VideoDetail/TranscriptSection.tsx
@@ -5,14 +5,9 @@ import { Toast } from "../../components/Toast";
 import { DocumentModal } from "../../components/DocumentModal";
 import { TRANSCRIPTION_LANGUAGES } from "../../constants/languages";
 import type { Video } from "../../types/video";
+import type { TranscriptSegment } from "../../types/transcript";
 import { LimitsResponse } from "../../types/limits";
 import { formatDuration } from "../../utils/format";
-
-interface TranscriptSegment {
-  start: number;
-  end: number;
-  text: string;
-}
 
 interface TranscriptSectionProps {
   video: Video;
@@ -206,7 +201,14 @@ export function TranscriptSection({
                   <span className="transcript-segment-time">
                     {formatDuration(seg.start)}
                   </span>
-                  <span className="transcript-segment-text">{seg.text}</span>
+                  <span className="transcript-segment-text">
+                    {seg.speaker && (
+                      <span className="transcript-segment-speaker">
+                        {seg.speaker}
+                      </span>
+                    )}
+                    {seg.text}
+                  </span>
                 </div>
               ))}
             </div>

--- a/web/src/pages/VideoDetail/TranscriptSection.tsx
+++ b/web/src/pages/VideoDetail/TranscriptSection.tsx
@@ -40,6 +40,7 @@ export function TranscriptSection({
   const toast = useToast();
   const [showDocumentModal, setShowDocumentModal] = useState(false);
   const [documentContent, setDocumentContent] = useState<string | null>(null);
+  const [uploadingTranscript, setUploadingTranscript] = useState(false);
   const uploadInputRef = useRef<HTMLInputElement>(null);
 
   async function retranscribe() {
@@ -61,6 +62,7 @@ export function TranscriptSection({
   async function uploadTranscript(file: File) {
     const formData = new FormData();
     formData.append("file", file);
+    setUploadingTranscript(true);
     try {
       const data = await apiFetch<{ segments: TranscriptSegment[] }>(
         `/api/videos/${video.id}/transcript`,
@@ -75,6 +77,8 @@ export function TranscriptSection({
       toast.show(
         err instanceof Error ? err.message : "Failed to upload transcript",
       );
+    } finally {
+      setUploadingTranscript(false);
     }
   }
 
@@ -161,9 +165,13 @@ export function TranscriptSection({
                   </button>
                   <button
                     onClick={() => uploadInputRef.current?.click()}
+                    disabled={uploadingTranscript}
                     className="detail-btn"
+                    style={{
+                      opacity: uploadingTranscript ? 0.5 : undefined,
+                    }}
                   >
-                    Upload transcript
+                    {uploadingTranscript ? "Uploading..." : "Upload transcript"}
                   </button>
                   <input
                     ref={uploadInputRef}
@@ -171,6 +179,7 @@ export function TranscriptSection({
                     accept=".vtt,text/vtt"
                     data-testid="transcript-upload-input"
                     onChange={handleUploadInputChange}
+                    disabled={uploadingTranscript}
                     style={{ display: "none" }}
                   />
                 </>

--- a/web/src/pages/VideoDetail/index.tsx
+++ b/web/src/pages/VideoDetail/index.tsx
@@ -10,6 +10,7 @@ import { SilenceRemovalModal } from "../../components/SilenceRemovalModal";
 import { Toast } from "../../components/Toast";
 import { ConfirmDialog, ConfirmDialogState } from "../../components/ConfirmDialog";
 import type { Video, Folder, Tag } from "../../types/video";
+import type { TranscriptSegment } from "../../types/transcript";
 import { LimitsResponse } from "../../types/limits";
 import { formatDuration, formatDate, expiryLabel } from "../../utils/format";
 import { copyToClipboard } from "../../utils/clipboard";
@@ -21,12 +22,6 @@ interface PlaylistInfo {
   id: string;
   title: string;
   videoCount: number;
-}
-
-interface TranscriptSegment {
-  start: number;
-  end: number;
-  text: string;
 }
 
 interface TranscriptResponse {

--- a/web/src/pages/VideoDetail/index.tsx
+++ b/web/src/pages/VideoDetail/index.tsx
@@ -789,6 +789,7 @@ export function VideoDetail() {
         onRetranscribeLanguageChange={setRetranscribeLanguage}
         onVideoUpdate={setVideo}
         onTranscriptClear={() => setTranscriptSegments([])}
+        onTranscriptSegmentsUpdate={setTranscriptSegments}
       />
 
       {/* Editing */}

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -3517,6 +3517,12 @@ textarea.form-input {
   color: var(--color-text);
 }
 
+.transcript-segment-speaker {
+  font-weight: 600;
+  margin-right: 6px;
+  color: var(--color-text);
+}
+
 /* Comments section */
 .comment-item {
   display: flex;

--- a/web/src/types/transcript.ts
+++ b/web/src/types/transcript.ts
@@ -1,0 +1,6 @@
+export interface TranscriptSegment {
+  start: number;
+  end: number;
+  text: string;
+  speaker?: string;
+}


### PR DESCRIPTION
Implements discussion #157.

Upload a pre-made VTT (MS Teams / Zoom), skip whisper, and use it as the transcript — replacing any existing one. Teams/Zoom transcribe per-participant, so their VTT is more accurate and speaker-attributed than whisper on the single mixed track.

## What it does
- **One tolerant `parseVTT`** for both Teams (`<v Speaker>` + GUID cue IDs) and Zoom (`Name: text` + integer cue IDs): skips opaque ID lines, extracts speaker two ways, and handles BOM, CRLF/CR, HTML entities, hours-optional timestamps, and optional `</v>`. Tag-only cues are dropped; a leading-timestamp prefix (`10:30 Meeting:`) is not misread as a speaker.
- **`mergeSegments`** joins consecutive same-speaker cues ≤2s apart (never shrinks end time on overlap).
- **`segmentsToVTT`** emits `<v Speaker>` (speaker name sanitized — no `<`/`>`/newlines).
- **`POST /api/videos/{id}/transcript`** (multipart, 5 MB cap, 413 on oversize) parses → merges → stores the VTT to S3 → sets `transcript_json` / `transcript_key` / `transcript_status='ready'`. Covers both set-where-none and replace-existing.
- **Speaker** is a new JSON-only field on `TranscriptSegment` (`omitempty`) — no DB migration, and existing whisper VTT output stays byte-identical (golden test green). It's included in transcript search.
- **Frontend**: an "Upload transcript (VTT)" button in the video detail transcript section, with an in-flight loading/disabled state.

## Notes
- GET and POST `/api/videos/{id}/transcript` share one router subtree so neither shadows the other; POST carries the larger body cap + writer gate, GET stays viewer-readable.
- OpenAPI schema updated with the optional `speaker` field.

Built TDD; full Go suite + 744 frontend tests pass, `go vet` clean.