### PR TITLE
chore: add grouped Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,27 @@
+version: 2
+updates:
+  # Grouped so an aws-sdk-go-v2 bump arrives as one PR, not a dozen.
+  # govulncheck in CI is the gate on whether it is safe to merge.
+  - package-ecosystem: gomod
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      go:
+        patterns: ["*"]
+
+  - package-ecosystem: npm
+    directory: /web
+    schedule:
+      interval: weekly
+    groups:
+      npm:
+        patterns: ["*"]
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly
+    groups:
+      actions:
+        patterns: ["*"]


### PR DESCRIPTION
Follow-up to #161. Those three advisories had been sitting on `main` unnoticed until CI on #160 tripped over them — nothing was watching for dependency updates.

`gomod` and `npm` weekly, `github-actions` monthly. Everything is grouped so an `aws-sdk-go-v2` bump arrives as one PR rather than a dozen; `govulncheck` in CI stays the gate on whether a bump is actually safe to merge.

**Known gap:** Dependabot does not bump the `go` directive, so stdlib advisories like [GO-2026-5856](https://pkg.go.dev/vuln/GO-2026-5856) still need a manual edit. Loosening `go.mod` to `go 1.26` would let `setup-go` resolve the latest patch on every run and pick those up for free, at the cost of a pinned toolchain — deliberately not doing that here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated dependency update checks for Go modules, npm packages, and GitHub Actions.
  * Updates are grouped by ecosystem to simplify maintenance and review.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->