### PR TITLE
chore: bump appVersion to 1.90.0

### DIFF
--- a/helm/sendrec/Chart.yaml
+++ b/helm/sendrec/Chart.yaml
@@ -20,5 +20,5 @@ maintainers:
 - name: mark24slides
 - name: alexneamtu 
 
-version: "1.2.2"
-appVersion: "1.89.1"
+version: "1.2.3"
+appVersion: "1.90.0"


### PR DESCRIPTION
Version bump ahead of tagging `v1.90.0`, the first release since `v1.89.1` (2026-06-24).

Minor rather than patch: the range carries a new feature, a schema migration, and a behaviour change.

| PR | |
|---|---|
| #158 | Teams/Zoom VTT transcript upload |
| #160 | bound transcode retries, retire abandoned uploads — **migration `000059`** |
| #169 | consume retry budget on upload and db-update failure |
| #161, #165, #168 | Go dependency CVE fixes, plus the Go 1.26.5 builder image that makes them real in the shipped binary |
| #167 | frontend dependencies, including vite 7 → 8 |
| #163, #164, #166 | CI and Dependabot only |

Chart version moves too, matching what the `v1.89.1` bump did.