### PR TITLE
fix(docker): build with Go 1.26.5 to match the go directive

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ COPY web/ .
 RUN pnpm build
 
 # Stage 2: Build Go binary
-FROM golang:1.26.4-alpine AS backend
+FROM golang:1.26.5-alpine AS backend
 WORKDIR /app
 COPY go.mod go.sum ./
 RUN go mod download


### PR DESCRIPTION
**Main is currently unbuildable.** My #161 raised the `go` directive to 1.26.5 to clear [GO-2026-5856](https://pkg.go.dev/vuln/GO-2026-5856) but left `FROM golang:1.26.4-alpine` in the Dockerfile. The alpine images pin `GOTOOLCHAIN=local`, so this is fatal rather than an implicit toolchain download:

```
go: go.mod requires go >= 1.26.5 (running go 1.26.4; GOTOOLCHAIN=local)
```

Every image build since that merge has failed at `go mod download` (Dockerfile line 98) — the `sendrec` app deployment at 19:11 today and the PR-164 preview build both died there.

There is a second reason the pin has to move: CI's `govulncheck` resolves its toolchain from `go.mod`, so it reported clean while the binary that actually ships was still compiled with 1.26.4 and still carried the advisory. Without this change #161 fixed the scanner, not the artifact.

Reproduced and verified locally against the real `go.mod`:

```
$ docker run --rm -v "$PWD":/src -w /src golang:1.26.4-alpine go mod download
go: go.mod requires go >= 1.26.5 (running go 1.26.4; GOTOOLCHAIN=local)

$ docker run --rm -v "$PWD":/src -w /src golang:1.26.5-alpine sh -c 'go mod download && go build ./...'
go mod download OK
go build OK
```

Worth pairing with a guard so the two can't drift again — the Dockerfile pin and the `go` directive have no link enforcing agreement.