### PR TITLE
release: prepare v1.90.1

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -64,3 +64,21 @@ jobs:
               --title "$TAG_NAME" \
               --generate-notes
           fi
+
+  deploy:
+    needs: publish
+    runs-on: ubuntu-latest
+    environment: production
+    steps:
+      - name: Deploy production via Coolify
+        env:
+          COOLIFY_API_URL: ${{ secrets.COOLIFY_API_URL }}
+          COOLIFY_API_TOKEN: ${{ secrets.COOLIFY_API_TOKEN }}
+          COOLIFY_SENDREC_APP_UUID: ${{ secrets.COOLIFY_SENDREC_APP_UUID }}
+          CF_ACCESS_CLIENT_ID: ${{ secrets.CF_ACCESS_CLIENT_ID }}
+          CF_ACCESS_CLIENT_SECRET: ${{ secrets.CF_ACCESS_CLIENT_SECRET }}
+        run: |
+          curl --fail-with-body -sS -X POST "$COOLIFY_API_URL/deploy?uuid=$COOLIFY_SENDREC_APP_UUID&force=true" \
+            -H "Authorization: Bearer $COOLIFY_API_TOKEN" \
+            -H "CF-Access-Client-Id: $CF_ACCESS_CLIENT_ID" \
+            -H "CF-Access-Client-Secret: $CF_ACCESS_CLIENT_SECRET"

--- a/helm/sendrec/Chart.yaml
+++ b/helm/sendrec/Chart.yaml
@@ -20,5 +20,5 @@ maintainers:
 - name: mark24slides
 - name: alexneamtu 
 
-version: "1.2.3"
-appVersion: "1.90.0"
+version: "1.2.4"
+appVersion: "1.90.1"


### PR DESCRIPTION
## Problem

Production still runs `v1.90.0`, built with Go 1.26.5. Main now contains the Go 1.26.6 security fix plus reviewed dependency and CI updates.

The release documentation says production tags deploy through Coolify, but the release workflow currently stops after publishing the images and GitHub release.

## Changes

- Bump the Helm chart from `1.2.3` to `1.2.4` and `appVersion` from `1.90.0` to `1.90.1`.
- Add a production-environment-gated job after image publication.
- Trigger the existing Coolify production application through its protected secrets and Cloudflare Access service token.

## Validation

- 39 frontend test files / 746 tests passed.
- Frontend typecheck and production build passed.
- `go test ./...` passed.
- `go mod verify` passed.
- `actionlint` passed for the release workflow.
- `helm lint helm/sendrec` passed.
- Current main release-image checks are green.

## Deployment

After merge, tag the merge commit as `v1.90.1`. The release workflow publishes `v1.90.1` and `latest`, waits for production approval, then triggers Coolify. Verify `https://app.sendrec.eu/api/health` reports `v1.90.1` and `status: ok`.
