### PR TITLE
fix(security): upgrade Go to 1.26.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ COPY web/ .
 RUN pnpm build
 
 # Stage 2: Build Go binary
-FROM golang:1.26.5-alpine AS backend
+FROM golang:1.26.6-alpine AS backend
 WORKDIR /app
 COPY go.mod go.sum ./
 RUN go mod download

--- a/Dockerfile.standalone
+++ b/Dockerfile.standalone
@@ -19,7 +19,7 @@ RUN git clone --depth 1 --branch v1.8.3 https://github.com/ggerganov/whisper.cpp
     cmake --build build --target whisper-cli -j$(nproc)
 
 # Stage 3: Build Go binary
-FROM golang:1.26.1-alpine AS backend
+FROM golang:1.26.6-alpine AS backend
 WORKDIR /app
 COPY go.mod go.sum ./
 RUN go mod download

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/sendrec/sendrec
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.43.4


### PR DESCRIPTION
Upgrade every pinned Go toolchain to security-fixed 1.26.6.

- fixes seven reachable standard-library vulnerabilities reported against Go 1.26.5
- keeps go.mod and both Docker builders aligned
- changes no dependencies or application code