### PR TITLE
fix(security): remediate audit findings SR-01 through SR-15

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,3 +5,16 @@ BASE_URL=http://localhost:8080
 S3_REGION=eu-central-1
 MAX_UPLOAD_BYTES=524288000
 # S3_PUBLIC_ENDPOINT=https://storage.example.com  # Public URL for presigned URLs (production only)
+
+# Set to true ONLY when a reverse proxy (Caddy, Traefik) sets X-Forwarded-For.
+# Left false, the header is ignored: clients can forge it and each forged value
+# would otherwise get its own rate-limit bucket.
+TRUSTED_PROXY=false
+
+# Allows user-configured webhooks to reach loopback and private addresses.
+# Local development only — in production this is an SSRF primitive.
+WEBHOOK_ALLOW_PRIVATE_TARGETS=false
+
+# Required whenever CREEM_API_KEY is set; the app refuses to start without it,
+# because an empty secret makes every billing webhook forgeable.
+# CREEM_WEBHOOK_SECRET=

--- a/cmd/sendrec/main.go
+++ b/cmd/sendrec/main.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/sendrec/sendrec/internal/database"
 	"github.com/sendrec/sendrec/internal/email"
+	"github.com/sendrec/sendrec/internal/httputil"
 	"github.com/sendrec/sendrec/internal/plans"
 	"github.com/sendrec/sendrec/internal/server"
 	slackpkg "github.com/sendrec/sendrec/internal/slack"
@@ -42,6 +43,15 @@ func main() {
 	if jwtSecret == "" {
 		log.Fatal("JWT_SECRET is required")
 	}
+
+	// Only believe X-Forwarded-For when a reverse proxy actually sets it —
+	// otherwise any client can forge it and mint a fresh rate-limit bucket
+	// per request. Set TRUSTED_PROXY=true when running behind Caddy/Traefik.
+	httputil.TrustProxyHeaders = getEnv("TRUSTED_PROXY", "false") == "true"
+
+	// User-configured webhooks may not reach loopback or private ranges unless
+	// a developer explicitly opts in to point one at their own machine.
+	webhookpkg.AllowPrivateTargets = getEnv("WEBHOOK_ALLOW_PRIVATE_TARGETS", "false") == "true"
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
@@ -118,6 +128,11 @@ func main() {
 
 	creemAPIKey := os.Getenv("CREEM_API_KEY")
 	creemWebhookSecret := os.Getenv("CREEM_WEBHOOK_SECRET")
+	// Billing enabled without a webhook secret leaves /api/webhooks/creem
+	// forgeable, so refuse to start rather than serve entitlements to anyone.
+	if creemAPIKey != "" && creemWebhookSecret == "" {
+		log.Fatal("CREEM_WEBHOOK_SECRET is required when CREEM_API_KEY is set")
+	}
 	creemProProductID := os.Getenv("CREEM_PRO_PRODUCT_ID")
 	creemOrgProProductID := os.Getenv("CREEM_ORG_PRO_PRODUCT_ID")
 	creemBusinessProductID := os.Getenv("CREEM_BUSINESS_PRODUCT_ID")

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -14,6 +14,7 @@ services:
       - JWT_SECRET=${JWT_SECRET:-dev-secret-change-in-production}
       - BASE_URL=${BASE_URL:-http://localhost:8080}
       - MAX_UPLOAD_BYTES=${MAX_UPLOAD_BYTES:-524288000}
+      - WEBHOOK_ALLOW_PRIVATE_TARGETS=${WEBHOOK_ALLOW_PRIVATE_TARGETS:-true}
       - AWS_REQUEST_CHECKSUM_CALCULATION=when_required
       - AWS_RESPONSE_CHECKSUM_VALIDATION=when_required
     depends_on:
@@ -26,7 +27,7 @@ services:
     image: postgres:18-alpine
     restart: unless-stopped
     ports:
-      - "5433:5432"
+      - "127.0.0.1:5433:5432"
     environment:
       POSTGRES_USER: sendrec
       POSTGRES_PASSWORD: ${SENDREC_DB_PASSWORD:-sendrec}
@@ -47,8 +48,8 @@ services:
       - sendrec-storage-meta:/var/lib/garage/meta
       - sendrec-storage-data:/var/lib/garage/data
     ports:
-      - "3900:3900"
-      - "3903:3903"
+      - "127.0.0.1:3900:3900"
+      - "127.0.0.1:3903:3903"
 
   garage-init:
     build:

--- a/docker-compose.e2e.yml
+++ b/docker-compose.e2e.yml
@@ -14,6 +14,7 @@ services:
       - JWT_SECRET=e2e-test-secret
       - BASE_URL=http://localhost:8080
       - MAX_UPLOAD_BYTES=524288000
+      - WEBHOOK_ALLOW_PRIVATE_TARGETS=${WEBHOOK_ALLOW_PRIVATE_TARGETS:-true}
       - AWS_REQUEST_CHECKSUM_CALCULATION=when_required
       - AWS_RESPONSE_CHECKSUM_VALIDATION=when_required
       - PLAN_BADGE_ENABLED=true
@@ -32,7 +33,7 @@ services:
   postgres:
     image: postgres:18-alpine
     ports:
-      - "5433:5432"
+      - "127.0.0.1:5433:5432"
     environment:
       POSTGRES_USER: sendrec
       POSTGRES_PASSWORD: sendrec
@@ -50,8 +51,8 @@ services:
       - sendrec-e2e-storage-meta:/var/lib/garage/meta
       - sendrec-e2e-storage-data:/var/lib/garage/data
     ports:
-      - "3900:3900"
-      - "3903:3903"
+      - "127.0.0.1:3900:3900"
+      - "127.0.0.1:3903:3903"
 
   garage-init:
     build:

--- a/garage.toml
+++ b/garage.toml
@@ -1,3 +1,12 @@
+# ⚠️  LOCAL DEVELOPMENT ONLY — the secrets below are committed to a public repo
+# and are therefore public knowledge. Anything running with this file has an
+# admin token every reader of the repo already knows.
+#
+# Do NOT use this file as a self-hosting template. Production deployments
+# generate real secrets in docker-entrypoint.sh / garage-init; the dev and e2e
+# compose files publish these ports on 127.0.0.1 only, so the admin API is not
+# reachable from the network.
+
 metadata_dir = "/var/lib/garage/meta"
 data_dir = "/var/lib/garage/data"
 db_engine = "sqlite"

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -13,6 +13,7 @@ import (
 	"net/http"
 	"net/mail"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/jackc/pgx/v5/pgconn"
@@ -100,6 +101,20 @@ func generateSecureToken() (raw string, hash string, err error) {
 	return raw, hash, nil
 }
 
+// timingEqualizerHash is a real bcrypt hash of a value no one can log in with.
+// Comparing against it on the unknown-email path costs the same as comparing a
+// genuine one, so login latency no longer reveals whether an account exists.
+// Computed once, on first use, at the same cost as stored password hashes.
+var timingEqualizerHash = sync.OnceValue(func() []byte {
+	hash, err := bcrypt.GenerateFromPassword([]byte("sendrec/login-timing-equalizer"), bcrypt.DefaultCost)
+	if err != nil {
+		// Fall back to a non-matching value; a malformed hash still costs a
+		// comparison, and login correctness does not depend on this.
+		return []byte("$2a$10$invalid")
+	}
+	return hash
+})
+
 func hashToken(raw string) string {
 	h := sha256.Sum256([]byte(raw))
 	return hex.EncodeToString(h[:])
@@ -124,6 +139,11 @@ func (h *Handler) Register(w http.ResponseWriter, r *http.Request) {
 
 	if _, err := mail.ParseAddress(req.Email); err != nil {
 		httputil.WriteError(w, http.StatusBadRequest, "invalid email address")
+		return
+	}
+
+	if msg := validate.Name(req.Name); msg != "" {
+		httputil.WriteError(w, http.StatusBadRequest, msg)
 		return
 	}
 
@@ -218,6 +238,10 @@ func (h *Handler) Login(w http.ResponseWriter, r *http.Request) {
 		"SELECT id, password, email_verified FROM users WHERE email = $1", req.Email,
 	).Scan(&userID, &hashedPassword, &emailVerified)
 	if err != nil {
+		// Returning here without hashing made an unknown address answer ~60ms
+		// faster than a wrong password, which enumerates accounts regardless of
+		// the identical response body (SR-09). Pay the same bcrypt cost.
+		_ = bcrypt.CompareHashAndPassword(timingEqualizerHash(), []byte(req.Password))
 		httputil.WriteError(w, http.StatusUnauthorized, "invalid email or password")
 		return
 	}
@@ -459,6 +483,15 @@ func (h *Handler) ResetPassword(w http.ResponseWriter, r *http.Request) {
 		userID,
 	); err != nil {
 		slog.Error("reset-password: failed to revoke refresh tokens", "error", err)
+	}
+
+	// A reset is account recovery: assume the credentials were compromised and
+	// cut off API keys too, which otherwise never expire (SR-05).
+	if _, err := h.db.Exec(r.Context(),
+		"DELETE FROM api_keys WHERE user_id = $1",
+		userID,
+	); err != nil {
+		slog.Error("reset-password: failed to revoke API keys", "error", err)
 	}
 
 	httputil.WriteJSON(w, http.StatusOK, messageResponse{Message: "Password updated successfully"})
@@ -723,9 +756,24 @@ func (h *Handler) UpdateUser(w http.ResponseWriter, r *http.Request) {
 			httputil.WriteError(w, http.StatusInternalServerError, "failed to update password")
 			return
 		}
+
+		// Changing the password is what a user does after suspecting theft, so
+		// it must invalidate stolen sessions here too — not just on the reset
+		// flow (SR-04). The caller re-authenticates with their new password.
+		if _, err := h.db.Exec(r.Context(),
+			"UPDATE refresh_tokens SET revoked = true, revoked_at = now() WHERE user_id = $1 AND revoked = false",
+			userID,
+		); err != nil {
+			slog.Error("update-user: failed to revoke refresh tokens", "error", err)
+		}
 	}
 
 	if hasNameChange {
+		if msg := validate.Name(req.Name); msg != "" {
+			httputil.WriteError(w, http.StatusBadRequest, msg)
+			return
+		}
+
 		if _, err := h.db.Exec(r.Context(),
 			"UPDATE users SET name = $1, updated_at = now() WHERE id = $2",
 			req.Name, userID,

--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -1959,3 +1959,84 @@ func TestUpdateUser_InvalidRetentionDays(t *testing.T) {
 		t.Errorf("expected retention days error, got %q", errMsg)
 	}
 }
+
+// SR-04: ResetPassword revoked every refresh token, but the settings password
+// change did not — a stolen 7-day refresh cookie survived the victim rotating
+// their password, which is the one action they take after a suspected theft.
+func TestUpdateUser_ChangePasswordRevokesRefreshTokens(t *testing.T) {
+	handler, mock := newTestHandler(t)
+	defer mock.Close()
+
+	oldHash, _ := bcrypt.GenerateFromPassword([]byte("oldpass123"), bcrypt.MinCost)
+
+	mock.ExpectQuery(`SELECT password FROM users WHERE id = \$1`).
+		WithArgs("user-uuid-1").
+		WillReturnRows(pgxmock.NewRows([]string{"password"}).AddRow(string(oldHash)))
+
+	mock.ExpectExec(`UPDATE users SET password = \$1, updated_at = now\(\) WHERE id = \$2`).
+		WithArgs(pgxmock.AnyArg(), "user-uuid-1").
+		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+
+	mock.ExpectExec(`UPDATE refresh_tokens SET revoked = true`).
+		WithArgs("user-uuid-1").
+		WillReturnResult(pgxmock.NewResult("UPDATE", 2))
+
+	body := `{"currentPassword":"oldpass123","newPassword":"newpass456"}`
+	req := httptest.NewRequest(http.MethodPatch, "/api/user", strings.NewReader(body))
+	req = req.WithContext(context.WithValue(req.Context(), userIDKey, "user-uuid-1"))
+	rec := httptest.NewRecorder()
+
+	handler.UpdateUser(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d: %s", http.StatusOK, rec.Code, rec.Body.String())
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("refresh tokens were not revoked on password change: %v", err)
+	}
+}
+
+// SR-05: API keys outlived credential recovery entirely. Resetting the password
+// after a compromise left any stolen key working indefinitely.
+func TestResetPassword_RevokesAPIKeys(t *testing.T) {
+	handler, mock := newTestHandler(t)
+	defer mock.Close()
+
+	rawToken := "reset-token-abc"
+	tokenHash := hashToken(rawToken)
+
+	mock.ExpectQuery(`SELECT user_id FROM password_resets WHERE token_hash = \$1`).
+		WithArgs(tokenHash).
+		WillReturnRows(pgxmock.NewRows([]string{"user_id"}).AddRow("user-uuid-1"))
+
+	mock.ExpectExec(`UPDATE password_resets SET used_at = now\(\)`).
+		WithArgs(tokenHash).
+		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+
+	mock.ExpectExec(`UPDATE users SET password = \$1, updated_at = now\(\) WHERE id = \$2`).
+		WithArgs(pgxmock.AnyArg(), "user-uuid-1").
+		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+
+	mock.ExpectExec(`UPDATE refresh_tokens SET revoked = true`).
+		WithArgs("user-uuid-1").
+		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+
+	mock.ExpectExec(`DELETE FROM api_keys WHERE user_id = \$1`).
+		WithArgs("user-uuid-1").
+		WillReturnResult(pgxmock.NewResult("DELETE", 1))
+
+	body := `{"token":"` + rawToken + `","password":"newpass456"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/auth/reset-password", strings.NewReader(body))
+	rec := httptest.NewRecorder()
+
+	handler.ResetPassword(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d: %s", http.StatusOK, rec.Code, rec.Body.String())
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("API keys were not revoked on password reset: %v", err)
+	}
+}

--- a/internal/billing/handlers.go
+++ b/internal/billing/handlers.go
@@ -515,6 +515,12 @@ func (h *Handlers) updateSubscriptionPlan(ctx context.Context, entity billingEnt
 }
 
 func (h *Handlers) verifySignature(body []byte, signature string) bool {
+	// Without a secret every caller can compute HMAC-SHA256(body, "") and forge
+	// a valid billing event, so fail closed rather than authenticate nobody.
+	if h.webhookSecret == "" {
+		return false
+	}
+
 	mac := hmac.New(sha256.New, []byte(h.webhookSecret))
 	mac.Write(body)
 	expected := hex.EncodeToString(mac.Sum(nil))

--- a/internal/billing/handlers_test.go
+++ b/internal/billing/handlers_test.go
@@ -581,3 +581,39 @@ func TestOrgWebhookActivated_UpdatesPlan(t *testing.T) {
 		t.Errorf("unmet mock expectations: %v", err)
 	}
 }
+
+// SR-07: an operator who sets CREEM_API_KEY but leaves CREEM_WEBHOOK_SECRET
+// empty made every forged payload verifiable via HMAC-SHA256(body, ""), which
+// was enough to flip a victim's plan. With no secret configured, no signature
+// may ever verify.
+func TestVerifySignatureRejectsEverythingWhenSecretIsEmpty(t *testing.T) {
+	handlers := &Handlers{webhookSecret: ""}
+	body := []byte(`{"eventType":"subscription.active"}`)
+
+	mac := hmac.New(sha256.New, []byte(""))
+	mac.Write(body)
+	forged := hex.EncodeToString(mac.Sum(nil))
+
+	if handlers.verifySignature(body, forged) {
+		t.Error("signature computed with the empty key must not verify")
+	}
+	if handlers.verifySignature(body, "") {
+		t.Error("empty signature must not verify against an empty secret")
+	}
+}
+
+func TestVerifySignatureAcceptsCorrectSignatureWhenSecretIsSet(t *testing.T) {
+	handlers := &Handlers{webhookSecret: "webhook-secret"}
+	body := []byte(`{"eventType":"subscription.active"}`)
+
+	mac := hmac.New(sha256.New, []byte("webhook-secret"))
+	mac.Write(body)
+	valid := hex.EncodeToString(mac.Sum(nil))
+
+	if !handlers.verifySignature(body, valid) {
+		t.Error("correctly signed body must verify")
+	}
+	if handlers.verifySignature(body, "deadbeef") {
+		t.Error("wrong signature must not verify")
+	}
+}

--- a/internal/httputil/clientip.go
+++ b/internal/httputil/clientip.go
@@ -1,0 +1,37 @@
+package httputil
+
+import (
+	"net"
+	"net/http"
+	"strings"
+)
+
+// TrustProxyHeaders reports whether X-Forwarded-For may be believed. It is a
+// deployment-wide fact (set once from TRUSTED_PROXY before the server starts),
+// so it lives here rather than being threaded through every limiter and handler.
+// Left false, the header is ignored entirely: any client can forge it.
+var TrustProxyHeaders bool
+
+// ClientIP returns the address used to key rate limiting and viewer dedup.
+//
+// Two things matter here. RemoteAddr carries an ephemeral port, so it must be
+// split or every new TCP connection lands in its own rate-limit bucket. And
+// X-Forwarded-For is only meaningful behind a proxy that appends to it — there
+// the last entry is the peer the proxy actually saw, while every earlier entry
+// is client-supplied and worthless for trust decisions.
+func ClientIP(r *http.Request) string {
+	if TrustProxyHeaders {
+		if forwarded := r.Header.Get("X-Forwarded-For"); forwarded != "" {
+			entries := strings.Split(forwarded, ",")
+			if last := strings.TrimSpace(entries[len(entries)-1]); last != "" {
+				return last
+			}
+		}
+	}
+
+	host, _, err := net.SplitHostPort(r.RemoteAddr)
+	if err != nil {
+		return r.RemoteAddr
+	}
+	return host
+}

--- a/internal/httputil/clientip_test.go
+++ b/internal/httputil/clientip_test.go
@@ -1,0 +1,98 @@
+package httputil
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// trustProxy sets the deployment-wide trust flag for one test and restores it.
+func trustProxy(t *testing.T, trusted bool) {
+	t.Helper()
+	previous := TrustProxyHeaders
+	TrustProxyHeaders = trusted
+	t.Cleanup(func() { TrustProxyHeaders = previous })
+}
+
+func TestClientIPStripsEphemeralPort(t *testing.T) {
+	trustProxy(t, false)
+
+	request := httptest.NewRequest(http.MethodGet, "/", nil)
+	request.RemoteAddr = "192.0.2.10:54321"
+
+	if got := ClientIP(request); got != "192.0.2.10" {
+		t.Errorf("expected port stripped from RemoteAddr, got %q", got)
+	}
+}
+
+func TestClientIPIsStableAcrossConnectionsFromSameHost(t *testing.T) {
+	trustProxy(t, false)
+
+	first := httptest.NewRequest(http.MethodGet, "/", nil)
+	first.RemoteAddr = "192.0.2.10:1111"
+	second := httptest.NewRequest(http.MethodGet, "/", nil)
+	second.RemoteAddr = "192.0.2.10:2222"
+
+	if ClientIP(first) != ClientIP(second) {
+		t.Errorf("same host on new connections must key alike, got %q and %q", ClientIP(first), ClientIP(second))
+	}
+}
+
+func TestClientIPIgnoresForwardedForWhenProxyUntrusted(t *testing.T) {
+	trustProxy(t, false)
+
+	request := httptest.NewRequest(http.MethodGet, "/", nil)
+	request.RemoteAddr = "192.0.2.10:54321"
+	request.Header.Set("X-Forwarded-For", "203.0.113.7")
+
+	if got := ClientIP(request); got != "192.0.2.10" {
+		t.Errorf("client-supplied X-Forwarded-For must be ignored, got %q", got)
+	}
+}
+
+func TestClientIPUsesLastForwardedEntryWhenProxyTrusted(t *testing.T) {
+	trustProxy(t, true)
+
+	request := httptest.NewRequest(http.MethodGet, "/", nil)
+	request.RemoteAddr = "10.0.0.1:54321"
+	// The client forged the first entry; the trusted proxy appended the peer it saw.
+	request.Header.Set("X-Forwarded-For", "1.2.3.4, 203.0.113.7")
+
+	if got := ClientIP(request); got != "203.0.113.7" {
+		t.Errorf("expected proxy-appended last entry, got %q", got)
+	}
+}
+
+func TestClientIPFallsBackToRemoteAddrWhenForwardedAbsent(t *testing.T) {
+	trustProxy(t, true)
+
+	request := httptest.NewRequest(http.MethodGet, "/", nil)
+	request.RemoteAddr = "192.0.2.10:54321"
+
+	if got := ClientIP(request); got != "192.0.2.10" {
+		t.Errorf("expected RemoteAddr host when header absent, got %q", got)
+	}
+}
+
+func TestClientIPHandlesIPv6(t *testing.T) {
+	trustProxy(t, false)
+
+	request := httptest.NewRequest(http.MethodGet, "/", nil)
+	request.RemoteAddr = "[2001:db8::1]:54321"
+
+	if got := ClientIP(request); got != "2001:db8::1" {
+		t.Errorf("expected IPv6 host without port, got %q", got)
+	}
+}
+
+func TestClientIPIgnoresEmptyForwardedEntry(t *testing.T) {
+	trustProxy(t, true)
+
+	request := httptest.NewRequest(http.MethodGet, "/", nil)
+	request.RemoteAddr = "192.0.2.10:54321"
+	request.Header.Set("X-Forwarded-For", "203.0.113.7, ")
+
+	if got := ClientIP(request); got != "192.0.2.10" {
+		t.Errorf("expected fallback when trailing entry is blank, got %q", got)
+	}
+}

--- a/internal/ratelimit/ratelimit.go
+++ b/internal/ratelimit/ratelimit.go
@@ -2,9 +2,10 @@ package ratelimit
 
 import (
 	"net/http"
-	"strings"
 	"sync"
 	"time"
+
+	"github.com/sendrec/sendrec/internal/httputil"
 )
 
 type visitor struct {
@@ -69,18 +70,7 @@ func (l *Limiter) cleanup() {
 
 func (l *Limiter) Middleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		ip := r.RemoteAddr
-		if forwarded := r.Header.Get("X-Forwarded-For"); forwarded != "" {
-			// Use only the first IP (the client IP set by the trusted reverse proxy).
-			// Subsequent IPs in the chain may be spoofed by the client.
-			if first, _, ok := strings.Cut(forwarded, ","); ok {
-				ip = strings.TrimSpace(first)
-			} else {
-				ip = strings.TrimSpace(forwarded)
-			}
-		}
-
-		if !l.allow(ip) {
+		if !l.allow(httputil.ClientIP(r)) {
 			w.Header().Set("Content-Type", "application/json")
 			w.Header().Set("Retry-After", "10")
 			w.WriteHeader(http.StatusTooManyRequests)

--- a/internal/ratelimit/ratelimit_test.go
+++ b/internal/ratelimit/ratelimit_test.go
@@ -5,6 +5,8 @@ import (
 	"net/http/httptest"
 	"testing"
 	"time"
+
+	"github.com/sendrec/sendrec/internal/httputil"
 )
 
 func TestNewLimiterAllowsFirstRequest(t *testing.T) {
@@ -220,7 +222,16 @@ func TestMiddlewareReturnsErrorBodyOn429(t *testing.T) {
 	}
 }
 
-func TestMiddlewareRespectsXForwardedForHeader(t *testing.T) {
+// trustProxy flips the deployment-wide trust flag for one test and restores it.
+func trustProxy(t *testing.T, trusted bool) {
+	t.Helper()
+	previous := httputil.TrustProxyHeaders
+	httputil.TrustProxyHeaders = trusted
+	t.Cleanup(func() { httputil.TrustProxyHeaders = previous })
+}
+
+func TestMiddlewareRespectsXForwardedForHeaderBehindTrustedProxy(t *testing.T) {
+	trustProxy(t, true)
 	limiter := NewLimiter(1, 1)
 
 	handler := limiter.Middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -245,7 +256,8 @@ func TestMiddlewareRespectsXForwardedForHeader(t *testing.T) {
 	}
 }
 
-func TestMiddlewareXForwardedForDifferentIPsAreIndependent(t *testing.T) {
+func TestMiddlewareXForwardedForDifferentIPsAreIndependentBehindTrustedProxy(t *testing.T) {
+	trustProxy(t, true)
 	limiter := NewLimiter(1, 1)
 
 	handler := limiter.Middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -267,6 +279,57 @@ func TestMiddlewareXForwardedForDifferentIPsAreIndependent(t *testing.T) {
 
 	if recorder.Code != http.StatusOK {
 		t.Errorf("expected 200 for different X-Forwarded-For IP, got %d", recorder.Code)
+	}
+}
+
+// SR-01: RemoteAddr carries an ephemeral port, so keying on it verbatim gave
+// every fresh TCP connection its own bucket — the limiter was bypassed by any
+// ordinary client, no header spoofing required.
+func TestMiddlewareLimitsAcrossNewConnectionsFromSameHost(t *testing.T) {
+	trustProxy(t, false)
+	limiter := NewLimiter(1, 1)
+
+	handler := limiter.Middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	firstRequest := httptest.NewRequest(http.MethodGet, "/", nil)
+	firstRequest.RemoteAddr = "203.0.113.9:11111"
+	handler.ServeHTTP(httptest.NewRecorder(), firstRequest)
+
+	// Same host, brand-new source port — must share the bucket.
+	secondRequest := httptest.NewRequest(http.MethodGet, "/", nil)
+	secondRequest.RemoteAddr = "203.0.113.9:22222"
+	recorder := httptest.NewRecorder()
+	handler.ServeHTTP(recorder, secondRequest)
+
+	if recorder.Code != http.StatusTooManyRequests {
+		t.Errorf("expected 429 for same host on a new connection, got %d", recorder.Code)
+	}
+}
+
+// SR-01: with no trusted proxy configured, a spoofed header must not mint buckets.
+func TestMiddlewareIgnoresSpoofedXForwardedForByDefault(t *testing.T) {
+	trustProxy(t, false)
+	limiter := NewLimiter(1, 1)
+
+	handler := limiter.Middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	firstRequest := httptest.NewRequest(http.MethodGet, "/", nil)
+	firstRequest.RemoteAddr = "203.0.113.9:11111"
+	firstRequest.Header.Set("X-Forwarded-For", "1.1.1.1")
+	handler.ServeHTTP(httptest.NewRecorder(), firstRequest)
+
+	secondRequest := httptest.NewRequest(http.MethodGet, "/", nil)
+	secondRequest.RemoteAddr = "203.0.113.9:11111"
+	secondRequest.Header.Set("X-Forwarded-For", "2.2.2.2")
+	recorder := httptest.NewRecorder()
+	handler.ServeHTTP(recorder, secondRequest)
+
+	if recorder.Code != http.StatusTooManyRequests {
+		t.Errorf("expected 429 despite rotating X-Forwarded-For, got %d", recorder.Code)
 	}
 }
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -510,17 +510,21 @@ func (s *Server) routes() {
 		watchAuthLimiter := ratelimit.NewLimiter(0.5, 5)
 		commentLimiter := ratelimit.NewLimiter(0.2, 3)
 		commentReadLimiter := ratelimit.NewLimiter(5, 20)
-		s.router.Get("/api/watch/{shareToken}", s.videoHandler.Watch)
-		s.router.Get("/api/watch/{shareToken}/download", s.videoHandler.WatchDownload)
+		// Unauthenticated watch surface: every GET records a view and can notify
+		// the owner, and the beacons write analytics rows, so they need the same
+		// throttling and body caps their siblings already had (SR-03).
+		watchLimiter := ratelimit.NewLimiter(5, 20)
+		s.router.With(watchLimiter.Middleware).Get("/api/watch/{shareToken}", s.videoHandler.Watch)
+		s.router.With(watchLimiter.Middleware).Get("/api/watch/{shareToken}/download", s.videoHandler.WatchDownload)
 		s.router.With(watchAuthLimiter.Middleware, maxBodySize(64*1024)).Post("/api/watch/{shareToken}/verify", s.videoHandler.VerifyWatchPassword)
 		s.router.With(commentReadLimiter.Middleware).Get("/api/watch/{shareToken}/comments", s.videoHandler.ListWatchComments)
 		s.router.With(commentLimiter.Middleware, maxBodySize(64*1024)).Post("/api/watch/{shareToken}/comments", s.videoHandler.PostWatchComment)
 		s.router.With(watchAuthLimiter.Middleware, maxBodySize(64*1024)).Post("/api/watch/{shareToken}/identify", s.videoHandler.IdentifyViewer)
-		s.router.Post("/api/watch/{shareToken}/cta-click", s.videoHandler.RecordCTAClick)
-		s.router.Post("/api/watch/{shareToken}/milestone", s.videoHandler.RecordMilestone)
-		s.router.Post("/api/watch/{shareToken}/segments", s.videoHandler.RecordSegments)
-		s.router.Get("/api/watch/{shareToken}/thumbnail", s.videoHandler.WatchThumbnail)
-		s.router.Get("/api/videos/{shareToken}/oembed", s.videoHandler.OEmbed)
+		s.router.With(watchLimiter.Middleware, maxBodySize(64*1024)).Post("/api/watch/{shareToken}/cta-click", s.videoHandler.RecordCTAClick)
+		s.router.With(watchLimiter.Middleware, maxBodySize(64*1024)).Post("/api/watch/{shareToken}/milestone", s.videoHandler.RecordMilestone)
+		s.router.With(watchLimiter.Middleware, maxBodySize(64*1024)).Post("/api/watch/{shareToken}/segments", s.videoHandler.RecordSegments)
+		s.router.With(watchLimiter.Middleware).Get("/api/watch/{shareToken}/thumbnail", s.videoHandler.WatchThumbnail)
+		s.router.With(watchLimiter.Middleware).Get("/api/videos/{shareToken}/oembed", s.videoHandler.OEmbed)
 		s.router.Get("/watch/{shareToken}", s.videoHandler.WatchPage)
 		s.router.Get("/embed/{shareToken}", s.videoHandler.EmbedPage)
 
@@ -542,17 +546,22 @@ func (s *Server) routes() {
 
 func (s *Server) handleHealth(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
+	// The exact build version is only useful to someone matching the deployment
+	// against known CVEs, and nothing consumes it here (SR-15). The feature flags
+	// stay: the SPA reads them to decide what to render.
 	if s.pinger != nil {
 		if err := s.pinger.Ping(r.Context()); err != nil {
 			w.WriteHeader(http.StatusServiceUnavailable)
-			_, _ = fmt.Fprintf(w, `{"status":"unhealthy","version":%q,"error":"database unreachable"}`, s.version)
+			_, _ = fmt.Fprint(w, `{"status":"unhealthy","error":"database unreachable"}`)
 			return
 		}
 	}
-	_, _ = fmt.Fprintf(w, `{"status":"ok","version":%q,"registrationEnabled":%t,"planBadgeEnabled":%t}`, s.version, s.registrationEnabled, s.planBadgeEnabled)
+	_, _ = fmt.Fprintf(w, `{"status":"ok","registrationEnabled":%t,"planBadgeEnabled":%t}`, s.registrationEnabled, s.planBadgeEnabled)
 }
 
 func (s *Server) handleRobotsTxt(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
-	_, _ = w.Write([]byte("User-agent: *\nAllow: /watch/\nAllow: /embed/\nDisallow: /\n"))
+	// Share links are unguessable but not secret once leaked; inviting crawlers
+	// to index them published the page content along with the URL (SR-13).
+	_, _ = w.Write([]byte("User-agent: *\nDisallow: /\n"))
 }

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -119,7 +119,7 @@ func TestHealthEndpointReturnsOK(t *testing.T) {
 		t.Errorf("expected status 200, got %d", rec.Code)
 	}
 
-	expected := `{"status":"ok","version":"","registrationEnabled":false,"planBadgeEnabled":false}`
+	expected := `{"status":"ok","registrationEnabled":false,"planBadgeEnabled":false}`
 	if rec.Body.String() != expected {
 		t.Errorf("expected body %q, got %q", expected, rec.Body.String())
 	}
@@ -147,7 +147,7 @@ func TestHealthEndpointWithPingSuccess(t *testing.T) {
 		t.Errorf("expected status 200, got %d", rec.Code)
 	}
 
-	expected := `{"status":"ok","version":"","registrationEnabled":false,"planBadgeEnabled":false}`
+	expected := `{"status":"ok","registrationEnabled":false,"planBadgeEnabled":false}`
 	if rec.Body.String() != expected {
 		t.Errorf("expected body %q, got %q", expected, rec.Body.String())
 	}
@@ -163,7 +163,7 @@ func TestHealthEndpointWithPingFailure(t *testing.T) {
 		t.Errorf("expected status 503, got %d", rec.Code)
 	}
 
-	expected := `{"status":"unhealthy","version":"","error":"database unreachable"}`
+	expected := `{"status":"unhealthy","error":"database unreachable"}`
 	if rec.Body.String() != expected {
 		t.Errorf("expected body %q, got %q", expected, rec.Body.String())
 	}
@@ -176,7 +176,7 @@ func TestHealthEndpointIncludesRegistrationEnabled(t *testing.T) {
 	})
 	rec := executeRequest(srv, http.MethodGet, "/api/health")
 
-	expected := `{"status":"ok","version":"","registrationEnabled":true,"planBadgeEnabled":false}`
+	expected := `{"status":"ok","registrationEnabled":true,"planBadgeEnabled":false}`
 	if rec.Body.String() != expected {
 		t.Errorf("expected body %q, got %q", expected, rec.Body.String())
 	}
@@ -189,7 +189,7 @@ func TestHealthEndpointRegistrationDisabled(t *testing.T) {
 	})
 	rec := executeRequest(srv, http.MethodGet, "/api/health")
 
-	expected := `{"status":"ok","version":"","registrationEnabled":false,"planBadgeEnabled":false}`
+	expected := `{"status":"ok","registrationEnabled":false,"planBadgeEnabled":false}`
 	if rec.Body.String() != expected {
 		t.Errorf("expected body %q, got %q", expected, rec.Body.String())
 	}
@@ -202,7 +202,7 @@ func TestHealthEndpointPlanBadgeEnabled(t *testing.T) {
 	})
 	rec := executeRequest(srv, http.MethodGet, "/api/health")
 
-	expected := `{"status":"ok","version":"","registrationEnabled":false,"planBadgeEnabled":true}`
+	expected := `{"status":"ok","registrationEnabled":false,"planBadgeEnabled":true}`
 	if rec.Body.String() != expected {
 		t.Errorf("expected body %q, got %q", expected, rec.Body.String())
 	}
@@ -214,7 +214,7 @@ func TestHealthEndpointPlanBadgeDefaultDisabled(t *testing.T) {
 	})
 	rec := executeRequest(srv, http.MethodGet, "/api/health")
 
-	expected := `{"status":"ok","version":"","registrationEnabled":false,"planBadgeEnabled":false}`
+	expected := `{"status":"ok","registrationEnabled":false,"planBadgeEnabled":false}`
 	if rec.Body.String() != expected {
 		t.Errorf("expected body %q, got %q", expected, rec.Body.String())
 	}
@@ -828,12 +828,13 @@ func TestRobotsTxtReturnsCorrectContent(t *testing.T) {
 		t.Errorf("expected Content-Type text/plain, got %q", contentType)
 	}
 
+	// SR-13: share and embed pages must not be invited into search indexes.
 	body := rec.Body.String()
-	if !strings.Contains(body, "Allow: /watch/") {
-		t.Error("expected robots.txt to allow /watch/")
+	if strings.Contains(body, "Allow: /watch/") {
+		t.Error("robots.txt must not invite crawlers to index share pages")
 	}
-	if !strings.Contains(body, "Allow: /embed/") {
-		t.Error("expected robots.txt to allow /embed/")
+	if strings.Contains(body, "Allow: /embed/") {
+		t.Error("robots.txt must not invite crawlers to index embed pages")
 	}
 	if !strings.Contains(body, "Disallow: /") {
 		t.Error("expected robots.txt to disallow /")
@@ -850,8 +851,66 @@ func TestSPADoesNotInterceptHealthEndpoint(t *testing.T) {
 		t.Errorf("expected status 200 for health endpoint with SPA, got %d", rec.Code)
 	}
 
-	expected := `{"status":"ok","version":"","registrationEnabled":false,"planBadgeEnabled":false}`
+	expected := `{"status":"ok","registrationEnabled":false,"planBadgeEnabled":false}`
 	if rec.Body.String() != expected {
 		t.Errorf("expected health JSON, got %q", rec.Body.String())
+	}
+}
+
+// --- SR-03: unauthenticated watch/analytics routes were registered bare ---
+//
+// GET /api/watch/{t} records a view (and can notify the owner) on every call,
+// and the three beacon POSTs parsed unbounded bodies, with no limiter on any of
+// them. Siblings like /verify and /comments were limited all along.
+
+func TestUnauthenticatedWatchAnalyticsRoutesAreRateLimited(t *testing.T) {
+	routes := []struct {
+		name   string
+		method string
+		path   string
+		body   string
+	}{
+		{"watch", http.MethodGet, "/api/watch/sometoken123", ""},
+		{"segments", http.MethodPost, "/api/watch/sometoken123/segments", `{"segments":[1,2,3]}`},
+		{"milestone", http.MethodPost, "/api/watch/sometoken123/milestone", `{"milestone":50}`},
+		{"cta-click", http.MethodPost, "/api/watch/sometoken123/cta-click", `{}`},
+	}
+
+	for _, route := range routes {
+		t.Run(route.name, func(t *testing.T) {
+			srv, _ := newServerWithDB(t)
+
+			for i := 0; i < 60; i++ {
+				rec := executeRequestWithBody(srv, route.method, route.path, route.body)
+				if rec.Code == http.StatusTooManyRequests {
+					return
+				}
+			}
+
+			t.Errorf("expected 429 after a burst against %s %s", route.method, route.path)
+		})
+	}
+}
+
+func TestWatchAnalyticsBeaconsRejectOversizedBodies(t *testing.T) {
+	paths := []string{
+		"/api/watch/sometoken123/segments",
+		"/api/watch/sometoken123/milestone",
+		"/api/watch/sometoken123/cta-click",
+	}
+
+	for _, path := range paths {
+		t.Run(path, func(t *testing.T) {
+			srv, _ := newServerWithDB(t)
+
+			// 1 MB of JSON; the handler decodes into a slice, so an unbounded
+			// body is a memory-amplification primitive.
+			oversized := `{"segments":[` + strings.Repeat("1,", 500_000) + `1]}`
+			rec := executeRequestWithBody(srv, http.MethodPost, path, oversized)
+
+			if rec.Code == http.StatusNoContent || rec.Code == http.StatusOK {
+				t.Errorf("expected oversized body to be rejected, got %d", rec.Code)
+			}
+		})
 	}
 }

--- a/internal/validate/validate.go
+++ b/internal/validate/validate.go
@@ -4,6 +4,7 @@ import "fmt"
 
 // Text field length limits — single source of truth for backend and frontend.
 const (
+	MaxNameLength                = 100
 	MaxTitleLength               = 500
 	MaxPlaylistTitleLength       = 200
 	MaxPlaylistDescriptionLength = 2000
@@ -27,6 +28,7 @@ func checkLen(value string, max int, field string) string {
 	return ""
 }
 
+func Name(s string) string               { return checkLen(s, MaxNameLength, "name") }
 func Title(s string) string              { return checkLen(s, MaxTitleLength, "title") }
 func PlaylistTitle(s string) string      { return checkLen(s, MaxPlaylistTitleLength, "playlist title") }
 func PlaylistDescription(s string) string {
@@ -68,6 +70,7 @@ func Password(password string) string {
 // FieldLimits returns a map of field names to max lengths for the /api/limits endpoint.
 func FieldLimits() map[string]int {
 	return map[string]int{
+		"name":                MaxNameLength,
 		"title":               MaxTitleLength,
 		"playlistTitle":       MaxPlaylistTitleLength,
 		"playlistDescription": MaxPlaylistDescriptionLength,

--- a/internal/validate/validate_test.go
+++ b/internal/validate/validate_test.go
@@ -1,6 +1,9 @@
 package validate
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 func TestTitle(t *testing.T) {
 	tests := []struct {
@@ -297,5 +300,27 @@ func TestFieldLimits(t *testing.T) {
 	}
 	if len(fl) < 13 {
 		t.Errorf("FieldLimits() returned %d entries, expected at least 13", len(fl))
+	}
+}
+
+// SR-10: user names had no length check at all, so a 60 KB name was stored and
+// rendered as the creator on every watch page.
+func TestName(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"empty", "", ""},
+		{"normal", "Alex Neamtu", ""},
+		{"at limit", strings.Repeat("a", MaxNameLength), ""},
+		{"over limit", strings.Repeat("a", MaxNameLength+1), "name must be 100 characters or fewer"},
+		{"far over limit", strings.Repeat("a", 60000), "name must be 100 characters or fewer"},
+	}
+
+	for _, tt := range tests {
+		if got := Name(tt.input); got != tt.want {
+			t.Errorf("Name(%s) = %q, want %q", tt.name, got, tt.want)
+		}
 	}
 }

--- a/internal/video/notification.go
+++ b/internal/video/notification.go
@@ -7,7 +7,9 @@ import (
 	"encoding/json"
 	"errors"
 	"log/slog"
+	"net"
 	"net/http"
+	"net/url"
 	"strings"
 	"time"
 
@@ -87,13 +89,34 @@ func (h *Handler) GetNotificationPreferences(w http.ResponseWriter, r *http.Requ
 	})
 }
 
-func isValidWebhookURL(u string) bool {
-	if strings.HasPrefix(u, "https://") {
+// isValidWebhookURL screens a user-supplied webhook target. It is a first pass
+// only — the real guarantee is the dial-time block in the webhook client, which
+// also covers DNS names that resolve inward and redirects (SR-06).
+//
+// The previous prefix match on "http://localhost" also accepted hosts like
+// http://localhost.example.com, sending plaintext to an attacker-chosen server.
+func isValidWebhookURL(raw string) bool {
+	parsed, err := url.Parse(raw)
+	if err != nil || parsed.Host == "" {
+		return false
+	}
+
+	host := parsed.Hostname()
+
+	if parsed.Scheme == "https" {
+		// Literal internal addresses are rejected here for a clear error at save
+		// time; hostnames are left to the dialer, which sees what they resolve to.
+		if ip := net.ParseIP(host); ip != nil && webhook.IsBlockedIP(ip) {
+			return false
+		}
 		return true
 	}
-	if strings.HasPrefix(u, "http://localhost") || strings.HasPrefix(u, "http://127.0.0.1") {
-		return true
+
+	// Plaintext is only for pointing at a listener on the developer's own machine.
+	if parsed.Scheme == "http" && webhook.AllowPrivateTargets {
+		return host == "localhost" || host == "127.0.0.1" || host == "::1"
 	}
+
 	return false
 }
 

--- a/internal/video/notification_test.go
+++ b/internal/video/notification_test.go
@@ -838,7 +838,17 @@ func TestPutNotificationPreferences_RejectsHttpWebhookUrl(t *testing.T) {
 	}
 }
 
+// allowLocalWebhookTargets opts a test into dialing loopback, which the SSRF
+// guard blocks by default (SR-06).
+func allowLocalWebhookTargets(t *testing.T) {
+	t.Helper()
+	previous := webhook.AllowPrivateTargets
+	webhook.AllowPrivateTargets = true
+	t.Cleanup(func() { webhook.AllowPrivateTargets = previous })
+}
+
 func TestPutNotificationPreferences_AllowsLocalhostHttp(t *testing.T) {
+	allowLocalWebhookTargets(t)
 	mock, err := pgxmock.NewPool()
 	if err != nil {
 		t.Fatal(err)
@@ -985,6 +995,7 @@ func TestTestWebhook_NoUrl(t *testing.T) {
 }
 
 func TestTestWebhook_Success(t *testing.T) {
+	allowLocalWebhookTargets(t)
 	mock, err := pgxmock.NewPool()
 	if err != nil {
 		t.Fatal(err)
@@ -1156,4 +1167,48 @@ func (m *mockSlackNotifier) SendViewNotification(_ context.Context, _, _, _, _ s
 func (m *mockSlackNotifier) SendCommentNotification(_ context.Context, _, _, _, _, _, _ string) error {
 	m.commentCalled = true
 	return nil
+}
+
+// SR-06: the old check was a prefix match on the whole URL, so any host merely
+// starting with "localhost" passed — plaintext to an attacker-controlled server.
+func TestIsValidWebhookURL_RejectsLookalikeLocalhostHosts(t *testing.T) {
+	allowLocalWebhookTargets(t)
+
+	rejected := []string{
+		"http://localhost.attacker.com/steal",
+		"http://127.0.0.1.attacker.com/steal",
+		"http://example.com/plain",
+		"ftp://example.com/x",
+		"not-a-url",
+		"",
+	}
+
+	for _, raw := range rejected {
+		if isValidWebhookURL(raw) {
+			t.Errorf("expected %q to be rejected", raw)
+		}
+	}
+}
+
+func TestIsValidWebhookURL_RejectsInternalHTTPSTargets(t *testing.T) {
+	previous := webhook.AllowPrivateTargets
+	webhook.AllowPrivateTargets = false
+	t.Cleanup(func() { webhook.AllowPrivateTargets = previous })
+
+	rejected := []string{
+		"https://127.0.0.1/admin",
+		"https://10.0.0.5/internal",
+		"https://169.254.169.254/latest/meta-data/",
+		"https://192.168.1.1/router",
+	}
+
+	for _, raw := range rejected {
+		if isValidWebhookURL(raw) {
+			t.Errorf("expected internal target %q to be rejected", raw)
+		}
+	}
+
+	if !isValidWebhookURL("https://hooks.example.com/endpoint") {
+		t.Error("expected a public https endpoint to remain valid")
+	}
 }

--- a/internal/video/oembed.go
+++ b/internal/video/oembed.go
@@ -31,14 +31,16 @@ func (h *Handler) OEmbed(w http.ResponseWriter, r *http.Request) {
 	var createdAt time.Time
 	var shareExpiresAt *time.Time
 	var thumbnailKey *string
+	var sharePassword *string
+	var emailGateEnabled bool
 
 	err := h.db.QueryRow(r.Context(),
-		`SELECT v.title, v.duration, u.name, v.created_at, v.share_expires_at, v.thumbnail_key
+		`SELECT v.title, v.duration, u.name, v.created_at, v.share_expires_at, v.thumbnail_key, v.share_password, v.email_gate_enabled
 		 FROM videos v
 		 JOIN users u ON u.id = v.user_id
 		 WHERE v.share_token = $1 AND v.status IN ('ready', 'processing')`,
 		shareToken,
-	).Scan(&title, &duration, &authorName, &createdAt, &shareExpiresAt, &thumbnailKey)
+	).Scan(&title, &duration, &authorName, &createdAt, &shareExpiresAt, &thumbnailKey, &sharePassword, &emailGateEnabled)
 	if err != nil {
 		httputil.WriteError(w, http.StatusNotFound, "video not found")
 		return
@@ -46,6 +48,12 @@ func (h *Handler) OEmbed(w http.ResponseWriter, r *http.Request) {
 
 	if shareExpiresAt != nil && time.Now().After(*shareExpiresAt) {
 		httputil.WriteError(w, http.StatusGone, "link expired")
+		return
+	}
+
+	// Title, author and thumbnail are content too — unfurling a protected link
+	// must not reveal them (SR-08).
+	if !h.enforceWatchAccess(w, r, shareToken, sharePassword, emailGateEnabled) {
 		return
 	}
 

--- a/internal/video/video_helpers.go
+++ b/internal/video/video_helpers.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/mssola/useragent"
+	"github.com/sendrec/sendrec/internal/httputil"
 	"github.com/sendrec/sendrec/internal/webhook"
 )
 
@@ -55,14 +56,10 @@ func viewerHash(ip, userAgent string) string {
 	return fmt.Sprintf("%x", h[:8])
 }
 
+// clientIP feeds viewerHash, so trusting a client-supplied X-Forwarded-For here
+// let anyone forge unlimited distinct "unique viewers" (SR-01/SR-03).
 func clientIP(r *http.Request) string {
-	if forwarded := r.Header.Get("X-Forwarded-For"); forwarded != "" {
-		if first, _, ok := strings.Cut(forwarded, ","); ok {
-			return strings.TrimSpace(first)
-		}
-		return strings.TrimSpace(forwarded)
-	}
-	return r.RemoteAddr
+	return httputil.ClientIP(r)
 }
 
 func categorizeReferrer(referer string) string {

--- a/internal/video/video_query.go
+++ b/internal/video/video_query.go
@@ -369,6 +369,7 @@ func (h *Handler) Watch(w http.ResponseWriter, r *http.Request) {
 	var summaryStatus string
 	var documentText *string
 	var documentStatus string
+	var emailGateEnabled bool
 	var ubCompanyName, ubLogoKey, ubColorBg, ubColorSurface, ubColorText, ubColorAccent, ubFooterText, ubCustomCSS *string
 	var obCompanyName, obLogoKey, obColorBg, obColorSurface, obColorText, obColorAccent, obFooterText, obCustomCSS *string
 	var vbCompanyName, vbLogoKey, vbColorBg, vbColorSurface, vbColorText, vbColorAccent, vbFooterText *string
@@ -384,7 +385,7 @@ func (h *Handler) Watch(w http.ResponseWriter, r *http.Request) {
 		        v.cta_text, v.cta_url,
 		        v.summary, v.chapters, v.summary_status,
 		        v.document, v.document_status,
-		        v.organization_id
+		        v.organization_id, v.email_gate_enabled
 		 FROM videos v
 		 JOIN users u ON u.id = v.user_id
 		 LEFT JOIN user_branding ub ON ub.user_id = v.user_id AND ub.organization_id IS NULL
@@ -400,7 +401,7 @@ func (h *Handler) Watch(w http.ResponseWriter, r *http.Request) {
 		&ctaText, &ctaUrl,
 		&summaryText, &chaptersJSON, &summaryStatus,
 		&documentText, &documentStatus,
-		&videoOrgID)
+		&videoOrgID, &emailGateEnabled)
 	if err != nil {
 		httputil.WriteError(w, http.StatusNotFound, "video not found")
 		return
@@ -411,11 +412,8 @@ func (h *Handler) Watch(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if sharePassword != nil {
-		if !hasValidWatchCookie(r, h.hmacSecret, shareToken, *sharePassword) {
-			httputil.WriteError(w, http.StatusForbidden, "password required")
-			return
-		}
+	if !h.enforceWatchAccess(w, r, shareToken, sharePassword, emailGateEnabled) {
+		return
 	}
 
 	baseBranding := brandingSettingsResponse{
@@ -679,11 +677,12 @@ func (h *Handler) WatchDownload(w http.ResponseWriter, r *http.Request) {
 	var sharePassword *string
 	var contentType string
 	var downloadEnabled bool
+	var emailGateEnabled bool
 
 	err := h.db.QueryRow(r.Context(),
-		`SELECT title, file_key, share_expires_at, share_password, content_type, download_enabled FROM videos WHERE share_token = $1 AND status IN ('ready', 'processing')`,
+		`SELECT title, file_key, share_expires_at, share_password, content_type, download_enabled, email_gate_enabled FROM videos WHERE share_token = $1 AND status IN ('ready', 'processing')`,
 		shareToken,
-	).Scan(&title, &fileKey, &shareExpiresAt, &sharePassword, &contentType, &downloadEnabled)
+	).Scan(&title, &fileKey, &shareExpiresAt, &sharePassword, &contentType, &downloadEnabled, &emailGateEnabled)
 	if err != nil {
 		httputil.WriteError(w, http.StatusNotFound, "video not found")
 		return
@@ -699,11 +698,8 @@ func (h *Handler) WatchDownload(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if sharePassword != nil {
-		if !hasValidWatchCookie(r, h.hmacSecret, shareToken, *sharePassword) {
-			httputil.WriteError(w, http.StatusForbidden, "password required")
-			return
-		}
+	if !h.enforceWatchAccess(w, r, shareToken, sharePassword, emailGateEnabled) {
+		return
 	}
 
 	filename := title + extensionForContentType(contentType)

--- a/internal/video/video_test.go
+++ b/internal/video/video_test.go
@@ -2078,8 +2078,8 @@ func TestWatch_Success(t *testing.T) {
 	mock.ExpectQuery(`SELECT v.id, v.title, v.duration, v.file_key, u.name, v.created_at, v.share_expires_at`).
 		WithArgs(shareToken).
 		WillReturnRows(
-			pgxmock.NewRows([]string{"id", "title", "duration", "file_key", "name", "created_at", "share_expires_at", "thumbnail_key", "share_password", "transcript_key", "transcript_json", "transcript_status", "user_id", "email", "view_notification", "content_type", "ub_company_name", "ub_logo_key", "ub_color_background", "ub_color_surface", "ub_color_text", "ub_color_accent", "ub_footer_text", "ub_custom_css", "ob_company_name", "ob_logo_key", "ob_color_background", "ob_color_surface", "ob_color_text", "ob_color_accent", "ob_footer_text", "ob_custom_css", "vb_company_name", "vb_logo_key", "vb_color_background", "vb_color_surface", "vb_color_text", "vb_color_accent", "vb_footer_text", "cta_text", "cta_url", "summary", "chapters", "summary_status", "document", "document_status", "organization_id"}).
-				AddRow(videoID, "Demo Recording", 180, "recordings/user-1/abc.webm", "Alex Neamtu", createdAt, &shareExpiresAt, (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), "none", "owner-user-id", "owner@example.com", (*string)(nil), "video/webm", (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), "none", (*string)(nil), "none", (*string)(nil)),
+			pgxmock.NewRows([]string{"id", "title", "duration", "file_key", "name", "created_at", "share_expires_at", "thumbnail_key", "share_password", "transcript_key", "transcript_json", "transcript_status", "user_id", "email", "view_notification", "content_type", "ub_company_name", "ub_logo_key", "ub_color_background", "ub_color_surface", "ub_color_text", "ub_color_accent", "ub_footer_text", "ub_custom_css", "ob_company_name", "ob_logo_key", "ob_color_background", "ob_color_surface", "ob_color_text", "ob_color_accent", "ob_footer_text", "ob_custom_css", "vb_company_name", "vb_logo_key", "vb_color_background", "vb_color_surface", "vb_color_text", "vb_color_accent", "vb_footer_text", "cta_text", "cta_url", "summary", "chapters", "summary_status", "document", "document_status", "organization_id", "email_gate_enabled"}).
+				AddRow(videoID, "Demo Recording", 180, "recordings/user-1/abc.webm", "Alex Neamtu", createdAt, &shareExpiresAt, (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), "none", "owner-user-id", "owner@example.com", (*string)(nil), "video/webm", (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), "none", (*string)(nil), "none", (*string)(nil), false),
 		)
 
 	mock.ExpectExec(`INSERT INTO video_views`).
@@ -2186,8 +2186,8 @@ func TestWatch_StorageError(t *testing.T) {
 	mock.ExpectQuery(`SELECT v.id, v.title, v.duration, v.file_key, u.name, v.created_at, v.share_expires_at`).
 		WithArgs(shareToken).
 		WillReturnRows(
-			pgxmock.NewRows([]string{"id", "title", "duration", "file_key", "name", "created_at", "share_expires_at", "thumbnail_key", "share_password", "transcript_key", "transcript_json", "transcript_status", "user_id", "email", "view_notification", "content_type", "ub_company_name", "ub_logo_key", "ub_color_background", "ub_color_surface", "ub_color_text", "ub_color_accent", "ub_footer_text", "ub_custom_css", "ob_company_name", "ob_logo_key", "ob_color_background", "ob_color_surface", "ob_color_text", "ob_color_accent", "ob_footer_text", "ob_custom_css", "vb_company_name", "vb_logo_key", "vb_color_background", "vb_color_surface", "vb_color_text", "vb_color_accent", "vb_footer_text", "cta_text", "cta_url", "summary", "chapters", "summary_status", "document", "document_status", "organization_id"}).
-				AddRow(videoID, "Demo Recording", 180, "recordings/user-1/abc.webm", "Alex Neamtu", createdAt, &shareExpiresAt, (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), "none", "owner-user-id", "owner@example.com", (*string)(nil), "video/webm", (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), "none", (*string)(nil), "none", (*string)(nil)),
+			pgxmock.NewRows([]string{"id", "title", "duration", "file_key", "name", "created_at", "share_expires_at", "thumbnail_key", "share_password", "transcript_key", "transcript_json", "transcript_status", "user_id", "email", "view_notification", "content_type", "ub_company_name", "ub_logo_key", "ub_color_background", "ub_color_surface", "ub_color_text", "ub_color_accent", "ub_footer_text", "ub_custom_css", "ob_company_name", "ob_logo_key", "ob_color_background", "ob_color_surface", "ob_color_text", "ob_color_accent", "ob_footer_text", "ob_custom_css", "vb_company_name", "vb_logo_key", "vb_color_background", "vb_color_surface", "vb_color_text", "vb_color_accent", "vb_footer_text", "cta_text", "cta_url", "summary", "chapters", "summary_status", "document", "document_status", "organization_id", "email_gate_enabled"}).
+				AddRow(videoID, "Demo Recording", 180, "recordings/user-1/abc.webm", "Alex Neamtu", createdAt, &shareExpiresAt, (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), "none", "owner-user-id", "owner@example.com", (*string)(nil), "video/webm", (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), "none", (*string)(nil), "none", (*string)(nil), false),
 		)
 
 	mock.ExpectExec(`INSERT INTO video_views`).
@@ -2237,8 +2237,8 @@ func TestWatch_ExpiredLink(t *testing.T) {
 	mock.ExpectQuery(`SELECT v.id, v.title, v.duration, v.file_key, u.name, v.created_at, v.share_expires_at`).
 		WithArgs(shareToken).
 		WillReturnRows(
-			pgxmock.NewRows([]string{"id", "title", "duration", "file_key", "name", "created_at", "share_expires_at", "thumbnail_key", "share_password", "transcript_key", "transcript_json", "transcript_status", "user_id", "email", "view_notification", "content_type", "ub_company_name", "ub_logo_key", "ub_color_background", "ub_color_surface", "ub_color_text", "ub_color_accent", "ub_footer_text", "ub_custom_css", "ob_company_name", "ob_logo_key", "ob_color_background", "ob_color_surface", "ob_color_text", "ob_color_accent", "ob_footer_text", "ob_custom_css", "vb_company_name", "vb_logo_key", "vb_color_background", "vb_color_surface", "vb_color_text", "vb_color_accent", "vb_footer_text", "cta_text", "cta_url", "summary", "chapters", "summary_status", "document", "document_status", "organization_id"}).
-				AddRow(videoID, "Demo Recording", 180, "recordings/user-1/abc.webm", "Alex Neamtu", createdAt, &shareExpiresAt, (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), "none", "owner-user-id", "owner@example.com", (*string)(nil), "video/webm", (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), "none", (*string)(nil), "none", (*string)(nil)),
+			pgxmock.NewRows([]string{"id", "title", "duration", "file_key", "name", "created_at", "share_expires_at", "thumbnail_key", "share_password", "transcript_key", "transcript_json", "transcript_status", "user_id", "email", "view_notification", "content_type", "ub_company_name", "ub_logo_key", "ub_color_background", "ub_color_surface", "ub_color_text", "ub_color_accent", "ub_footer_text", "ub_custom_css", "ob_company_name", "ob_logo_key", "ob_color_background", "ob_color_surface", "ob_color_text", "ob_color_accent", "ob_footer_text", "ob_custom_css", "vb_company_name", "vb_logo_key", "vb_color_background", "vb_color_surface", "vb_color_text", "vb_color_accent", "vb_footer_text", "cta_text", "cta_url", "summary", "chapters", "summary_status", "document", "document_status", "organization_id", "email_gate_enabled"}).
+				AddRow(videoID, "Demo Recording", 180, "recordings/user-1/abc.webm", "Alex Neamtu", createdAt, &shareExpiresAt, (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), "none", "owner-user-id", "owner@example.com", (*string)(nil), "video/webm", (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), "none", (*string)(nil), "none", (*string)(nil), false),
 		)
 
 	r := chi.NewRouter()
@@ -2546,8 +2546,8 @@ func TestWatch_RecordsView(t *testing.T) {
 	mock.ExpectQuery(`SELECT v.id, v.title, v.duration, v.file_key, u.name, v.created_at, v.share_expires_at`).
 		WithArgs(shareToken).
 		WillReturnRows(
-			pgxmock.NewRows([]string{"id", "title", "duration", "file_key", "name", "created_at", "share_expires_at", "thumbnail_key", "share_password", "transcript_key", "transcript_json", "transcript_status", "user_id", "email", "view_notification", "content_type", "ub_company_name", "ub_logo_key", "ub_color_background", "ub_color_surface", "ub_color_text", "ub_color_accent", "ub_footer_text", "ub_custom_css", "ob_company_name", "ob_logo_key", "ob_color_background", "ob_color_surface", "ob_color_text", "ob_color_accent", "ob_footer_text", "ob_custom_css", "vb_company_name", "vb_logo_key", "vb_color_background", "vb_color_surface", "vb_color_text", "vb_color_accent", "vb_footer_text", "cta_text", "cta_url", "summary", "chapters", "summary_status", "document", "document_status", "organization_id"}).
-				AddRow(videoID, "Demo Recording", 180, "recordings/user-1/abc.webm", "Alex Neamtu", createdAt, &shareExpiresAt, (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), "none", "owner-user-id", "owner@example.com", (*string)(nil), "video/webm", (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), "none", (*string)(nil), "none", (*string)(nil)),
+			pgxmock.NewRows([]string{"id", "title", "duration", "file_key", "name", "created_at", "share_expires_at", "thumbnail_key", "share_password", "transcript_key", "transcript_json", "transcript_status", "user_id", "email", "view_notification", "content_type", "ub_company_name", "ub_logo_key", "ub_color_background", "ub_color_surface", "ub_color_text", "ub_color_accent", "ub_footer_text", "ub_custom_css", "ob_company_name", "ob_logo_key", "ob_color_background", "ob_color_surface", "ob_color_text", "ob_color_accent", "ob_footer_text", "ob_custom_css", "vb_company_name", "vb_logo_key", "vb_color_background", "vb_color_surface", "vb_color_text", "vb_color_accent", "vb_footer_text", "cta_text", "cta_url", "summary", "chapters", "summary_status", "document", "document_status", "organization_id", "email_gate_enabled"}).
+				AddRow(videoID, "Demo Recording", 180, "recordings/user-1/abc.webm", "Alex Neamtu", createdAt, &shareExpiresAt, (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), "none", "owner-user-id", "owner@example.com", (*string)(nil), "video/webm", (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), "none", (*string)(nil), "none", (*string)(nil), false),
 		)
 
 	mock.ExpectExec(`INSERT INTO video_views`).
@@ -2595,8 +2595,8 @@ func TestWatch_IncludesThumbnailURL(t *testing.T) {
 	mock.ExpectQuery(`SELECT v.id, v.title, v.duration, v.file_key, u.name, v.created_at, v.share_expires_at`).
 		WithArgs(shareToken).
 		WillReturnRows(
-			pgxmock.NewRows([]string{"id", "title", "duration", "file_key", "name", "created_at", "share_expires_at", "thumbnail_key", "share_password", "transcript_key", "transcript_json", "transcript_status", "user_id", "email", "view_notification", "content_type", "ub_company_name", "ub_logo_key", "ub_color_background", "ub_color_surface", "ub_color_text", "ub_color_accent", "ub_footer_text", "ub_custom_css", "ob_company_name", "ob_logo_key", "ob_color_background", "ob_color_surface", "ob_color_text", "ob_color_accent", "ob_footer_text", "ob_custom_css", "vb_company_name", "vb_logo_key", "vb_color_background", "vb_color_surface", "vb_color_text", "vb_color_accent", "vb_footer_text", "cta_text", "cta_url", "summary", "chapters", "summary_status", "document", "document_status", "organization_id"}).
-				AddRow(videoID, "Demo Recording", 180, "recordings/user-1/abc.webm", "Alex Neamtu", createdAt, &shareExpiresAt, &thumbKey, (*string)(nil), (*string)(nil), (*string)(nil), "none", "owner-user-id", "owner@example.com", (*string)(nil), "video/webm", (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), "none", (*string)(nil), "none", (*string)(nil)),
+			pgxmock.NewRows([]string{"id", "title", "duration", "file_key", "name", "created_at", "share_expires_at", "thumbnail_key", "share_password", "transcript_key", "transcript_json", "transcript_status", "user_id", "email", "view_notification", "content_type", "ub_company_name", "ub_logo_key", "ub_color_background", "ub_color_surface", "ub_color_text", "ub_color_accent", "ub_footer_text", "ub_custom_css", "ob_company_name", "ob_logo_key", "ob_color_background", "ob_color_surface", "ob_color_text", "ob_color_accent", "ob_footer_text", "ob_custom_css", "vb_company_name", "vb_logo_key", "vb_color_background", "vb_color_surface", "vb_color_text", "vb_color_accent", "vb_footer_text", "cta_text", "cta_url", "summary", "chapters", "summary_status", "document", "document_status", "organization_id", "email_gate_enabled"}).
+				AddRow(videoID, "Demo Recording", 180, "recordings/user-1/abc.webm", "Alex Neamtu", createdAt, &shareExpiresAt, &thumbKey, (*string)(nil), (*string)(nil), (*string)(nil), "none", "owner-user-id", "owner@example.com", (*string)(nil), "video/webm", (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), "none", (*string)(nil), "none", (*string)(nil), false),
 		)
 
 	mock.ExpectExec(`INSERT INTO video_views`).
@@ -3394,27 +3394,39 @@ func TestViewerHash_Returns16Characters(t *testing.T) {
 
 // --- clientIP Tests ---
 
-func TestClientIP_UsesXForwardedFor(t *testing.T) {
+// SR-01: clientIP feeds viewerHash. Honoring a client-supplied X-Forwarded-For
+// let anyone mint unlimited distinct "unique viewers", so the header counts only
+// when a trusted proxy is configured — and then only its own last entry.
+func TestClientIP_UsesLastForwardedEntryBehindTrustedProxy(t *testing.T) {
+	previous := httputil.TrustProxyHeaders
+	httputil.TrustProxyHeaders = true
+	t.Cleanup(func() { httputil.TrustProxyHeaders = previous })
+
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
 	req.Header.Set("X-Forwarded-For", "203.0.113.50, 70.41.3.18")
-	if ip := clientIP(req); ip != "203.0.113.50" {
-		t.Errorf("expected %q, got %q", "203.0.113.50", ip)
+	if ip := clientIP(req); ip != "70.41.3.18" {
+		t.Errorf("expected %q, got %q", "70.41.3.18", ip)
 	}
 }
 
-func TestClientIP_FallsBackToRemoteAddr(t *testing.T) {
+func TestClientIP_IgnoresForwardedForWithoutTrustedProxy(t *testing.T) {
+	previous := httputil.TrustProxyHeaders
+	httputil.TrustProxyHeaders = false
+	t.Cleanup(func() { httputil.TrustProxyHeaders = previous })
+
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
 	req.RemoteAddr = "192.168.1.100:54321"
-	if ip := clientIP(req); ip != "192.168.1.100:54321" {
-		t.Errorf("expected %q, got %q", "192.168.1.100:54321", ip)
+	req.Header.Set("X-Forwarded-For", "203.0.113.50")
+	if ip := clientIP(req); ip != "192.168.1.100" {
+		t.Errorf("spoofed header must be ignored, expected %q, got %q", "192.168.1.100", ip)
 	}
 }
 
-func TestClientIP_SingleXForwardedFor(t *testing.T) {
+func TestClientIP_StripsPortFromRemoteAddr(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
-	req.Header.Set("X-Forwarded-For", "203.0.113.50")
-	if ip := clientIP(req); ip != "203.0.113.50" {
-		t.Errorf("expected %q, got %q", "203.0.113.50", ip)
+	req.RemoteAddr = "192.168.1.100:54321"
+	if ip := clientIP(req); ip != "192.168.1.100" {
+		t.Errorf("expected %q, got %q", "192.168.1.100", ip)
 	}
 }
 
@@ -3988,10 +4000,10 @@ func TestWatchDownload_Success(t *testing.T) {
 	shareToken := "abc123defghi"
 	shareExpiresAt := time.Now().Add(7 * 24 * time.Hour)
 
-	mock.ExpectQuery(`SELECT title, file_key, share_expires_at, share_password, content_type, download_enabled FROM videos WHERE share_token = \$1 AND status IN \('ready', 'processing'\)`).
+	mock.ExpectQuery(`SELECT title, file_key, share_expires_at, share_password, content_type, download_enabled, email_gate_enabled FROM videos WHERE share_token = \$1 AND status IN \('ready', 'processing'\)`).
 		WithArgs(shareToken).
-		WillReturnRows(pgxmock.NewRows([]string{"title", "file_key", "share_expires_at", "share_password", "content_type", "download_enabled"}).
-			AddRow("Demo Recording", "recordings/user-1/abc.webm", &shareExpiresAt, (*string)(nil), "video/webm", true))
+		WillReturnRows(pgxmock.NewRows([]string{"title", "file_key", "share_expires_at", "share_password", "content_type", "download_enabled", "email_gate_enabled"}).
+			AddRow("Demo Recording", "recordings/user-1/abc.webm", &shareExpiresAt, (*string)(nil), "video/webm", true, false))
 
 	r := chi.NewRouter()
 	r.Get("/api/watch/{shareToken}/download", handler.WatchDownload)
@@ -4031,7 +4043,7 @@ func TestWatchDownload_VideoNotFound(t *testing.T) {
 
 	shareToken := "nonexistent12"
 
-	mock.ExpectQuery(`SELECT title, file_key, share_expires_at, share_password, content_type, download_enabled FROM videos WHERE share_token = \$1 AND status IN \('ready', 'processing'\)`).
+	mock.ExpectQuery(`SELECT title, file_key, share_expires_at, share_password, content_type, download_enabled, email_gate_enabled FROM videos WHERE share_token = \$1 AND status IN \('ready', 'processing'\)`).
 		WithArgs(shareToken).
 		WillReturnError(pgx.ErrNoRows)
 
@@ -4069,10 +4081,10 @@ func TestWatchDownload_Expired(t *testing.T) {
 	shareToken := "abc123defghi"
 	shareExpiresAt := time.Now().Add(-1 * time.Hour)
 
-	mock.ExpectQuery(`SELECT title, file_key, share_expires_at, share_password, content_type, download_enabled FROM videos WHERE share_token = \$1 AND status IN \('ready', 'processing'\)`).
+	mock.ExpectQuery(`SELECT title, file_key, share_expires_at, share_password, content_type, download_enabled, email_gate_enabled FROM videos WHERE share_token = \$1 AND status IN \('ready', 'processing'\)`).
 		WithArgs(shareToken).
-		WillReturnRows(pgxmock.NewRows([]string{"title", "file_key", "share_expires_at", "share_password", "content_type", "download_enabled"}).
-			AddRow("Demo Recording", "recordings/user-1/abc.webm", &shareExpiresAt, (*string)(nil), "video/webm", true))
+		WillReturnRows(pgxmock.NewRows([]string{"title", "file_key", "share_expires_at", "share_password", "content_type", "download_enabled", "email_gate_enabled"}).
+			AddRow("Demo Recording", "recordings/user-1/abc.webm", &shareExpiresAt, (*string)(nil), "video/webm", true, false))
 
 	r := chi.NewRouter()
 	r.Get("/api/watch/{shareToken}/download", handler.WatchDownload)
@@ -4171,10 +4183,10 @@ func TestWatchDownload_Disabled(t *testing.T) {
 	shareToken := "abc123defghi"
 	shareExpiresAt := time.Now().Add(7 * 24 * time.Hour)
 
-	mock.ExpectQuery(`SELECT title, file_key, share_expires_at, share_password, content_type, download_enabled FROM videos WHERE share_token = \$1 AND status IN \('ready', 'processing'\)`).
+	mock.ExpectQuery(`SELECT title, file_key, share_expires_at, share_password, content_type, download_enabled, email_gate_enabled FROM videos WHERE share_token = \$1 AND status IN \('ready', 'processing'\)`).
 		WithArgs(shareToken).
-		WillReturnRows(pgxmock.NewRows([]string{"title", "file_key", "share_expires_at", "share_password", "content_type", "download_enabled"}).
-			AddRow("Demo Recording", "recordings/user-1/abc.webm", &shareExpiresAt, (*string)(nil), "video/webm", false))
+		WillReturnRows(pgxmock.NewRows([]string{"title", "file_key", "share_expires_at", "share_password", "content_type", "download_enabled", "email_gate_enabled"}).
+			AddRow("Demo Recording", "recordings/user-1/abc.webm", &shareExpiresAt, (*string)(nil), "video/webm", false, false))
 
 	r := chi.NewRouter()
 	r.Get("/api/watch/{shareToken}/download", handler.WatchDownload)
@@ -4409,8 +4421,8 @@ func TestWatch_IncludesTranscriptWhenReady(t *testing.T) {
 	mock.ExpectQuery(`SELECT v.id, v.title, v.duration, v.file_key, u.name, v.created_at, v.share_expires_at`).
 		WithArgs(shareToken).
 		WillReturnRows(
-			pgxmock.NewRows([]string{"id", "title", "duration", "file_key", "name", "created_at", "share_expires_at", "thumbnail_key", "share_password", "transcript_key", "transcript_json", "transcript_status", "user_id", "email", "view_notification", "content_type", "ub_company_name", "ub_logo_key", "ub_color_background", "ub_color_surface", "ub_color_text", "ub_color_accent", "ub_footer_text", "ub_custom_css", "ob_company_name", "ob_logo_key", "ob_color_background", "ob_color_surface", "ob_color_text", "ob_color_accent", "ob_footer_text", "ob_custom_css", "vb_company_name", "vb_logo_key", "vb_color_background", "vb_color_surface", "vb_color_text", "vb_color_accent", "vb_footer_text", "cta_text", "cta_url", "summary", "chapters", "summary_status", "document", "document_status", "organization_id"}).
-				AddRow(videoID, "Demo Recording", 180, "recordings/user-1/abc.webm", "Alex Neamtu", createdAt, &shareExpiresAt, (*string)(nil), (*string)(nil), &transcriptKey, &transcriptJSON, "ready", "owner-user-id", "owner@example.com", (*string)(nil), "video/webm", (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), "none", (*string)(nil), "none", (*string)(nil)),
+			pgxmock.NewRows([]string{"id", "title", "duration", "file_key", "name", "created_at", "share_expires_at", "thumbnail_key", "share_password", "transcript_key", "transcript_json", "transcript_status", "user_id", "email", "view_notification", "content_type", "ub_company_name", "ub_logo_key", "ub_color_background", "ub_color_surface", "ub_color_text", "ub_color_accent", "ub_footer_text", "ub_custom_css", "ob_company_name", "ob_logo_key", "ob_color_background", "ob_color_surface", "ob_color_text", "ob_color_accent", "ob_footer_text", "ob_custom_css", "vb_company_name", "vb_logo_key", "vb_color_background", "vb_color_surface", "vb_color_text", "vb_color_accent", "vb_footer_text", "cta_text", "cta_url", "summary", "chapters", "summary_status", "document", "document_status", "organization_id", "email_gate_enabled"}).
+				AddRow(videoID, "Demo Recording", 180, "recordings/user-1/abc.webm", "Alex Neamtu", createdAt, &shareExpiresAt, (*string)(nil), (*string)(nil), &transcriptKey, &transcriptJSON, "ready", "owner-user-id", "owner@example.com", (*string)(nil), "video/webm", (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), "none", (*string)(nil), "none", (*string)(nil), false),
 		)
 
 	mock.ExpectExec(`INSERT INTO video_views`).
@@ -4475,8 +4487,8 @@ func TestWatch_OmitsTranscriptWhenNone(t *testing.T) {
 	mock.ExpectQuery(`SELECT v.id, v.title, v.duration, v.file_key, u.name, v.created_at, v.share_expires_at`).
 		WithArgs(shareToken).
 		WillReturnRows(
-			pgxmock.NewRows([]string{"id", "title", "duration", "file_key", "name", "created_at", "share_expires_at", "thumbnail_key", "share_password", "transcript_key", "transcript_json", "transcript_status", "user_id", "email", "view_notification", "content_type", "ub_company_name", "ub_logo_key", "ub_color_background", "ub_color_surface", "ub_color_text", "ub_color_accent", "ub_footer_text", "ub_custom_css", "ob_company_name", "ob_logo_key", "ob_color_background", "ob_color_surface", "ob_color_text", "ob_color_accent", "ob_footer_text", "ob_custom_css", "vb_company_name", "vb_logo_key", "vb_color_background", "vb_color_surface", "vb_color_text", "vb_color_accent", "vb_footer_text", "cta_text", "cta_url", "summary", "chapters", "summary_status", "document", "document_status", "organization_id"}).
-				AddRow(videoID, "Demo Recording", 180, "recordings/user-1/abc.webm", "Alex Neamtu", createdAt, &shareExpiresAt, (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), "none", "owner-user-id", "owner@example.com", (*string)(nil), "video/webm", (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), "none", (*string)(nil), "none", (*string)(nil)),
+			pgxmock.NewRows([]string{"id", "title", "duration", "file_key", "name", "created_at", "share_expires_at", "thumbnail_key", "share_password", "transcript_key", "transcript_json", "transcript_status", "user_id", "email", "view_notification", "content_type", "ub_company_name", "ub_logo_key", "ub_color_background", "ub_color_surface", "ub_color_text", "ub_color_accent", "ub_footer_text", "ub_custom_css", "ob_company_name", "ob_logo_key", "ob_color_background", "ob_color_surface", "ob_color_text", "ob_color_accent", "ob_footer_text", "ob_custom_css", "vb_company_name", "vb_logo_key", "vb_color_background", "vb_color_surface", "vb_color_text", "vb_color_accent", "vb_footer_text", "cta_text", "cta_url", "summary", "chapters", "summary_status", "document", "document_status", "organization_id", "email_gate_enabled"}).
+				AddRow(videoID, "Demo Recording", 180, "recordings/user-1/abc.webm", "Alex Neamtu", createdAt, &shareExpiresAt, (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), "none", "owner-user-id", "owner@example.com", (*string)(nil), "video/webm", (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), "none", (*string)(nil), "none", (*string)(nil), false),
 		)
 
 	mock.ExpectExec(`INSERT INTO video_views`).
@@ -4535,8 +4547,8 @@ func TestWatch_TranscriptPoll_SkipsViewRecording(t *testing.T) {
 	mock.ExpectQuery(`SELECT v.id, v.title, v.duration, v.file_key, u.name, v.created_at, v.share_expires_at`).
 		WithArgs(shareToken).
 		WillReturnRows(
-			pgxmock.NewRows([]string{"id", "title", "duration", "file_key", "name", "created_at", "share_expires_at", "thumbnail_key", "share_password", "transcript_key", "transcript_json", "transcript_status", "user_id", "email", "view_notification", "content_type", "ub_company_name", "ub_logo_key", "ub_color_background", "ub_color_surface", "ub_color_text", "ub_color_accent", "ub_footer_text", "ub_custom_css", "ob_company_name", "ob_logo_key", "ob_color_background", "ob_color_surface", "ob_color_text", "ob_color_accent", "ob_footer_text", "ob_custom_css", "vb_company_name", "vb_logo_key", "vb_color_background", "vb_color_surface", "vb_color_text", "vb_color_accent", "vb_footer_text", "cta_text", "cta_url", "summary", "chapters", "summary_status", "document", "document_status", "organization_id"}).
-				AddRow(videoID, "Demo Recording", 180, "recordings/user-1/abc.webm", "Alex Neamtu", createdAt, &shareExpiresAt, (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), "processing", "owner-user-id", "owner@example.com", (*string)(nil), "video/webm", (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), "none", (*string)(nil), "none", (*string)(nil)),
+			pgxmock.NewRows([]string{"id", "title", "duration", "file_key", "name", "created_at", "share_expires_at", "thumbnail_key", "share_password", "transcript_key", "transcript_json", "transcript_status", "user_id", "email", "view_notification", "content_type", "ub_company_name", "ub_logo_key", "ub_color_background", "ub_color_surface", "ub_color_text", "ub_color_accent", "ub_footer_text", "ub_custom_css", "ob_company_name", "ob_logo_key", "ob_color_background", "ob_color_surface", "ob_color_text", "ob_color_accent", "ob_footer_text", "ob_custom_css", "vb_company_name", "vb_logo_key", "vb_color_background", "vb_color_surface", "vb_color_text", "vb_color_accent", "vb_footer_text", "cta_text", "cta_url", "summary", "chapters", "summary_status", "document", "document_status", "organization_id", "email_gate_enabled"}).
+				AddRow(videoID, "Demo Recording", 180, "recordings/user-1/abc.webm", "Alex Neamtu", createdAt, &shareExpiresAt, (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), "processing", "owner-user-id", "owner@example.com", (*string)(nil), "video/webm", (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), "none", (*string)(nil), "none", (*string)(nil), false),
 		)
 
 	// No INSERT INTO video_views expected — poll should skip view recording
@@ -5850,8 +5862,8 @@ func TestOEmbed_Success(t *testing.T) {
 	mock.ExpectQuery(`SELECT v.title, v.duration, u.name, v.created_at, v.share_expires_at, v.thumbnail_key`).
 		WithArgs(shareToken).
 		WillReturnRows(
-			pgxmock.NewRows([]string{"title", "duration", "name", "created_at", "share_expires_at", "thumbnail_key"}).
-				AddRow("Demo Recording", 180, "Alex Neamtu", createdAt, &shareExpiresAt, stringPtr("thumbnails/user-1/abc.jpg")),
+			pgxmock.NewRows([]string{"title", "duration", "name", "created_at", "share_expires_at", "thumbnail_key", "share_password", "email_gate_enabled"}).
+				AddRow("Demo Recording", 180, "Alex Neamtu", createdAt, &shareExpiresAt, stringPtr("thumbnails/user-1/abc.jpg"), (*string)(nil), false),
 		)
 
 	r := chi.NewRouter()
@@ -5966,8 +5978,8 @@ func TestOEmbed_ExpiredLink(t *testing.T) {
 	mock.ExpectQuery(`SELECT v.title, v.duration, u.name, v.created_at, v.share_expires_at, v.thumbnail_key`).
 		WithArgs(shareToken).
 		WillReturnRows(
-			pgxmock.NewRows([]string{"title", "duration", "name", "created_at", "share_expires_at", "thumbnail_key"}).
-				AddRow("Demo Recording", 180, "Alex Neamtu", createdAt, &shareExpiresAt, (*string)(nil)),
+			pgxmock.NewRows([]string{"title", "duration", "name", "created_at", "share_expires_at", "thumbnail_key", "share_password", "email_gate_enabled"}).
+				AddRow("Demo Recording", 180, "Alex Neamtu", createdAt, &shareExpiresAt, (*string)(nil), (*string)(nil), false),
 		)
 
 	r := chi.NewRouter()
@@ -6008,8 +6020,8 @@ func TestOEmbed_NoThumbnail(t *testing.T) {
 	mock.ExpectQuery(`SELECT v.title, v.duration, u.name, v.created_at, v.share_expires_at, v.thumbnail_key`).
 		WithArgs(shareToken).
 		WillReturnRows(
-			pgxmock.NewRows([]string{"title", "duration", "name", "created_at", "share_expires_at", "thumbnail_key"}).
-				AddRow("No Thumb Video", 60, "Jane Doe", createdAt, &shareExpiresAt, (*string)(nil)),
+			pgxmock.NewRows([]string{"title", "duration", "name", "created_at", "share_expires_at", "thumbnail_key", "share_password", "email_gate_enabled"}).
+				AddRow("No Thumb Video", 60, "Jane Doe", createdAt, &shareExpiresAt, (*string)(nil), (*string)(nil), false),
 		)
 
 	r := chi.NewRouter()

--- a/internal/video/watch_access_test.go
+++ b/internal/video/watch_access_test.go
@@ -1,0 +1,247 @@
+package video
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/pashagolub/pgxmock/v4"
+)
+
+// SR-02 / SR-08: the share-password and email-gate checks were enforced only on
+// the server-rendered watch pages. Every JSON/redirect surface handed out the
+// content — presigned video URL, download URL, thumbnail, oEmbed metadata — to
+// anyone holding the share link. These tests pin the gate to the data APIs.
+
+var watchAPIColumns = []string{
+	"id", "title", "duration", "file_key", "name", "created_at", "share_expires_at",
+	"thumbnail_key", "share_password", "transcript_key", "transcript_json", "transcript_status",
+	"user_id", "email", "view_notification", "content_type",
+	"ub_company_name", "ub_logo_key", "ub_color_background", "ub_color_surface", "ub_color_text", "ub_color_accent", "ub_footer_text", "ub_custom_css",
+	"ob_company_name", "ob_logo_key", "ob_color_background", "ob_color_surface", "ob_color_text", "ob_color_accent", "ob_footer_text", "ob_custom_css",
+	"vb_company_name", "vb_logo_key", "vb_color_background", "vb_color_surface", "vb_color_text", "vb_color_accent", "vb_footer_text",
+	"cta_text", "cta_url", "summary", "chapters", "summary_status",
+	"document", "document_status", "organization_id", "email_gate_enabled",
+}
+
+// watchAPIRow builds a Watch row with the gate flags under test.
+func watchAPIRow(videoID string, sharePassword *string, emailGateEnabled bool, shareExpiresAt *time.Time) *pgxmock.Rows {
+	return pgxmock.NewRows(watchAPIColumns).AddRow(
+		videoID, "Demo Recording", 180, "recordings/user-1/abc.webm", "Alex Neamtu",
+		time.Date(2026, 2, 5, 14, 0, 0, 0, time.UTC), shareExpiresAt,
+		(*string)(nil), sharePassword, (*string)(nil), (*string)(nil), "none",
+		"owner-user-id", "owner@example.com", (*string)(nil), "video/webm",
+		(*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil),
+		(*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil),
+		(*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil),
+		(*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), "none",
+		(*string)(nil), "none", (*string)(nil), emailGateEnabled,
+	)
+}
+
+func serveWatchAPI(handler *Handler, req *http.Request) *httptest.ResponseRecorder {
+	r := chi.NewRouter()
+	r.Get("/api/watch/{shareToken}", handler.Watch)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+	return rec
+}
+
+func gateCookie(t *testing.T, shareToken, email string) *http.Cookie {
+	t.Helper()
+	return &http.Cookie{
+		Name:  emailGateCookieName(shareToken),
+		Value: signEmailGateCookie(testHMACSecret, shareToken, email),
+	}
+}
+
+func TestWatchAPI_EmailGateEnabled_NoCookie_IsDenied(t *testing.T) {
+	mock, err := pgxmock.NewPool()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer mock.Close()
+
+	handler := NewHandler(mock, &mockStorage{downloadURL: "https://s3.example.com/video"}, testBaseURL, 0, 0, 0, 0, testHMACSecret, false)
+	shareToken := "abc123defghi"
+	expiresAt := time.Now().Add(7 * 24 * time.Hour)
+
+	mock.ExpectQuery(`SELECT v.id, v.title, v.duration, v.file_key`).
+		WithArgs(shareToken).
+		WillReturnRows(watchAPIRow("video-001", nil, true, &expiresAt))
+
+	rec := serveWatchAPI(handler, httptest.NewRequest(http.MethodGet, "/api/watch/"+shareToken, nil))
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("expected 403 for gated video without an email cookie, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if body := rec.Body.String(); strings.Contains(body, "s3.example.com") {
+		t.Errorf("presigned video URL leaked past the email gate: %s", body)
+	}
+}
+
+func TestWatchAPI_EmailGateEnabled_ValidCookie_IsAllowed(t *testing.T) {
+	mock, err := pgxmock.NewPool()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer mock.Close()
+
+	handler := NewHandler(mock, &mockStorage{downloadURL: "https://s3.example.com/video"}, testBaseURL, 0, 0, 0, 0, testHMACSecret, false)
+	shareToken := "abc123defghi"
+	expiresAt := time.Now().Add(7 * 24 * time.Hour)
+
+	mock.ExpectQuery(`SELECT v.id, v.title, v.duration, v.file_key`).
+		WithArgs(shareToken).
+		WillReturnRows(watchAPIRow("video-001", nil, true, &expiresAt))
+	mock.ExpectExec(`INSERT INTO video_views`).
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnResult(pgxmock.NewResult("INSERT", 1))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/watch/"+shareToken, nil)
+	req.AddCookie(gateCookie(t, shareToken, "viewer@example.com"))
+	rec := serveWatchAPI(handler, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200 for identified viewer, got %d: %s", rec.Code, rec.Body.String())
+	}
+	time.Sleep(50 * time.Millisecond)
+}
+
+func TestWatchAPI_EmailGateDisabled_IsAllowed(t *testing.T) {
+	mock, err := pgxmock.NewPool()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer mock.Close()
+
+	handler := NewHandler(mock, &mockStorage{downloadURL: "https://s3.example.com/video"}, testBaseURL, 0, 0, 0, 0, testHMACSecret, false)
+	shareToken := "abc123defghi"
+	expiresAt := time.Now().Add(7 * 24 * time.Hour)
+
+	mock.ExpectQuery(`SELECT v.id, v.title, v.duration, v.file_key`).
+		WithArgs(shareToken).
+		WillReturnRows(watchAPIRow("video-001", nil, false, &expiresAt))
+	mock.ExpectExec(`INSERT INTO video_views`).
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnResult(pgxmock.NewResult("INSERT", 1))
+
+	rec := serveWatchAPI(handler, httptest.NewRequest(http.MethodGet, "/api/watch/"+shareToken, nil))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("ungated video must still play, got %d: %s", rec.Code, rec.Body.String())
+	}
+	time.Sleep(50 * time.Millisecond)
+}
+
+func TestWatchDownload_EmailGateEnabled_NoCookie_IsDenied(t *testing.T) {
+	mock, err := pgxmock.NewPool()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer mock.Close()
+
+	handler := NewHandler(mock, &mockStorage{downloadDispositionURL: "https://s3.example.com/dl"}, testBaseURL, 0, 0, 0, 0, testHMACSecret, false)
+	shareToken := "abc123defghi"
+	expiresAt := time.Now().Add(7 * 24 * time.Hour)
+
+	mock.ExpectQuery(`SELECT title, file_key, share_expires_at, share_password, content_type, download_enabled`).
+		WithArgs(shareToken).
+		WillReturnRows(pgxmock.NewRows([]string{"title", "file_key", "share_expires_at", "share_password", "content_type", "download_enabled", "email_gate_enabled"}).
+			AddRow("Demo Recording", "recordings/user-1/abc.webm", &expiresAt, (*string)(nil), "video/webm", true, true))
+
+	r := chi.NewRouter()
+	r.Get("/api/watch/{shareToken}/download", handler.WatchDownload)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/api/watch/"+shareToken+"/download", nil))
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("expected 403 for gated download, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if strings.Contains(rec.Body.String(), "s3.example.com") {
+		t.Errorf("download URL leaked past the email gate: %s", rec.Body.String())
+	}
+}
+
+func TestWatchThumbnail_PasswordProtected_NoCookie_IsDenied(t *testing.T) {
+	mock, err := pgxmock.NewPool()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer mock.Close()
+
+	handler := NewHandler(mock, &mockStorage{downloadURL: "https://s3.example.com/thumb.jpg"}, testBaseURL, 0, 0, 0, 0, testHMACSecret, false)
+	shareToken := "validtoken12"
+	thumbKey := "recordings/u1/thumb.jpg"
+	expiresAt := time.Now().Add(7 * 24 * time.Hour)
+	hashed := "$2a$10$abcdefghijklmnopqrstuv"
+
+	mock.ExpectQuery(`SELECT v.thumbnail_key, v.share_expires_at`).
+		WithArgs(shareToken).
+		WillReturnRows(pgxmock.NewRows([]string{"thumbnail_key", "share_expires_at", "share_password", "email_gate_enabled"}).
+			AddRow(&thumbKey, &expiresAt, &hashed, false))
+
+	rec := serveWatchThumbnail(handler, httptest.NewRequest(http.MethodGet, "/api/watch/"+shareToken+"/thumbnail", nil))
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("expected 403 for a password-protected thumbnail, got %d (Location=%q)", rec.Code, rec.Header().Get("Location"))
+	}
+}
+
+func TestWatchThumbnail_EmailGateEnabled_NoCookie_IsDenied(t *testing.T) {
+	mock, err := pgxmock.NewPool()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer mock.Close()
+
+	handler := NewHandler(mock, &mockStorage{downloadURL: "https://s3.example.com/thumb.jpg"}, testBaseURL, 0, 0, 0, 0, testHMACSecret, false)
+	shareToken := "validtoken12"
+	thumbKey := "recordings/u1/thumb.jpg"
+	expiresAt := time.Now().Add(7 * 24 * time.Hour)
+
+	mock.ExpectQuery(`SELECT v.thumbnail_key, v.share_expires_at`).
+		WithArgs(shareToken).
+		WillReturnRows(pgxmock.NewRows([]string{"thumbnail_key", "share_expires_at", "share_password", "email_gate_enabled"}).
+			AddRow(&thumbKey, &expiresAt, (*string)(nil), true))
+
+	rec := serveWatchThumbnail(handler, httptest.NewRequest(http.MethodGet, "/api/watch/"+shareToken+"/thumbnail", nil))
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("expected 403 for an email-gated thumbnail, got %d (Location=%q)", rec.Code, rec.Header().Get("Location"))
+	}
+}
+
+func TestOEmbed_PasswordProtected_IsDenied(t *testing.T) {
+	mock, err := pgxmock.NewPool()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer mock.Close()
+
+	handler := NewHandler(mock, &mockStorage{downloadURL: "https://s3.example.com/thumb.jpg"}, testBaseURL, 0, 0, 0, 0, testHMACSecret, false)
+	shareToken := "abc123defghi"
+	createdAt := time.Date(2026, 2, 10, 14, 30, 0, 0, time.UTC)
+	expiresAt := time.Now().Add(7 * 24 * time.Hour)
+	hashed := "$2a$10$abcdefghijklmnopqrstuv"
+
+	mock.ExpectQuery(`SELECT v.title, v.duration, u.name, v.created_at, v.share_expires_at, v.thumbnail_key`).
+		WithArgs(shareToken).
+		WillReturnRows(pgxmock.NewRows([]string{"title", "duration", "name", "created_at", "share_expires_at", "thumbnail_key", "share_password", "email_gate_enabled"}).
+			AddRow("Secret Recording", 180, "Alex Neamtu", createdAt, &expiresAt, stringPtr("thumbnails/user-1/abc.jpg"), &hashed, false))
+
+	r := chi.NewRouter()
+	r.Get("/api/videos/{shareToken}/oembed", handler.OEmbed)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/api/videos/"+shareToken+"/oembed", nil))
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("expected 403 from oEmbed for a password-protected video, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if strings.Contains(rec.Body.String(), "Secret Recording") {
+		t.Errorf("oEmbed leaked the title of a password-protected video: %s", rec.Body.String())
+	}
+}

--- a/internal/video/watch_auth.go
+++ b/internal/video/watch_auth.go
@@ -36,12 +36,20 @@ func watchCookieName(shareToken string) string {
 	return "wa_" + prefix
 }
 
+// deriveCookieKey separates a cookie-signing key from the JWT secret it comes
+// from, so no single key signs two different kinds of message (SR-12). Deriving
+// here rather than at the call sites keeps the raw secret out of every HMAC.
+func deriveCookieKey(secret, purpose string) []byte {
+	sum := sha256.Sum256([]byte("sendrec/" + purpose + "/v1|" + secret))
+	return sum[:]
+}
+
 func signWatchCookie(hmacSecret, shareToken, passwordHash string) string {
 	hashPrefix := passwordHash
 	if len(hashPrefix) > 16 {
 		hashPrefix = hashPrefix[:16]
 	}
-	mac := hmac.New(sha256.New, []byte(hmacSecret))
+	mac := hmac.New(sha256.New, deriveCookieKey(hmacSecret, "watch-cookie"))
 	mac.Write([]byte(shareToken + "|" + hashPrefix))
 	return hex.EncodeToString(mac.Sum(nil))
 }
@@ -69,6 +77,28 @@ func hasValidWatchCookie(r *http.Request, hmacSecret, shareToken, passwordHash s
 		return false
 	}
 	return verifyWatchCookie(hmacSecret, shareToken, passwordHash, cookie.Value)
+}
+
+// enforceWatchAccess applies the share-password and email-gate checks that guard
+// a shared video. Every watch surface — JSON, download, thumbnail, oEmbed — must
+// route through it; enforcing only on the rendered pages left the data APIs open
+// to anyone holding the share link.
+//
+// It writes the error response and returns false when access is denied.
+func (h *Handler) enforceWatchAccess(w http.ResponseWriter, r *http.Request, shareToken string, sharePassword *string, emailGateEnabled bool) bool {
+	if sharePassword != nil && !hasValidWatchCookie(r, h.hmacSecret, shareToken, *sharePassword) {
+		httputil.WriteError(w, http.StatusForbidden, "password required")
+		return false
+	}
+
+	if emailGateEnabled {
+		if _, ok := hasValidEmailGateCookie(r, h.hmacSecret, shareToken); !ok {
+			httputil.WriteError(w, http.StatusForbidden, "email required")
+			return false
+		}
+	}
+
+	return true
 }
 
 type verifyPasswordRequest struct {
@@ -125,7 +155,7 @@ func emailGateCookieName(shareToken string) string {
 }
 
 func signEmailGateCookie(hmacSecret, shareToken, email string) string {
-	mac := hmac.New(sha256.New, []byte(hmacSecret))
+	mac := hmac.New(sha256.New, deriveCookieKey(hmacSecret, "email-gate-cookie"))
 	mac.Write([]byte(shareToken + "|" + email))
 	sig := hex.EncodeToString(mac.Sum(nil))
 	return email + "|" + sig

--- a/internal/video/watch_auth_test.go
+++ b/internal/video/watch_auth_test.go
@@ -2,6 +2,9 @@ package video
 
 import (
 	"bytes"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"net/http"
@@ -338,8 +341,8 @@ func TestWatch_PasswordProtected_NoCookie(t *testing.T) {
 	mock.ExpectQuery(`SELECT v.id, v.title, v.duration, v.file_key, u.name, v.created_at, v.share_expires_at`).
 		WithArgs(shareToken).
 		WillReturnRows(
-			pgxmock.NewRows([]string{"id", "title", "duration", "file_key", "name", "created_at", "share_expires_at", "thumbnail_key", "share_password", "transcript_key", "transcript_json", "transcript_status", "user_id", "email", "view_notification", "content_type", "ub_company_name", "ub_logo_key", "ub_color_background", "ub_color_surface", "ub_color_text", "ub_color_accent", "ub_footer_text", "ub_custom_css", "ob_company_name", "ob_logo_key", "ob_color_background", "ob_color_surface", "ob_color_text", "ob_color_accent", "ob_footer_text", "ob_custom_css", "vb_company_name", "vb_logo_key", "vb_color_background", "vb_color_surface", "vb_color_text", "vb_color_accent", "vb_footer_text", "cta_text", "cta_url", "summary", "chapters", "summary_status", "document", "document_status", "organization_id"}).
-				AddRow("video-001", "Demo Recording", 180, "recordings/user-1/abc.webm", "Alex Neamtu", createdAt, &shareExpiresAt, (*string)(nil), &passwordHash, (*string)(nil), (*string)(nil), "none", "owner-user-id", "owner@example.com", (*string)(nil), "video/webm", (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), "none", (*string)(nil), "none", (*string)(nil)),
+			pgxmock.NewRows([]string{"id", "title", "duration", "file_key", "name", "created_at", "share_expires_at", "thumbnail_key", "share_password", "transcript_key", "transcript_json", "transcript_status", "user_id", "email", "view_notification", "content_type", "ub_company_name", "ub_logo_key", "ub_color_background", "ub_color_surface", "ub_color_text", "ub_color_accent", "ub_footer_text", "ub_custom_css", "ob_company_name", "ob_logo_key", "ob_color_background", "ob_color_surface", "ob_color_text", "ob_color_accent", "ob_footer_text", "ob_custom_css", "vb_company_name", "vb_logo_key", "vb_color_background", "vb_color_surface", "vb_color_text", "vb_color_accent", "vb_footer_text", "cta_text", "cta_url", "summary", "chapters", "summary_status", "document", "document_status", "organization_id", "email_gate_enabled"}).
+				AddRow("video-001", "Demo Recording", 180, "recordings/user-1/abc.webm", "Alex Neamtu", createdAt, &shareExpiresAt, (*string)(nil), &passwordHash, (*string)(nil), (*string)(nil), "none", "owner-user-id", "owner@example.com", (*string)(nil), "video/webm", (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), "none", (*string)(nil), "none", (*string)(nil), false),
 		)
 
 	r := chi.NewRouter()
@@ -376,8 +379,8 @@ func TestWatch_PasswordProtected_ValidCookie(t *testing.T) {
 	mock.ExpectQuery(`SELECT v.id, v.title, v.duration, v.file_key, u.name, v.created_at, v.share_expires_at`).
 		WithArgs(shareToken).
 		WillReturnRows(
-			pgxmock.NewRows([]string{"id", "title", "duration", "file_key", "name", "created_at", "share_expires_at", "thumbnail_key", "share_password", "transcript_key", "transcript_json", "transcript_status", "user_id", "email", "view_notification", "content_type", "ub_company_name", "ub_logo_key", "ub_color_background", "ub_color_surface", "ub_color_text", "ub_color_accent", "ub_footer_text", "ub_custom_css", "ob_company_name", "ob_logo_key", "ob_color_background", "ob_color_surface", "ob_color_text", "ob_color_accent", "ob_footer_text", "ob_custom_css", "vb_company_name", "vb_logo_key", "vb_color_background", "vb_color_surface", "vb_color_text", "vb_color_accent", "vb_footer_text", "cta_text", "cta_url", "summary", "chapters", "summary_status", "document", "document_status", "organization_id"}).
-				AddRow(videoID, "Demo Recording", 180, "recordings/user-1/abc.webm", "Alex Neamtu", createdAt, &shareExpiresAt, (*string)(nil), &passwordHash, (*string)(nil), (*string)(nil), "none", "owner-user-id", "owner@example.com", (*string)(nil), "video/webm", (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), "none", (*string)(nil), "none", (*string)(nil)),
+			pgxmock.NewRows([]string{"id", "title", "duration", "file_key", "name", "created_at", "share_expires_at", "thumbnail_key", "share_password", "transcript_key", "transcript_json", "transcript_status", "user_id", "email", "view_notification", "content_type", "ub_company_name", "ub_logo_key", "ub_color_background", "ub_color_surface", "ub_color_text", "ub_color_accent", "ub_footer_text", "ub_custom_css", "ob_company_name", "ob_logo_key", "ob_color_background", "ob_color_surface", "ob_color_text", "ob_color_accent", "ob_footer_text", "ob_custom_css", "vb_company_name", "vb_logo_key", "vb_color_background", "vb_color_surface", "vb_color_text", "vb_color_accent", "vb_footer_text", "cta_text", "cta_url", "summary", "chapters", "summary_status", "document", "document_status", "organization_id", "email_gate_enabled"}).
+				AddRow(videoID, "Demo Recording", 180, "recordings/user-1/abc.webm", "Alex Neamtu", createdAt, &shareExpiresAt, (*string)(nil), &passwordHash, (*string)(nil), (*string)(nil), "none", "owner-user-id", "owner@example.com", (*string)(nil), "video/webm", (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*string)(nil), "none", (*string)(nil), "none", (*string)(nil), false),
 		)
 
 	mock.ExpectExec(`INSERT INTO video_views`).
@@ -421,10 +424,10 @@ func TestWatchDownload_PasswordProtected_NoCookie(t *testing.T) {
 	shareToken := "abc123defghi"
 	shareExpiresAt := time.Now().Add(7 * 24 * time.Hour)
 
-	mock.ExpectQuery(`SELECT title, file_key, share_expires_at, share_password, content_type, download_enabled FROM videos WHERE share_token = \$1 AND status IN \('ready', 'processing'\)`).
+	mock.ExpectQuery(`SELECT title, file_key, share_expires_at, share_password, content_type, download_enabled, email_gate_enabled FROM videos WHERE share_token = \$1 AND status IN \('ready', 'processing'\)`).
 		WithArgs(shareToken).
-		WillReturnRows(pgxmock.NewRows([]string{"title", "file_key", "share_expires_at", "share_password", "content_type", "download_enabled"}).
-			AddRow("Demo Recording", "recordings/user-1/abc.webm", &shareExpiresAt, &passwordHash, "video/webm", true))
+		WillReturnRows(pgxmock.NewRows([]string{"title", "file_key", "share_expires_at", "share_password", "content_type", "download_enabled", "email_gate_enabled"}).
+			AddRow("Demo Recording", "recordings/user-1/abc.webm", &shareExpiresAt, &passwordHash, "video/webm", true, false))
 
 	r := chi.NewRouter()
 	r.Get("/api/watch/{shareToken}/download", handler.WatchDownload)
@@ -564,5 +567,43 @@ func TestWatchPage_PasswordProtected_ShowsPasswordForm(t *testing.T) {
 
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Errorf("unmet pgxmock expectations: %v", err)
+	}
+}
+
+// SR-12: watch and email-gate cookies were HMAC'd with the raw JWT signing key.
+// Key separation is cheap; sharing one key across purposes is the kind of thing
+// that only becomes a problem once some other message format collides with it.
+func TestWatchCookieKeyIsSeparatedFromJWTSecret(t *testing.T) {
+	const secret = "shared-jwt-secret"
+	const shareToken = "abc123defghi"
+	const passwordHash = "$2a$10$abcdefghijklmnopqrstuv"
+
+	rawKeyMAC := hmac.New(sha256.New, []byte(secret))
+	rawKeyMAC.Write([]byte(shareToken + "|" + passwordHash[:16]))
+	rawKeySignature := hex.EncodeToString(rawKeyMAC.Sum(nil))
+
+	if got := signWatchCookie(secret, shareToken, passwordHash); got == rawKeySignature {
+		t.Error("watch cookie is still signed with the raw JWT secret")
+	}
+
+	// Separation must not break the cookie's own round trip.
+	if !verifyWatchCookie(secret, shareToken, passwordHash, signWatchCookie(secret, shareToken, passwordHash)) {
+		t.Error("watch cookie failed to verify against its own signature")
+	}
+}
+
+func TestEmailGateCookieUsesADistinctKeyFromWatchCookies(t *testing.T) {
+	const secret = "shared-jwt-secret"
+	const shareToken = "abc123defghi"
+
+	gate := signEmailGateCookie(secret, shareToken, "viewer@example.com")
+	watch := signWatchCookie(secret, shareToken, "viewer@example.com")
+
+	if strings.HasSuffix(gate, watch) {
+		t.Error("email-gate and watch cookies share a signing key")
+	}
+
+	if _, ok := verifyEmailGateCookie(secret, shareToken, gate); !ok {
+		t.Error("email-gate cookie failed to verify against its own signature")
 	}
 }

--- a/internal/video/watch_page.go
+++ b/internal/video/watch_page.go
@@ -2000,10 +2000,20 @@ var emailGatePageTemplate = template.Must(template.New("emailgate").Parse(`<!DOC
 </body>
 </html>`))
 
+// injectScriptNonce adds the per-request CSP nonce to the operator-configured
+// analytics snippet. The snippet is emitted as trusted HTML, so accept only the
+// shape this rewrite actually handles — one leading <script> tag — and drop
+// anything else rather than emit markup the nonce does not cover (SR-14).
 func injectScriptNonce(scriptTag, nonce string) template.HTML {
 	if scriptTag == "" {
 		return ""
 	}
+
+	if !strings.HasPrefix(scriptTag, "<script") || strings.Count(scriptTag, "<script") != 1 {
+		slog.Warn("watch-page: ignoring ANALYTICS_SCRIPT, expected exactly one leading <script> tag")
+		return ""
+	}
+
 	injected := strings.Replace(scriptTag, "<script", "<script nonce=\""+nonce+"\"", 1)
 	return template.HTML(injected)
 }
@@ -2270,13 +2280,15 @@ func (h *Handler) WatchThumbnail(w http.ResponseWriter, r *http.Request) {
 
 	var thumbnailKey *string
 	var shareExpiresAt *time.Time
+	var sharePassword *string
+	var emailGateEnabled bool
 
 	err := h.db.QueryRow(r.Context(),
-		`SELECT v.thumbnail_key, v.share_expires_at
+		`SELECT v.thumbnail_key, v.share_expires_at, v.share_password, v.email_gate_enabled
 		 FROM videos v
 		 WHERE v.share_token = $1 AND v.status IN ('ready', 'processing')`,
 		shareToken,
-	).Scan(&thumbnailKey, &shareExpiresAt)
+	).Scan(&thumbnailKey, &shareExpiresAt, &sharePassword, &emailGateEnabled)
 	if err != nil {
 		http.NotFound(w, r)
 		return
@@ -2284,6 +2296,12 @@ func (h *Handler) WatchThumbnail(w http.ResponseWriter, r *http.Request) {
 
 	if shareExpiresAt != nil && time.Now().After(*shareExpiresAt) {
 		http.NotFound(w, r)
+		return
+	}
+
+	// The thumbnail of a screen recording is itself sensitive, so it may not
+	// outrun the password/email gate protecting the video (SR-08).
+	if !h.enforceWatchAccess(w, r, shareToken, sharePassword, emailGateEnabled) {
 		return
 	}
 

--- a/internal/video/watch_page_test.go
+++ b/internal/video/watch_page_test.go
@@ -1404,6 +1404,12 @@ func TestInjectScriptNonce(t *testing.T) {
 			`<script nonce="n123" defer src="/script.js" data-website-id="xxx"></script>`},
 		{"plausible", `<script defer data-domain="example.com" src="https://plausible.io/js/script.js"></script>`, "n456",
 			`<script nonce="n456" defer data-domain="example.com" src="https://plausible.io/js/script.js"></script>`},
+		// SR-14: the snippet is operator-supplied and injected by string surgery.
+		// Anything that is not a single well-formed <script> tag would put the
+		// nonce somewhere unintended, so it must not be emitted at all.
+		{"bare url", `https://analytics.example.com/s.js`, "n1", ""},
+		{"leading markup", `<img src=x><script src="s.js"></script>`, "n1", ""},
+		{"two script tags", `<script src="a.js"></script><script src="b.js"></script>`, "n1", ""},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -2540,8 +2546,8 @@ func TestWatchThumbnail_Redirects(t *testing.T) {
 
 	mock.ExpectQuery(`SELECT v.thumbnail_key, v.share_expires_at`).
 		WithArgs("validtoken12").
-		WillReturnRows(pgxmock.NewRows([]string{"thumbnail_key", "share_expires_at"}).
-			AddRow(&thumbKey, &expiresAt))
+		WillReturnRows(pgxmock.NewRows([]string{"thumbnail_key", "share_expires_at", "share_password", "email_gate_enabled"}).
+			AddRow(&thumbKey, &expiresAt, (*string)(nil), false))
 
 	req := httptest.NewRequest(http.MethodGet, "/api/watch/validtoken12/thumbnail", nil)
 	rec := serveWatchThumbnail(handler, req)
@@ -2595,8 +2601,8 @@ func TestWatchThumbnail_NoThumbnail(t *testing.T) {
 
 	mock.ExpectQuery(`SELECT v.thumbnail_key, v.share_expires_at`).
 		WithArgs("nothumbtoken").
-		WillReturnRows(pgxmock.NewRows([]string{"thumbnail_key", "share_expires_at"}).
-			AddRow((*string)(nil), &expiresAt))
+		WillReturnRows(pgxmock.NewRows([]string{"thumbnail_key", "share_expires_at", "share_password", "email_gate_enabled"}).
+			AddRow((*string)(nil), &expiresAt, (*string)(nil), false))
 
 	req := httptest.NewRequest(http.MethodGet, "/api/watch/nothumbtoken/thumbnail", nil)
 	rec := serveWatchThumbnail(handler, req)
@@ -2623,8 +2629,8 @@ func TestWatchThumbnail_Expired(t *testing.T) {
 
 	mock.ExpectQuery(`SELECT v.thumbnail_key, v.share_expires_at`).
 		WithArgs("expiredtoken").
-		WillReturnRows(pgxmock.NewRows([]string{"thumbnail_key", "share_expires_at"}).
-			AddRow(&thumbKey, &expiredAt))
+		WillReturnRows(pgxmock.NewRows([]string{"thumbnail_key", "share_expires_at", "share_password", "email_gate_enabled"}).
+			AddRow(&thumbKey, &expiredAt, (*string)(nil), false))
 
 	req := httptest.NewRequest(http.MethodGet, "/api/watch/expiredtoken/thumbnail", nil)
 	rec := serveWatchThumbnail(handler, req)

--- a/internal/webhook/ssrf.go
+++ b/internal/webhook/ssrf.go
@@ -1,0 +1,58 @@
+package webhook
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"syscall"
+)
+
+// AllowPrivateTargets permits webhooks to reach loopback and private addresses.
+// Off in production; set from WEBHOOK_ALLOW_PRIVATE_TARGETS so local development
+// can point a webhook at a listener on the developer's own machine.
+var AllowPrivateTargets bool
+
+// IsBlockedIP reports whether an address belongs to the infrastructure rather
+// than the internet — loopback, RFC1918, link-local (including the cloud
+// metadata endpoint at 169.254.169.254), and unique-local IPv6.
+func IsBlockedIP(ip net.IP) bool {
+	if AllowPrivateTargets {
+		return false
+	}
+
+	return ip.IsLoopback() ||
+		ip.IsPrivate() ||
+		ip.IsLinkLocalUnicast() ||
+		ip.IsLinkLocalMulticast() ||
+		ip.IsInterfaceLocalMulticast() ||
+		ip.IsUnspecified()
+}
+
+// blockInternalTargets rejects connections to internal addresses at dial time.
+//
+// Validating the configured URL is not enough: the hostname may resolve to an
+// internal address, may resolve differently on the second lookup, or the target
+// may redirect. The dialer sees the address actually being connected to on every
+// hop, so this is the one place the check cannot be routed around.
+func blockInternalTargets(_ context.Context, _, address string) error {
+	host, _, err := net.SplitHostPort(address)
+	if err != nil {
+		return fmt.Errorf("webhook: cannot parse dial address %q: %w", address, err)
+	}
+
+	ip := net.ParseIP(host)
+	if ip == nil {
+		return fmt.Errorf("webhook: unresolved dial address %q", host)
+	}
+
+	if IsBlockedIP(ip) {
+		return fmt.Errorf("webhook: refusing to connect to internal address %s", ip)
+	}
+
+	return nil
+}
+
+// safeDialControl is the net.Dialer Control hook wired into the webhook client.
+func safeDialControl(network, address string, _ syscall.RawConn) error {
+	return blockInternalTargets(context.Background(), network, address)
+}

--- a/internal/webhook/ssrf_test.go
+++ b/internal/webhook/ssrf_test.go
@@ -1,0 +1,63 @@
+package webhook
+
+import (
+	"net"
+	"testing"
+)
+
+// SR-06: user-controlled webhook URLs are an outbound request primitive. Blocking
+// has to happen at dial time, not just on the configured string, because DNS
+// names and redirects both resolve to addresses the validator never sees.
+
+func TestBlockedDialTargets(t *testing.T) {
+	blocked := []string{
+		"127.0.0.1",       // loopback
+		"127.5.5.5",       // loopback range
+		"::1",             // IPv6 loopback
+		"10.0.0.5",        // RFC1918
+		"172.16.4.1",      // RFC1918
+		"192.168.1.10",    // RFC1918
+		"169.254.169.254", // link-local / cloud metadata
+		"fd00::1",         // IPv6 unique-local
+		"fe80::1",         // IPv6 link-local
+		"0.0.0.0",         // unspecified
+	}
+
+	for _, addr := range blocked {
+		ip := net.ParseIP(addr)
+		if ip == nil {
+			t.Fatalf("bad test fixture %q", addr)
+		}
+		if !IsBlockedIP(ip) {
+			t.Errorf("expected %s to be blocked as an internal target", addr)
+		}
+	}
+}
+
+func TestAllowedDialTargets(t *testing.T) {
+	allowed := []string{
+		"93.184.216.34",     // public IPv4
+		"2606:2800:220:1::", // public IPv6
+		"8.8.8.8",
+	}
+
+	for _, addr := range allowed {
+		ip := net.ParseIP(addr)
+		if ip == nil {
+			t.Fatalf("bad test fixture %q", addr)
+		}
+		if IsBlockedIP(ip) {
+			t.Errorf("expected %s to be allowed", addr)
+		}
+	}
+}
+
+func TestAllowPrivateTargetsOptsOutForLocalDevelopment(t *testing.T) {
+	previous := AllowPrivateTargets
+	AllowPrivateTargets = true
+	t.Cleanup(func() { AllowPrivateTargets = previous })
+
+	if IsBlockedIP(net.ParseIP("127.0.0.1")) {
+		t.Error("loopback must be reachable when explicitly allowed for local development")
+	}
+}

--- a/internal/webhook/webhook.go
+++ b/internal/webhook/webhook.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"net"
 	"net/http"
 	"time"
 
@@ -33,10 +34,27 @@ type Client struct {
 }
 
 // New creates a webhook client.
+//
+// The transport refuses to dial internal addresses and does not follow
+// redirects: both are ways a user-supplied URL can reach services that are not
+// on the internet (SR-06).
 func New(db database.DBTX) *Client {
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.DialContext = (&net.Dialer{
+		Timeout:   10 * time.Second,
+		KeepAlive: 30 * time.Second,
+		Control:   safeDialControl,
+	}).DialContext
+
 	return &Client{
-		db:          db,
-		http:        &http.Client{Timeout: 10 * time.Second},
+		db: db,
+		http: &http.Client{
+			Timeout:   10 * time.Second,
+			Transport: transport,
+			CheckRedirect: func(*http.Request, []*http.Request) error {
+				return http.ErrUseLastResponse
+			},
+		},
 		retryDelays: []time.Duration{1 * time.Second, 4 * time.Second},
 	}
 }

--- a/internal/webhook/webhook_test.go
+++ b/internal/webhook/webhook_test.go
@@ -52,7 +52,17 @@ func expectDeliveryLog(mock pgxmock.PgxPoolIface, eventName string, attempt int)
 		WillReturnResult(pgxmock.NewResult("INSERT", 1))
 }
 
+// allowLocalDispatch lets a test dial the httptest server on loopback, which the
+// SSRF guard blocks by default (SR-06).
+func allowLocalDispatch(t *testing.T) {
+	t.Helper()
+	previous := AllowPrivateTargets
+	AllowPrivateTargets = true
+	t.Cleanup(func() { AllowPrivateTargets = previous })
+}
+
 func TestDispatchSuccess(t *testing.T) {
+	allowLocalDispatch(t)
 	mock, err := pgxmock.NewPool()
 	if err != nil {
 		t.Fatal(err)
@@ -107,6 +117,7 @@ func TestDispatchSuccess(t *testing.T) {
 }
 
 func TestDispatchRetryOnServerError(t *testing.T) {
+	allowLocalDispatch(t)
 	mock, err := pgxmock.NewPool()
 	if err != nil {
 		t.Fatal(err)
@@ -154,6 +165,7 @@ func TestDispatchRetryOnServerError(t *testing.T) {
 }
 
 func TestDispatchAllRetriesFail(t *testing.T) {
+	allowLocalDispatch(t)
 	mock, err := pgxmock.NewPool()
 	if err != nil {
 		t.Fatal(err)
@@ -200,6 +212,7 @@ func TestDispatchAllRetriesFail(t *testing.T) {
 }
 
 func TestDispatchConnectionError(t *testing.T) {
+	allowLocalDispatch(t)
 	mock, err := pgxmock.NewPool()
 	if err != nil {
 		t.Fatal(err)
@@ -235,6 +248,7 @@ func TestDispatchConnectionError(t *testing.T) {
 }
 
 func TestResponseBodyTruncation(t *testing.T) {
+	allowLocalDispatch(t)
 	mock, err := pgxmock.NewPool()
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
Security remediation for the audited findings SR-01 through SR-15. Validated dynamically + statically (see `.ai/security-audit-validation-report.md`). The follow-up gaps found during validation are addressed in the stacked PR #185.