### PR TITLE
ci: build the Docker image on every PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,6 +111,21 @@ jobs:
       - name: Build Go binary
         run: go build -o bin/sendrec ./cmd/sendrec
 
+  # The jobs above build the app the way a developer does: the Go toolchain
+  # comes from go.mod, pnpm from pnpm/action-setup. The image pins its own
+  # versions instead, so a Dockerfile that disagrees with go.mod or a lockfile
+  # the image build rejects both passed CI and only failed at release time.
+  # Building the image here closes that gap.
+  docker-build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Build image
+        run: docker build -t sendrec:ci .
+
   e2e:
     if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'workflow_dispatch'
     needs: test


### PR DESCRIPTION
Three failures this cycle passed CI and broke the image build, because **CI never built the image**:

| Change | CI saw | Image build |
|---|---|---|
| #161 raised the `go` directive to 1.26.5 | toolchain resolved from `go.mod` — green | `golang:1.26.4-alpine` + `GOTOOLCHAIN=local` → `go mod download` fails |
| #167 updated the lockfile | pnpm 10.26.0 via `pnpm/action-setup` — green | corepack resolves pnpm 11.20.0, whose release-age policy rejects it |

Both were discovered only after tagging `v1.90.0`, which published nothing.

The existing jobs build the app the way a developer does — Go toolchain from `go.mod`, pnpm from `pnpm/action-setup`. The image pins its own versions independently, and nothing verified the two agree. This builds the same Dockerfile the release publishes, without pushing.

Costs a few minutes per PR, in exchange for catching a class of failure that currently surfaces only at release.

### Not done here

The job is **not** a required status check — that is a branch protection change, not a workflow change. Worth adding once it has proven stable.

No build cache either. If the added time is annoying, `docker/build-push-action` with `cache-from: type=gha` is the usual fix; I left it out rather than add moving parts to a check whose whole point is fidelity to the release build.