### PR TITLE
fix(transcode): consume retry budget on upload and db-update failure

### DIFF
--- a/internal/video/normalize.go
+++ b/internal/video/normalize.go
@@ -75,7 +75,8 @@ type ffprobeResult struct {
 	} `json:"streams"`
 }
 
-func probeVideoProperties(inputPath string) (videoProperties, error) {
+// See transcodeToMP4 for why this is a var.
+var probeVideoProperties = func(inputPath string) (videoProperties, error) {
 	cmd := exec.Command("ffprobe",
 		"-v", "error",
 		"-select_streams", "v:0",
@@ -125,7 +126,8 @@ func buildNormalizeArgs(inputPath, outputPath, audioFilter string) []string {
 	return args
 }
 
-func transcodeToIOSCompatible(inputPath, outputPath, audioFilter string) error {
+// See transcodeToMP4 for why this is a var.
+var transcodeToIOSCompatible = func(inputPath, outputPath, audioFilter string) error {
 	args := buildNormalizeArgs(inputPath, outputPath, audioFilter)
 	cmd := exec.Command("ffmpeg", args...)
 	output, err := cmd.CombinedOutput()
@@ -212,6 +214,7 @@ func NormalizeVideoAsync(ctx context.Context, db database.DBTX, storage ObjectSt
 
 	if err := storage.UploadFile(ctx, fileKey, tmpOutputPath, "video/mp4"); err != nil {
 		slog.Error("normalize: failed to upload", "video_id", videoID, "error", err)
+		recordTranscodeFailure(ctx, db, videoID, err)
 		return
 	}
 
@@ -220,6 +223,7 @@ func NormalizeVideoAsync(ctx context.Context, db database.DBTX, storage ObjectSt
 		videoID, newFileSize,
 	); err != nil {
 		slog.Error("normalize: failed to update db", "video_id", videoID, "error", err)
+		recordTranscodeFailure(ctx, db, videoID, err)
 		return
 	}
 

--- a/internal/video/transcode.go
+++ b/internal/video/transcode.go
@@ -30,7 +30,9 @@ func buildTranscodeArgs(inputPath, outputPath, audioFilter string) []string {
 	return args
 }
 
-func transcodeToMP4(inputPath, outputPath, audioFilter string) error {
+// Package-level var so tests can reach the steps after ffmpeg without needing
+// an ffmpeg binary or a real video fixture.
+var transcodeToMP4 = func(inputPath, outputPath, audioFilter string) error {
 	args := buildTranscodeArgs(inputPath, outputPath, audioFilter)
 	cmd := exec.Command("ffmpeg", args...)
 	output, err := cmd.CombinedOutput()
@@ -170,6 +172,7 @@ func TranscodeWebMAsync(ctx context.Context, db database.DBTX, storage ObjectSto
 
 	if err := storage.UploadFile(ctx, newFileKey, tmpOutputPath, "video/mp4"); err != nil {
 		slog.Error("transcode: failed to upload", "video_id", videoID, "error", err)
+		recordTranscodeFailure(ctx, db, videoID, err)
 		return
 	}
 
@@ -178,6 +181,7 @@ func TranscodeWebMAsync(ctx context.Context, db database.DBTX, storage ObjectSto
 		videoID, newFileKey, newFileSize,
 	); err != nil {
 		slog.Error("transcode: failed to update db", "video_id", videoID, "error", err)
+		recordTranscodeFailure(ctx, db, videoID, err)
 		return
 	}
 

--- a/internal/video/transcode.go
+++ b/internal/video/transcode.go
@@ -73,12 +73,15 @@ func isPermanentFFmpegError(err error) bool {
 func recordTranscodeFailure(ctx context.Context, db database.DBTX, videoID string, cause error) {
 	permanent := isPermanentFFmpegError(cause)
 
+	// The cause carries raw ffmpeg output, so it can hold arbitrary bytes, and
+	// truncation can split a rune. Postgres rejects both invalid UTF-8 and NUL
+	// in a text column; either would fail this UPDATE and leave the attempt
+	// counter untouched, which is the loop this whole mechanism exists to stop.
 	msg := cause.Error()
 	if len(msg) > 2000 {
-		// Byte-slicing can split a rune; Postgres rejects invalid UTF-8, which
-		// would fail this UPDATE and leave the attempt counter untouched.
-		msg = strings.ToValidUTF8(msg[:2000], "")
+		msg = msg[:2000]
 	}
+	msg = strings.ReplaceAll(strings.ToValidUTF8(msg, ""), "\x00", "")
 
 	var attempts int
 	err := db.QueryRow(ctx,

--- a/internal/video/transcode_test.go
+++ b/internal/video/transcode_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"slices"
 	"strings"
 	"testing"
@@ -355,5 +356,106 @@ func TestNormalizeVideoAsync_StopsWhenBudgetExhausted(t *testing.T) {
 	}
 	if s.downloadToFileCount != 0 {
 		t.Errorf("expected no download, got %d", s.downloadToFileCount)
+	}
+}
+
+// stubFFmpeg replaces the ffmpeg call with one that just writes the output
+// file, so a test can reach the upload and db-update steps that follow.
+func stubFFmpeg(t *testing.T, target *func(string, string, string) error) {
+	t.Helper()
+	original := *target
+	*target = func(_, outputPath, _ string) error {
+		return os.WriteFile(outputPath, []byte("fake mp4"), 0o600)
+	}
+	t.Cleanup(func() { *target = original })
+}
+
+// An upload failure leaves the video exactly as the worker query found it, so
+// without an attempt bump the worker re-downloads and re-runs ffmpeg forever.
+func TestTranscodeWebMAsync_UploadFailureConsumesBudget(t *testing.T) {
+	mock, err := pgxmock.NewPool()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer mock.Close()
+
+	stubFFmpeg(t, &transcodeToMP4)
+	s := &mockStorage{uploadFileErr: fmt.Errorf("s3 unavailable")}
+
+	mock.ExpectQuery(`SELECT content_type, transcode_attempts FROM videos`).
+		WithArgs("video-1").
+		WillReturnRows(pgxmock.NewRows([]string{"content_type", "transcode_attempts"}).
+			AddRow("video/webm", 0))
+	mock.ExpectQuery(`UPDATE videos`).
+		WithArgs("video-1", "s3 unavailable", false, maxTranscodeAttempts).
+		WillReturnRows(pgxmock.NewRows([]string{"transcode_attempts"}).AddRow(1))
+
+	TranscodeWebMAsync(context.Background(), mock, s, "video-1", "recordings/user/video.webm", "")
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet expectations: %v", err)
+	}
+}
+
+// The transcoded object is already uploaded by this point, so an unbounded
+// retry also leaves a duplicate .mp4 behind on every pass.
+func TestTranscodeWebMAsync_DBUpdateFailureConsumesBudget(t *testing.T) {
+	mock, err := pgxmock.NewPool()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer mock.Close()
+
+	stubFFmpeg(t, &transcodeToMP4)
+	s := &mockStorage{}
+
+	mock.ExpectQuery(`SELECT content_type, transcode_attempts FROM videos`).
+		WithArgs("video-1").
+		WillReturnRows(pgxmock.NewRows([]string{"content_type", "transcode_attempts"}).
+			AddRow("video/webm", 0))
+	mock.ExpectExec(`UPDATE videos SET file_key`).
+		WithArgs("video-1", pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnError(errors.New("deadlock detected"))
+	mock.ExpectQuery(`UPDATE videos`).
+		WithArgs("video-1", "deadlock detected", false, maxTranscodeAttempts).
+		WillReturnRows(pgxmock.NewRows([]string{"transcode_attempts"}).AddRow(1))
+
+	TranscodeWebMAsync(context.Background(), mock, s, "video-1", "recordings/user/video.webm", "")
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet expectations: %v", err)
+	}
+}
+
+func TestNormalizeVideoAsync_UploadFailureConsumesBudget(t *testing.T) {
+	mock, err := pgxmock.NewPool()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer mock.Close()
+
+	stubFFmpeg(t, &transcodeToIOSCompatible)
+	// Report a non-h264 codec so needsNormalization() is true and the re-encode
+	// path runs instead of the early "already compatible" exit.
+	originalProbe := probeVideoProperties
+	probeVideoProperties = func(string) (videoProperties, error) {
+		return videoProperties{CodecName: "vp9", Width: 1280, Height: 720}, nil
+	}
+	t.Cleanup(func() { probeVideoProperties = originalProbe })
+
+	s := &mockStorage{uploadFileErr: fmt.Errorf("s3 unavailable")}
+
+	mock.ExpectQuery(`SELECT ios_normalized, transcode_attempts FROM videos`).
+		WithArgs("video-1").
+		WillReturnRows(pgxmock.NewRows([]string{"ios_normalized", "transcode_attempts"}).
+			AddRow(false, 0))
+	mock.ExpectQuery(`UPDATE videos`).
+		WithArgs("video-1", "s3 unavailable", false, maxTranscodeAttempts).
+		WillReturnRows(pgxmock.NewRows([]string{"transcode_attempts"}).AddRow(1))
+
+	NormalizeVideoAsync(context.Background(), mock, s, "video-1", "recordings/user/video.mp4", "")
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet expectations: %v", err)
 	}
 }

--- a/internal/video/transcode_test.go
+++ b/internal/video/transcode_test.go
@@ -44,22 +44,6 @@ func TestTranscodeWebMAsync_FFmpegFails(t *testing.T) {
 	}
 }
 
-func TestTranscodeWebMAsync_UploadError(t *testing.T) {
-	mock, err := pgxmock.NewPool()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer mock.Close()
-
-	s := &mockStorage{uploadFileErr: fmt.Errorf("upload failed")}
-
-	TranscodeWebMAsync(context.Background(), mock, s, "video-123", "recordings/user/video.webm", "")
-
-	if err := mock.ExpectationsWereMet(); err != nil {
-		t.Errorf("unmet expectations: %v", err)
-	}
-}
-
 func TestIsPermanentFFmpegError(t *testing.T) {
 	if isPermanentFFmpegError(nil) {
 		t.Error("expected nil error to be non-permanent")
@@ -451,6 +435,64 @@ func TestNormalizeVideoAsync_UploadFailureConsumesBudget(t *testing.T) {
 			AddRow(false, 0))
 	mock.ExpectQuery(`UPDATE videos`).
 		WithArgs("video-1", "s3 unavailable", false, maxTranscodeAttempts).
+		WillReturnRows(pgxmock.NewRows([]string{"transcode_attempts"}).AddRow(1))
+
+	NormalizeVideoAsync(context.Background(), mock, s, "video-1", "recordings/user/video.mp4", "")
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet expectations: %v", err)
+	}
+}
+
+// ffmpeg output reaches this column verbatim, so a short message can still
+// carry bytes Postgres refuses even when no truncation happens.
+func TestRecordTranscodeFailure_SanitizesShortMessages(t *testing.T) {
+	mock, err := pgxmock.NewPool()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer mock.Close()
+
+	// Invalid UTF-8 and a NUL, well under the truncation threshold. NUL is
+	// valid UTF-8, so ToValidUTF8 alone does not remove it.
+	cause := fmt.Errorf("ffmpeg: %s", "bad\xffbyte\x00here")
+
+	mock.ExpectQuery(`UPDATE videos`).
+		WithArgs("video-1", "ffmpeg: badbytehere", false, maxTranscodeAttempts).
+		WillReturnRows(pgxmock.NewRows([]string{"transcode_attempts"}).AddRow(1))
+
+	recordTranscodeFailure(context.Background(), mock, "video-1", cause)
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet expectations: %v", err)
+	}
+}
+
+func TestNormalizeVideoAsync_DBUpdateFailureConsumesBudget(t *testing.T) {
+	mock, err := pgxmock.NewPool()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer mock.Close()
+
+	stubFFmpeg(t, &transcodeToIOSCompatible)
+	originalProbe := probeVideoProperties
+	probeVideoProperties = func(string) (videoProperties, error) {
+		return videoProperties{CodecName: "vp9", Width: 1280, Height: 720}, nil
+	}
+	t.Cleanup(func() { probeVideoProperties = originalProbe })
+
+	s := &mockStorage{}
+
+	mock.ExpectQuery(`SELECT ios_normalized, transcode_attempts FROM videos`).
+		WithArgs("video-1").
+		WillReturnRows(pgxmock.NewRows([]string{"ios_normalized", "transcode_attempts"}).
+			AddRow(false, 0))
+	mock.ExpectExec(`UPDATE videos SET file_size`).
+		WithArgs("video-1", pgxmock.AnyArg()).
+		WillReturnError(errors.New("deadlock detected"))
+	mock.ExpectQuery(`UPDATE videos`).
+		WithArgs("video-1", "deadlock detected", false, maxTranscodeAttempts).
 		WillReturnRows(pgxmock.NewRows([]string{"transcode_attempts"}).AddRow(1))
 
 	NormalizeVideoAsync(context.Background(), mock, s, "video-1", "recordings/user/video.mp4", "")


### PR DESCRIPTION
Closes #162.

`recordTranscodeFailure` covered only the download and ffmpeg branches. A failing `UploadFile` or final `UPDATE` returned with `transcode_attempts` untouched, so the worker query — which selects on `transcode_attempts < $1` — re-selected the same video on the next tick and repeated the **full** download and ffmpeg run before dying in the same place. That is the unbounded loop #160 set out to close, reached through a different branch.

The db-update case is worse in one respect: the transcoded object is already uploaded by that point, so every pass also leaves a duplicate `.mp4` behind.

Four call sites, two in `transcode.go` and two in `normalize.go`. The temp-file and `os.Stat` branches are deliberately left alone — those are local-disk failures that affect every video equally, so bounding them per-video would be wrong.

### Tradeoff

Transient storage outages now consume budget, so a video can exhaust its 5 attempts during one and never retry afterward. I took the flat bound because a stuck video is recoverable by resetting the counter, whereas an unbounded ffmpeg loop is not. A separate, larger cap for transient failures is the alternative if that is the wrong call.

### Testing

The existing `TestTranscodeWebMAsync_UploadError` sets no DB expectations and dies at the first query, so it never reached the upload branch and could not fail. Real coverage needs to get past ffmpeg, and CI has no ffmpeg binary — so `transcodeToMP4`, `transcodeToIOSCompatible`, and `probeVideoProperties` are now package-level vars that tests can substitute.

Three new tests, each verified to fail before the fix:

```
--- FAIL: TestTranscodeWebMAsync_UploadFailureConsumesBudget
--- FAIL: TestTranscodeWebMAsync_DBUpdateFailureConsumesBudget
--- FAIL: TestNormalizeVideoAsync_UploadFailureConsumesBudget
```

and pass after. `go vet ./internal/...` clean, `go test ./...` all packages pass.