### PR TITLE
fix(docker): pin pnpm so the image build matches CI

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -2,6 +2,7 @@
   "name": "sendrec-web",
   "private": true,
   "type": "module",
+  "packageManager": "pnpm@10.26.0",
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",


### PR DESCRIPTION
The `v1.90.0` release build failed, so no image was published and prod is still on `v1.89.1`.

```
rolldown@1.2.3 was published at 2026-08-05T10:51:12Z, within the
minimumReleaseAge cutoff (2026-08-04T21:52:44Z)
...
Dockerfile:6
RUN corepack enable && pnpm install --frozen-lockfile
```

Nothing pins `packageManager`, so the two environments were free to diverge:

| Environment | pnpm |
|---|---|
| local | 10.26.0 |
| CI (`pnpm/action-setup`) | 10.26.0 |
| Docker (`corepack` on `node:24-alpine`) | **11.20.0** |

pnpm 11 enforces a minimum release age by default. The image build therefore rejected a lockfile CI had just accepted minutes earlier — which is why every check on #167 was green while the release build could not succeed.

The skew has existed as long as `packageManager` has been absent. #167 was simply the first bump to pull in a package published within the last day. Any future dependency update can trip it again, on a lockfile CI has already approved.

Pinning to the version already used by CI and local makes all three agree, and changes no security posture relative to what CI and local were already doing.

### Verification

`docker build --target frontend` succeeds with this change and fails without it. The full build gets through the frontend and Go stages and stops only at `FROM alexneamtu/sendrec-base:latest`, which has no arm64 manifest — a limitation of my machine, not the build; CI runs amd64.

### Follow-up

`v1.90.0` is tagged at `0a61d5e` but published nothing. Once this merges the tag needs to move to include it, or a `v1.90.1` needs cutting.