### PR TITLE
Security remediation follow-up: F-1..F-4 fixes, C-1..C-3 cleanup, TRUSTED_PROXY docs

### DIFF
--- a/SELF-HOSTING.md
+++ b/SELF-HOSTING.md
@@ -211,6 +211,15 @@ volumes:
 
 Put a reverse proxy (Caddy, nginx, Traefik) in front to handle TLS. The proxy should route your app domain to port 8080 and your storage domain to Garage port 3900.
 
+### Rate limiting behind a proxy (`TRUSTED_PROXY`)
+
+Per-IP rate limiting keys on the connection's source address. Behind a reverse proxy every request arrives from the *proxy's* address, so the setting matters:
+
+- **`TRUSTED_PROXY` unset or `false`, behind a proxy** — all traffic looks like it comes from the proxy IP, so every user shares a single rate-limit bucket. One busy client trips the limit for everyone — a self-inflicted denial of service.
+- **`TRUSTED_PROXY=true`** — the app believes the last `X-Forwarded-For` entry and limits per real client IP.
+
+Set `TRUSTED_PROXY=true` **only** when an edge proxy you control always sets `X-Forwarded-For` (Caddy, nginx, and Traefik do by default). If the app is exposed to the internet directly, leave it `false`: otherwise clients forge the header and evade rate limiting entirely.
+
 ## Environment variables
 
 ### Required

--- a/cmd/sendrec/main.go
+++ b/cmd/sendrec/main.go
@@ -144,7 +144,6 @@ func main() {
 	planBadgeEnabled := getEnv("PLAN_BADGE_ENABLED", "false") == "true"
 
 	srv := server.New(server.Config{
-		Version:                   version,
 		DB:                        db.Pool,
 		Pinger:                    db,
 		Storage:                   store,

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -9,6 +9,9 @@ services:
     environment:
       - DATABASE_URL=postgres://sendrec:${SENDREC_DB_PASSWORD:-sendrec}@postgres:5432/sendrec?sslmode=disable
       - S3_ENDPOINT=http://garage:3900
+      # S3_ENDPOINT is the internal Docker hostname; browsers can't reach it, so
+      # presigned upload/download URLs must be signed for a host-reachable one.
+      - S3_PUBLIC_ENDPOINT=${S3_PUBLIC_ENDPOINT:-http://localhost:3900}
       - S3_REGION=${S3_REGION:-eu-central-1}
       - S3_BUCKET=recordings
       - JWT_SECRET=${JWT_SECRET:-dev-secret-change-in-production}
@@ -32,6 +35,9 @@ services:
       POSTGRES_USER: sendrec
       POSTGRES_PASSWORD: ${SENDREC_DB_PASSWORD:-sendrec}
       POSTGRES_DB: sendrec
+      # postgres:18+ refuses a data volume mounted at the legacy path root;
+      # point PGDATA at a subdirectory of the mount so initdb runs cleanly.
+      PGDATA: /var/lib/postgresql/data/pgdata
     volumes:
       - sendrec-db:/var/lib/postgresql/data
     healthcheck:

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -766,6 +766,15 @@ func (h *Handler) UpdateUser(w http.ResponseWriter, r *http.Request) {
 		); err != nil {
 			slog.Error("update-user: failed to revoke refresh tokens", "error", err)
 		}
+
+		// Same reasoning as the reset flow: a password change is a lock-out
+		// action, so cut off never-expiring API keys too (SR-05).
+		if _, err := h.db.Exec(r.Context(),
+			"DELETE FROM api_keys WHERE user_id = $1",
+			userID,
+		); err != nil {
+			slog.Error("update-user: failed to revoke API keys", "error", err)
+		}
 	}
 
 	if hasNameChange {

--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -1997,6 +1997,47 @@ func TestUpdateUser_ChangePasswordRevokesRefreshTokens(t *testing.T) {
 	}
 }
 
+// SR-05 (settings path): the reset flow revokes API keys, but a password change
+// from settings must do the same — a stolen key otherwise survives the exact
+// action a compromised user takes to lock an attacker out.
+func TestUpdateUser_ChangePasswordRevokesAPIKeys(t *testing.T) {
+	handler, mock := newTestHandler(t)
+	defer mock.Close()
+
+	oldHash, _ := bcrypt.GenerateFromPassword([]byte("oldpass123"), bcrypt.MinCost)
+
+	mock.ExpectQuery(`SELECT password FROM users WHERE id = \$1`).
+		WithArgs("user-uuid-1").
+		WillReturnRows(pgxmock.NewRows([]string{"password"}).AddRow(string(oldHash)))
+
+	mock.ExpectExec(`UPDATE users SET password = \$1, updated_at = now\(\) WHERE id = \$2`).
+		WithArgs(pgxmock.AnyArg(), "user-uuid-1").
+		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+
+	mock.ExpectExec(`UPDATE refresh_tokens SET revoked = true`).
+		WithArgs("user-uuid-1").
+		WillReturnResult(pgxmock.NewResult("UPDATE", 2))
+
+	mock.ExpectExec(`DELETE FROM api_keys WHERE user_id = \$1`).
+		WithArgs("user-uuid-1").
+		WillReturnResult(pgxmock.NewResult("DELETE", 1))
+
+	body := `{"currentPassword":"oldpass123","newPassword":"newpass456"}`
+	req := httptest.NewRequest(http.MethodPatch, "/api/user", strings.NewReader(body))
+	req = req.WithContext(context.WithValue(req.Context(), userIDKey, "user-uuid-1"))
+	rec := httptest.NewRecorder()
+
+	handler.UpdateUser(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d: %s", http.StatusOK, rec.Code, rec.Body.String())
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("API keys were not revoked on settings password change: %v", err)
+	}
+}
+
 // SR-05: API keys outlived credential recovery entirely. Resetting the password
 // after a compromise left any stolen key working indefinitely.
 func TestResetPassword_RevokesAPIKeys(t *testing.T) {

--- a/internal/scim/handler.go
+++ b/internal/scim/handler.go
@@ -12,6 +12,7 @@ import (
 	"github.com/jackc/pgx/v5"
 
 	"github.com/sendrec/sendrec/internal/database"
+	"github.com/sendrec/sendrec/internal/validate"
 )
 
 type Handler struct {
@@ -101,6 +102,11 @@ func (h *Handler) CreateUser(w http.ResponseWriter, r *http.Request) {
 	externalID := req.ExternalID
 	if externalID == "" {
 		externalID = email
+	}
+
+	if msg := validate.Name(name); msg != "" {
+		writeError(w, http.StatusBadRequest, msg)
+		return
 	}
 
 	userID, created, err := h.resolveUser(r.Context(), orgID, externalID, email, name)
@@ -318,6 +324,12 @@ func (h *Handler) PatchUser(w http.ResponseWriter, r *http.Request) {
 			writeError(w, http.StatusBadRequest, "invalid patch operation")
 			return
 		}
+		if update.Name != nil {
+			if msg := validate.Name(*update.Name); msg != "" {
+				writeError(w, http.StatusBadRequest, msg)
+				return
+			}
+		}
 		if err := h.applyUserUpdate(r.Context(), orgID, userID, update); err != nil {
 			writeError(w, http.StatusInternalServerError, "update user failed")
 			return
@@ -369,6 +381,13 @@ func (h *Handler) ReplaceUser(w http.ResponseWriter, r *http.Request) {
 	}
 	if update.ExternalID != nil && *update.ExternalID == "" {
 		update.ExternalID = nil
+	}
+
+	if update.Name != nil {
+		if msg := validate.Name(*update.Name); msg != "" {
+			writeError(w, http.StatusBadRequest, msg)
+			return
+		}
 	}
 
 	if err := h.applyUserUpdate(r.Context(), orgID, userID, update); err != nil {

--- a/internal/scim/handler_test.go
+++ b/internal/scim/handler_test.go
@@ -12,6 +12,8 @@ import (
 	"github.com/go-chi/chi/v5"
 	"github.com/jackc/pgx/v5"
 	"github.com/pashagolub/pgxmock/v4"
+
+	"github.com/sendrec/sendrec/internal/validate"
 )
 
 func newTestHandler(t *testing.T) (*Handler, pgxmock.PgxPoolIface) {
@@ -146,6 +148,49 @@ func TestCreateUser_NewUser(t *testing.T) {
 	}
 	if user.UserName != "jane@example.com" {
 		t.Errorf("UserName = %q, want jane@example.com", user.UserName)
+	}
+}
+
+// SR-10 (SCIM create path): a provisioning client must not be able to store an
+// unbounded display name. Rejected at the trust boundary, before any DB write.
+func TestCreateUser_RejectsOverlongName(t *testing.T) {
+	handler, mock := newTestHandler(t)
+	defer mock.Close()
+
+	longName := strings.Repeat("a", validate.MaxNameLength+1)
+	body := `{"userName":"jane@example.com","name":{"formatted":"` + longName + `"}}`
+	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(body))
+	req = withOrgID(req, "org-1")
+	rec := httptest.NewRecorder()
+
+	handler.CreateUser(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("got status %d, want 400; body: %s", rec.Code, rec.Body.String())
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("overlong name must be rejected before any DB call: %v", err)
+	}
+}
+
+// SR-10 (SCIM update path): the same cap applies to Replace/PATCH updates.
+func TestReplaceUser_RejectsOverlongName(t *testing.T) {
+	handler, mock := newTestHandler(t)
+	defer mock.Close()
+
+	longName := strings.Repeat("a", validate.MaxNameLength+1)
+	body := `{"userName":"jane@example.com","name":{"formatted":"` + longName + `"},"active":true}`
+	req := httptest.NewRequest(http.MethodPut, "/", strings.NewReader(body))
+	req = withOrgID(req, "org-1")
+	rec := httptest.NewRecorder()
+
+	handler.ReplaceUser(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("got status %d, want 400; body: %s", rec.Code, rec.Body.String())
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("overlong name must be rejected before any DB call: %v", err)
 	}
 }
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -29,7 +29,6 @@ type Pinger interface {
 }
 
 type Config struct {
-	Version                 string
 	DB                      database.DBTX
 	Pinger                  Pinger
 	Storage                 video.ObjectStorage
@@ -73,7 +72,6 @@ type Config struct {
 
 type Server struct {
 	router              chi.Router
-	version             string
 	pinger              Pinger
 	authHandler         *auth.Handler
 	videoHandler        *video.Handler
@@ -100,7 +98,7 @@ func New(cfg Config) *Server {
 		AllowedFrameAncestors: cfg.AllowedFrameAncestors,
 	}))
 
-	s := &Server{router: r, version: cfg.Version, pinger: cfg.Pinger, db: cfg.DB, webFS: cfg.WebFS, enableDocs: cfg.EnableDocs, registrationEnabled: cfg.RegistrationEnabled, planBadgeEnabled: cfg.PlanBadgeEnabled, analyticsScript: cfg.AnalyticsScript}
+	s := &Server{router: r, pinger: cfg.Pinger, db: cfg.DB, webFS: cfg.WebFS, enableDocs: cfg.EnableDocs, registrationEnabled: cfg.RegistrationEnabled, planBadgeEnabled: cfg.PlanBadgeEnabled, analyticsScript: cfg.AnalyticsScript}
 
 	if cfg.DB != nil {
 		jwtSecret := cfg.JWTSecret

--- a/internal/sso/handler.go
+++ b/internal/sso/handler.go
@@ -12,12 +12,14 @@ import (
 	"net/url"
 	"sort"
 	"time"
+	"unicode/utf8"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/jackc/pgx/v5"
 	"github.com/sendrec/sendrec/internal/auth"
 	"github.com/sendrec/sendrec/internal/database"
 	"github.com/sendrec/sendrec/internal/httputil"
+	"github.com/sendrec/sendrec/internal/validate"
 )
 
 // Handler implements the HTTP endpoints for social login and SSO callbacks.
@@ -61,6 +63,20 @@ func (h *Handler) Providers(w http.ResponseWriter, r *http.Request) {
 	httputil.WriteJSON(w, http.StatusOK, providersResponse{Providers: names})
 }
 
+// clampName bounds an IdP-supplied display name to the app-wide name limit
+// (SR-10). SSO must not *reject* on it — that would block login over a
+// cosmetic field — so it truncates on a UTF-8 boundary instead.
+func clampName(name string) string {
+	if len(name) <= validate.MaxNameLength {
+		return name
+	}
+	b := name[:validate.MaxNameLength]
+	for len(b) > 0 && !utf8.ValidString(b) {
+		b = b[:len(b)-1]
+	}
+	return b
+}
+
 // resolveUser maps an external identity to a local user account, creating
 // new users and identity links as needed.
 func (h *Handler) resolveUser(ctx context.Context, providerName string, info *UserInfo) (string, error) {
@@ -99,7 +115,7 @@ func (h *Handler) resolveUser(ctx context.Context, providerName string, info *Us
 	// 3. No existing user -- create one.
 	err = h.db.QueryRow(ctx,
 		"INSERT INTO users (email, password, name, email_verified) VALUES ($1, $2, $3, true) ON CONFLICT (email) DO UPDATE SET email = EXCLUDED.email RETURNING id",
-		info.Email, "", info.Name,
+		info.Email, "", clampName(info.Name),
 	).Scan(&userID)
 	if err != nil {
 		return "", fmt.Errorf("create user: %w", err)

--- a/internal/sso/handler_test.go
+++ b/internal/sso/handler_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/pashagolub/pgxmock/v4"
 	"github.com/sendrec/sendrec/internal/auth"
 	"github.com/sendrec/sendrec/internal/integration"
+	"github.com/sendrec/sendrec/internal/validate"
 )
 
 const testJWTSecret = "test-sso-jwt-secret"
@@ -240,6 +241,53 @@ func TestCallback_NewUser_CreatesAccount(t *testing.T) {
 
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
+// maxLenArg matches any string whose byte length is at most n.
+type maxLenArg int
+
+func (m maxLenArg) Match(v interface{}) bool {
+	s, ok := v.(string)
+	return ok && len(s) <= int(m)
+}
+
+// SR-10 (SSO path): a hostile or misconfigured IdP returning a giant display
+// name must not land unbounded in the DB. SSO clamps rather than rejects (a
+// reject would block login over a cosmetic field), so the stored name stays
+// within the app-wide cap.
+func TestResolveUser_ClampsOverlongName(t *testing.T) {
+	handler, mock := newTestHandler(t)
+	defer mock.Close()
+
+	longName := strings.Repeat("x", 60000)
+
+	mock.ExpectQuery(`SELECT user_id FROM external_identities WHERE provider = \$1 AND external_id = \$2`).
+		WithArgs("github", "gh-1").
+		WillReturnError(pgx.ErrNoRows)
+	mock.ExpectQuery(`SELECT id, email_verified FROM users WHERE email = \$1`).
+		WithArgs("big@example.com").
+		WillReturnError(pgx.ErrNoRows)
+	mock.ExpectQuery(`INSERT INTO users`).
+		WithArgs("big@example.com", "", maxLenArg(validate.MaxNameLength)).
+		WillReturnRows(pgxmock.NewRows([]string{"id"}).AddRow("user-uuid-1"))
+	mock.ExpectExec(`INSERT INTO external_identities`).
+		WithArgs("user-uuid-1", "github", "gh-1", "big@example.com").
+		WillReturnResult(pgxmock.NewResult("INSERT", 1))
+
+	userID, err := handler.resolveUser(context.Background(), "github", &UserInfo{
+		ExternalID: "gh-1",
+		Email:      "big@example.com",
+		Name:       longName,
+	})
+	if err != nil {
+		t.Fatalf("resolveUser: %v", err)
+	}
+	if userID != "user-uuid-1" {
+		t.Errorf("userID = %q, want user-uuid-1", userID)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("name was not clamped to the app-wide cap: %v", err)
 	}
 }
 

--- a/internal/video/video_analytics.go
+++ b/internal/video/video_analytics.go
@@ -114,7 +114,7 @@ func (h *Handler) RecordCTAClick(w http.ResponseWriter, r *http.Request) {
 	go func() {
 		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 		defer cancel()
-		ip := clientIP(r)
+		ip := httputil.ClientIP(r)
 		hash := viewerHash(ip, r.UserAgent())
 		if _, err := h.db.Exec(ctx,
 			`INSERT INTO cta_clicks (video_id, viewer_hash) VALUES ($1, $2)`,
@@ -171,7 +171,7 @@ func (h *Handler) RecordMilestone(w http.ResponseWriter, r *http.Request) {
 	go func() {
 		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 		defer cancel()
-		ip := clientIP(r)
+		ip := httputil.ClientIP(r)
 		hash := viewerHash(ip, r.UserAgent())
 		if _, err := h.db.Exec(ctx,
 			`INSERT INTO view_milestones (video_id, viewer_hash, milestone) VALUES ($1, $2, $3) ON CONFLICT DO NOTHING`,

--- a/internal/video/video_helpers.go
+++ b/internal/video/video_helpers.go
@@ -5,12 +5,10 @@ import (
 	"crypto/sha256"
 	"fmt"
 	"log/slog"
-	"net/http"
 	"strings"
 	"time"
 
 	"github.com/mssola/useragent"
-	"github.com/sendrec/sendrec/internal/httputil"
 	"github.com/sendrec/sendrec/internal/webhook"
 )
 
@@ -54,12 +52,6 @@ func deleteWithRetry(ctx context.Context, storage ObjectStorage, key string, max
 func viewerHash(ip, userAgent string) string {
 	h := sha256.Sum256([]byte(ip + "|" + userAgent))
 	return fmt.Sprintf("%x", h[:8])
-}
-
-// clientIP feeds viewerHash, so trusting a client-supplied X-Forwarded-For here
-// let anyone forge unlimited distinct "unique viewers" (SR-01/SR-03).
-func clientIP(r *http.Request) string {
-	return httputil.ClientIP(r)
 }
 
 func categorizeReferrer(referer string) string {

--- a/internal/video/video_test.go
+++ b/internal/video/video_test.go
@@ -3394,42 +3394,6 @@ func TestViewerHash_Returns16Characters(t *testing.T) {
 
 // --- clientIP Tests ---
 
-// SR-01: clientIP feeds viewerHash. Honoring a client-supplied X-Forwarded-For
-// let anyone mint unlimited distinct "unique viewers", so the header counts only
-// when a trusted proxy is configured — and then only its own last entry.
-func TestClientIP_UsesLastForwardedEntryBehindTrustedProxy(t *testing.T) {
-	previous := httputil.TrustProxyHeaders
-	httputil.TrustProxyHeaders = true
-	t.Cleanup(func() { httputil.TrustProxyHeaders = previous })
-
-	req := httptest.NewRequest(http.MethodGet, "/", nil)
-	req.Header.Set("X-Forwarded-For", "203.0.113.50, 70.41.3.18")
-	if ip := clientIP(req); ip != "70.41.3.18" {
-		t.Errorf("expected %q, got %q", "70.41.3.18", ip)
-	}
-}
-
-func TestClientIP_IgnoresForwardedForWithoutTrustedProxy(t *testing.T) {
-	previous := httputil.TrustProxyHeaders
-	httputil.TrustProxyHeaders = false
-	t.Cleanup(func() { httputil.TrustProxyHeaders = previous })
-
-	req := httptest.NewRequest(http.MethodGet, "/", nil)
-	req.RemoteAddr = "192.168.1.100:54321"
-	req.Header.Set("X-Forwarded-For", "203.0.113.50")
-	if ip := clientIP(req); ip != "192.168.1.100" {
-		t.Errorf("spoofed header must be ignored, expected %q, got %q", "192.168.1.100", ip)
-	}
-}
-
-func TestClientIP_StripsPortFromRemoteAddr(t *testing.T) {
-	req := httptest.NewRequest(http.MethodGet, "/", nil)
-	req.RemoteAddr = "192.168.1.100:54321"
-	if ip := clientIP(req); ip != "192.168.1.100" {
-		t.Errorf("expected %q, got %q", "192.168.1.100", ip)
-	}
-}
-
 // --- deleteWithRetry Tests ---
 
 func TestDeleteWithRetry_SucceedsFirstAttempt(t *testing.T) {

--- a/internal/video/video_test.go
+++ b/internal/video/video_test.go
@@ -3392,8 +3392,6 @@ func TestViewerHash_Returns16Characters(t *testing.T) {
 	}
 }
 
-// --- clientIP Tests ---
-
 // --- deleteWithRetry Tests ---
 
 func TestDeleteWithRetry_SucceedsFirstAttempt(t *testing.T) {

--- a/internal/video/view.go
+++ b/internal/video/view.go
@@ -5,6 +5,8 @@ import (
 	"log/slog"
 	"net/http"
 	"time"
+
+	"github.com/sendrec/sendrec/internal/httputil"
 )
 
 type viewParams struct {
@@ -22,7 +24,7 @@ func (h *Handler) recordViewAsync(r *http.Request, p viewParams) {
 	go func() {
 		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 		defer cancel()
-		ip := clientIP(r)
+		ip := httputil.ClientIP(r)
 		hash := viewerHash(ip, r.UserAgent())
 		ref := categorizeReferrer(r.Header.Get("Referer"))
 		browser := parseBrowser(r.UserAgent())

--- a/internal/video/watch_auth.go
+++ b/internal/video/watch_auth.go
@@ -223,7 +223,7 @@ func (h *Handler) IdentifyViewer(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	ip := clientIP(r)
+	ip := httputil.ClientIP(r)
 	hash := viewerHash(ip, r.UserAgent())
 
 	go func() {

--- a/internal/webhook/ssrf.go
+++ b/internal/webhook/ssrf.go
@@ -1,7 +1,6 @@
 package webhook
 
 import (
-	"context"
 	"fmt"
 	"net"
 	"syscall"
@@ -28,13 +27,14 @@ func IsBlockedIP(ip net.IP) bool {
 		ip.IsUnspecified()
 }
 
-// blockInternalTargets rejects connections to internal addresses at dial time.
+// safeDialControl is the net.Dialer Control hook wired into the webhook client;
+// it rejects connections to internal addresses at dial time.
 //
 // Validating the configured URL is not enough: the hostname may resolve to an
 // internal address, may resolve differently on the second lookup, or the target
 // may redirect. The dialer sees the address actually being connected to on every
 // hop, so this is the one place the check cannot be routed around.
-func blockInternalTargets(_ context.Context, _, address string) error {
+func safeDialControl(_, address string, _ syscall.RawConn) error {
 	host, _, err := net.SplitHostPort(address)
 	if err != nil {
 		return fmt.Errorf("webhook: cannot parse dial address %q: %w", address, err)
@@ -50,9 +50,4 @@ func blockInternalTargets(_ context.Context, _, address string) error {
 	}
 
 	return nil
-}
-
-// safeDialControl is the net.Dialer Control hook wired into the webhook client.
-func safeDialControl(network, address string, _ syscall.RawConn) error {
-	return blockInternalTargets(context.Background(), network, address)
 }


### PR DESCRIPTION
Follow-up to `1c97dab` (`fix(security): remediate audit findings SR-01 through SR-15`): closes four correctness gaps the remediation missed, three cleanups it left behind, and one doc note.

### Correctness
- **F-1 (SR-05)** — `UpdateUser` now revokes API keys on a settings password change (was refresh-tokens-only, the exact path the validator demonstrated).
- **F-2 (SR-10)** — name-length cap at the IdP write paths: SCIM `CreateUser`/`PatchUser`/`ReplaceUser` reject over-long names (400); SSO clamps (rejecting would block login over a cosmetic field).
- **F-3** — `postgres:18-alpine` refuses a data volume at the legacy path root (reproduced); fixed with a `PGDATA` subdirectory. `e2e` unaffected (no data volume).
- **F-4** — dev compose now sets `S3_PUBLIC_ENDPOINT`, so presigned URLs resolve to a host-reachable endpoint.

### Cleanup (net deletion)
- **C-1** — dropped the `clientIP` wrapper for `httputil.ClientIP` (+ 3 duplicate tests).
- **C-2** — inlined `blockInternalTargets` into `safeDialControl`.
- **C-3** — removed dead `version` plumbing (kept the startup-log reader).

### Docs
- **D-1** — documented the `TRUSTED_PROXY` rate-limit trade-off in `SELF-HOSTING.md`.

### Verification
gofmt / `go build ./...` / `go vet ./...` clean · `go test ./...` 22 pkgs ok, 0 fail · golangci-lint 0 issues.

New tests: `TestUpdateUser_ChangePasswordRevokesAPIKeys`, `TestCreateUser_RejectsOverlongName`, `TestReplaceUser_RejectsOverlongName`, `TestResolveUser_ClampsOverlongName`.

Detail and two "left alone" notes (DB-level name CHECK; SR-11 `admin_token` still shipping) in `.ai/security-followup-report.md`.
