### PR TITLE
chore: format with gofmt 1.26

### DIFF
--- a/internal/ratelimit/ratelimit.go
+++ b/internal/ratelimit/ratelimit.go
@@ -9,8 +9,8 @@ import (
 )
 
 type visitor struct {
-	tokens    float64
-	lastSeen  time.Time
+	tokens   float64
+	lastSeen time.Time
 }
 
 type Limiter struct {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -29,45 +29,45 @@ type Pinger interface {
 }
 
 type Config struct {
-	DB                      database.DBTX
-	Pinger                  Pinger
-	Storage                 video.ObjectStorage
-	WebFS                   fs.FS
-	JWTSecret               string
-	BaseURL                 string
-	MaxUploadBytes          int64
-	MaxVideosPerMonth       int
-	MaxVideoDurationSeconds int
-	MaxPlaylists            int
-	S3PublicEndpoint        string
-	EnableDocs              bool
-	BrandingEnabled         bool
-	AiEnabled               bool
-	TranscriptionEnabled    bool
-	NoiseReductionFilter    string
-	AllowedFrameAncestors   string
-	AnalyticsScript         string
-	EmailSender             auth.EmailSender
-	CommentNotifier         video.CommentNotifier
-	ViewNotifier            video.ViewNotifier
-	SlackNotifier           video.SlackNotifier
-	WebhookClient           *webhook.Client
-	CreemAPIKey              string
-	CreemWebhookSecret       string
-	CreemProProductID        string
-	CreemOrgProProductID     string
-	CreemBusinessProductID   string
+	DB                        database.DBTX
+	Pinger                    Pinger
+	Storage                   video.ObjectStorage
+	WebFS                     fs.FS
+	JWTSecret                 string
+	BaseURL                   string
+	MaxUploadBytes            int64
+	MaxVideosPerMonth         int
+	MaxVideoDurationSeconds   int
+	MaxPlaylists              int
+	S3PublicEndpoint          string
+	EnableDocs                bool
+	BrandingEnabled           bool
+	AiEnabled                 bool
+	TranscriptionEnabled      bool
+	NoiseReductionFilter      string
+	AllowedFrameAncestors     string
+	AnalyticsScript           string
+	EmailSender               auth.EmailSender
+	CommentNotifier           video.CommentNotifier
+	ViewNotifier              video.ViewNotifier
+	SlackNotifier             video.SlackNotifier
+	WebhookClient             *webhook.Client
+	CreemAPIKey               string
+	CreemWebhookSecret        string
+	CreemProProductID         string
+	CreemOrgProProductID      string
+	CreemBusinessProductID    string
 	CreemOrgBusinessProductID string
-	RegistrationEnabled     bool
-	PlanBadgeEnabled        bool
-	GeoIPDBPath             string
-	GoogleClientID          string
-	GoogleClientSecret      string
-	GoogleAllowedDomains    []string
-	MicrosoftClientID       string
-	MicrosoftClientSecret   string
-	GitHubSSOClientID       string
-	GitHubSSOClientSecret   string
+	RegistrationEnabled       bool
+	PlanBadgeEnabled          bool
+	GeoIPDBPath               string
+	GoogleClientID            string
+	GoogleClientSecret        string
+	GoogleAllowedDomains      []string
+	MicrosoftClientID         string
+	MicrosoftClientSecret     string
+	GitHubSSOClientID         string
+	GitHubSSOClientSecret     string
 }
 
 type Server struct {

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -88,8 +88,8 @@ func newServerWithDB(t *testing.T) (*server.Server, pgxmock.PgxPoolIface) {
 
 func testWebFS() fstest.MapFS {
 	return fstest.MapFS{
-		"index.html":    {Data: []byte("<html>app</html>")},
-		"assets/app.js": {Data: []byte("console.log('app')")},
+		"index.html":     {Data: []byte("<html>app</html>")},
+		"assets/app.js":  {Data: []byte("console.log('app')")},
 		"assets/app.css": {Data: []byte("body{}")},
 	}
 }

--- a/internal/slack/slack.go
+++ b/internal/slack/slack.go
@@ -29,9 +29,9 @@ func New(db database.DBTX) *Client {
 }
 
 type block struct {
-	Type     string  `json:"type"`
-	Text     *text   `json:"text,omitempty"`
-	Elements []text  `json:"elements,omitempty"`
+	Type     string `json:"type"`
+	Text     *text  `json:"text,omitempty"`
+	Elements []text `json:"elements,omitempty"`
 }
 
 type text struct {

--- a/internal/sso/oidc_test.go
+++ b/internal/sso/oidc_test.go
@@ -31,11 +31,11 @@ func newOIDCTestServer(t *testing.T) (*httptest.Server, *rsa.PrivateKey) {
 
 	mux.HandleFunc("GET /.well-known/openid-configuration", func(w http.ResponseWriter, r *http.Request) {
 		discovery := map[string]any{
-			"issuer":                 serverURL,
-			"authorization_endpoint": serverURL + "/authorize",
-			"token_endpoint":         serverURL + "/token",
-			"userinfo_endpoint":      serverURL + "/userinfo",
-			"jwks_uri":               serverURL + "/jwks",
+			"issuer":                                serverURL,
+			"authorization_endpoint":                serverURL + "/authorize",
+			"token_endpoint":                        serverURL + "/token",
+			"userinfo_endpoint":                     serverURL + "/userinfo",
+			"jwks_uri":                              serverURL + "/jwks",
 			"id_token_signing_alg_values_supported": []string{"RS256"},
 		}
 		w.Header().Set("Content-Type", "application/json")
@@ -201,11 +201,11 @@ func newOIDCTestServerTrailingSlash(t *testing.T) *httptest.Server {
 	mux.HandleFunc("GET /.well-known/openid-configuration", func(w http.ResponseWriter, r *http.Request) {
 		// Return issuer WITH trailing slash (Auth0 behavior)
 		discovery := map[string]any{
-			"issuer":                 serverURL + "/",
-			"authorization_endpoint": serverURL + "/authorize",
-			"token_endpoint":         serverURL + "/token",
-			"userinfo_endpoint":      serverURL + "/userinfo",
-			"jwks_uri":               serverURL + "/jwks",
+			"issuer":                                serverURL + "/",
+			"authorization_endpoint":                serverURL + "/authorize",
+			"token_endpoint":                        serverURL + "/token",
+			"userinfo_endpoint":                     serverURL + "/userinfo",
+			"jwks_uri":                              serverURL + "/jwks",
 			"id_token_signing_alg_values_supported": []string{"RS256"},
 		}
 		w.Header().Set("Content-Type", "application/json")
@@ -281,11 +281,11 @@ func newOIDCTestServerWithEmail(t *testing.T, opts oidcTestOpts) *httptest.Serve
 	mux.HandleFunc("GET /.well-known/openid-configuration", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(map[string]any{
-			"issuer":                 serverURL,
-			"authorization_endpoint": serverURL + "/authorize",
-			"token_endpoint":         serverURL + "/token",
-			"userinfo_endpoint":      serverURL + "/userinfo",
-			"jwks_uri":               serverURL + "/jwks",
+			"issuer":                                serverURL,
+			"authorization_endpoint":                serverURL + "/authorize",
+			"token_endpoint":                        serverURL + "/token",
+			"userinfo_endpoint":                     serverURL + "/userinfo",
+			"jwks_uri":                              serverURL + "/jwks",
 			"id_token_signing_alg_values_supported": []string{"RS256"},
 		})
 	})

--- a/internal/validate/validate.go
+++ b/internal/validate/validate.go
@@ -28,25 +28,25 @@ func checkLen(value string, max int, field string) string {
 	return ""
 }
 
-func Name(s string) string               { return checkLen(s, MaxNameLength, "name") }
-func Title(s string) string              { return checkLen(s, MaxTitleLength, "title") }
-func PlaylistTitle(s string) string      { return checkLen(s, MaxPlaylistTitleLength, "playlist title") }
+func Name(s string) string          { return checkLen(s, MaxNameLength, "name") }
+func Title(s string) string         { return checkLen(s, MaxTitleLength, "title") }
+func PlaylistTitle(s string) string { return checkLen(s, MaxPlaylistTitleLength, "playlist title") }
 func PlaylistDescription(s string) string {
 	return checkLen(s, MaxPlaylistDescriptionLength, "playlist description")
 }
-func FolderName(s string) string    { return checkLen(s, MaxFolderNameLength, "folder name") }
-func TagName(s string) string       { return checkLen(s, MaxTagNameLength, "tag name") }
-func CommentBody(s string) string   { return checkLen(s, MaxCommentBodyLength, "comment") }
-func CompanyName(s string) string   { return checkLen(s, MaxCompanyNameLength, "company name") }
-func FooterText(s string) string    { return checkLen(s, MaxFooterTextLength, "footer text") }
-func CustomCSS(s string) string     { return checkLen(s, MaxCustomCSSLength, "custom CSS") }
+func FolderName(s string) string  { return checkLen(s, MaxFolderNameLength, "folder name") }
+func TagName(s string) string     { return checkLen(s, MaxTagNameLength, "tag name") }
+func CommentBody(s string) string { return checkLen(s, MaxCommentBodyLength, "comment") }
+func CompanyName(s string) string { return checkLen(s, MaxCompanyNameLength, "company name") }
+func FooterText(s string) string  { return checkLen(s, MaxFooterTextLength, "footer text") }
+func CustomCSS(s string) string   { return checkLen(s, MaxCustomCSSLength, "custom CSS") }
 func SlackWebhookURL(s string) string {
 	return checkLen(s, MaxSlackWebhookURLLength, "Slack webhook URL")
 }
-func WebhookURL(s string) string  { return checkLen(s, MaxWebhookURLLength, "webhook URL") }
-func APIKeyName(s string) string  { return checkLen(s, MaxAPIKeyNameLength, "API key name") }
-func OrgName(s string) string     { return checkLen(s, MaxOrgNameLength, "organization name") }
-func OrgSlug(s string) string     { return checkLen(s, MaxOrgSlugLength, "organization slug") }
+func WebhookURL(s string) string { return checkLen(s, MaxWebhookURLLength, "webhook URL") }
+func APIKeyName(s string) string { return checkLen(s, MaxAPIKeyNameLength, "API key name") }
+func OrgName(s string) string    { return checkLen(s, MaxOrgNameLength, "organization name") }
+func OrgSlug(s string) string    { return checkLen(s, MaxOrgSlugLength, "organization slug") }
 
 var validRetentionDays = map[int]bool{0: true, 30: true, 60: true, 90: true, 180: true, 365: true}
 

--- a/internal/video/embed_page_test.go
+++ b/internal/video/embed_page_test.go
@@ -137,15 +137,15 @@ func TestEmbedPage_Success_RendersVideoPlayer(t *testing.T) {
 	body := rec.Body.String()
 
 	checks := map[string]string{
-		"video element": "<video",
-		"controls":      "player-controls",
-		"spinner":       "player-spinner",
-		"error overlay": "player-error",
-		"seek tooltip":  "seek-time-tooltip",
-		"playsinline":   "playsinline",
-		"video source":  `src="https://s3.example.com/video.webm"`,
-		"watch link":    `/watch/` + shareToken,
-		"watch on text": "Watch on",
+		"video element":   "<video",
+		"controls":        "player-controls",
+		"spinner":         "player-spinner",
+		"error overlay":   "player-error",
+		"seek tooltip":    "seek-time-tooltip",
+		"playsinline":     "playsinline",
+		"video source":    `src="https://s3.example.com/video.webm"`,
+		"watch link":      `/watch/` + shareToken,
+		"watch on text":   "Watch on",
 		"caption overlay": `id="caption-overlay"`,
 		"caption render":  "function bindCaptions()",
 	}

--- a/internal/video/folder.go
+++ b/internal/video/folder.go
@@ -321,4 +321,3 @@ func (h *Handler) SetVideoFolder(w http.ResponseWriter, r *http.Request) {
 
 	w.WriteHeader(http.StatusNoContent)
 }
-

--- a/internal/video/player_shared.go
+++ b/internal/video/player_shared.go
@@ -825,17 +825,19 @@ const safariWarningHTML = `
 
 // playlistJS contains the shared JavaScript for both the playlist watch and embed pages.
 // It expects the following variables to be declared before this code runs:
-//   videos, currentIndex, player, container, listItems, countdownTimer, autoAdvance,
-//   storageKey, aaToggle, aaTrack, nextOverlay, nextTitleEl, progressEl, nextCountdownEl,
-//   controls, overlay, playBtn, overlayBtn, seekBar, seekProgress, seekBuffered, seekThumb,
-//   timeCurrent, timeDuration, muteBtn, volumeSlider, speedBtn, speedMenu, pipBtn,
-//   fullscreenBtn, spinner, errorOverlay, seekTooltip, shortcutsBtn, shortcutsPanel, hideTimer.
+//
+//	videos, currentIndex, player, container, listItems, countdownTimer, autoAdvance,
+//	storageKey, aaToggle, aaTrack, nextOverlay, nextTitleEl, progressEl, nextCountdownEl,
+//	controls, overlay, playBtn, overlayBtn, seekBar, seekProgress, seekBuffered, seekThumb,
+//	timeCurrent, timeDuration, muteBtn, volumeSlider, speedBtn, speedMenu, pipBtn,
+//	fullscreenBtn, spinner, errorOverlay, seekTooltip, shortcutsBtn, shortcutsPanel, hideTimer.
 //
 // Each page may define hook functions before this code runs:
-//   onPlaylistVideoSwitch(index, item) — called after every video switch; use for page-specific
-//     UI updates (e.g. updating title/counter elements, loading comments).
-//   onPlaylistInit() — called once during setup; use for page-specific initialisation
-//     (e.g. sidebar collapse button wiring, loading comments for the first video).
+//
+//	onPlaylistVideoSwitch(index, item) — called after every video switch; use for page-specific
+//	  UI updates (e.g. updating title/counter elements, loading comments).
+//	onPlaylistInit() — called once during setup; use for page-specific initialisation
+//	  (e.g. sidebar collapse button wiring, loading comments for the first video).
 const playlistJS = `
         if (aaToggle) {
             aaToggle.addEventListener('click', function() {

--- a/internal/video/playlist_watch.go
+++ b/internal/video/playlist_watch.go
@@ -761,7 +761,6 @@ var playlistWatchTemplate = template.Must(template.New("playlist-watch").Funcs(t
 </body>
 </html>`))
 
-
 func (h *Handler) PlaylistWatchPage(w http.ResponseWriter, r *http.Request) {
 	shareToken := chi.URLParam(r, "shareToken")
 	nonce := httputil.NonceFromContext(r.Context())

--- a/internal/video/playlist_watch_test.go
+++ b/internal/video/playlist_watch_test.go
@@ -69,16 +69,16 @@ func TestPlaylistWatchPage_Success(t *testing.T) {
 
 	body := rec.Body.String()
 	checks := map[string]string{
-		"playlist title":   "My Playlist",
-		"first video":      "First Video",
-		"second video":     "Second Video",
-		"video element":    "<video",
-		"video source":     `src="https://storage.example.com/test-url"`,
-		"video list":       `class="video-list"`,
-		"player counter":   "1 of 2",
-		"nonce in style":   `nonce="test-nonce"`,
-		"nonce in script":  `<script nonce="test-nonce">`,
-		"branding":         "SendRec",
+		"playlist title":  "My Playlist",
+		"first video":     "First Video",
+		"second video":    "Second Video",
+		"video element":   "<video",
+		"video source":    `src="https://storage.example.com/test-url"`,
+		"video list":      `class="video-list"`,
+		"player counter":  "1 of 2",
+		"nonce in style":  `nonce="test-nonce"`,
+		"nonce in script": `<script nonce="test-nonce">`,
+		"branding":        "SendRec",
 	}
 	for name, want := range checks {
 		if !strings.Contains(body, want) {

--- a/internal/video/transcribe_worker_test.go
+++ b/internal/video/transcribe_worker_test.go
@@ -13,8 +13,8 @@ type stubTranscriber struct {
 	err       error
 }
 
-func (s stubTranscriber) Name() string      { return "stub" }
-func (s stubTranscriber) Available() bool   { return s.available }
+func (s stubTranscriber) Name() string    { return "stub" }
+func (s stubTranscriber) Available() bool { return s.available }
 func (s stubTranscriber) Transcribe(ctx context.Context, audioPath, language string) ([]TranscriptSegment, error) {
 	return s.segments, s.err
 }

--- a/internal/video/transcriber_factory.go
+++ b/internal/video/transcriber_factory.go
@@ -12,10 +12,10 @@ import (
 // environment variable. Supported providers:
 //   - "" or "local": runs whisper-cli locally (default).
 //   - "openai":      OpenAI-compatible /v1/audio/transcriptions endpoint.
-//                    Works with OpenAI, Groq, Scaleway, self-hosted Faster-Whisper, etc.
-//                    Reads TRANSCRIPTION_API_URL, TRANSCRIPTION_API_KEY, TRANSCRIPTION_MODEL.
+//     Works with OpenAI, Groq, Scaleway, self-hosted Faster-Whisper, etc.
+//     Reads TRANSCRIPTION_API_URL, TRANSCRIPTION_API_KEY, TRANSCRIPTION_MODEL.
 //   - "deepgram":    Deepgram /v1/listen.
-//                    Reads TRANSCRIPTION_API_KEY, TRANSCRIPTION_MODEL.
+//     Reads TRANSCRIPTION_API_KEY, TRANSCRIPTION_MODEL.
 func NewTranscriberFromEnv() (Transcriber, error) {
 	provider := strings.ToLower(strings.TrimSpace(os.Getenv("TRANSCRIPTION_PROVIDER")))
 	switch provider {

--- a/internal/video/video_analytics.go
+++ b/internal/video/video_analytics.go
@@ -64,7 +64,7 @@ type trendData struct {
 
 type referrerData struct {
 	Source     string  `json:"source"`
-	Count      int64  `json:"count"`
+	Count      int64   `json:"count"`
 	Percentage float64 `json:"percentage"`
 }
 

--- a/internal/video/vtt_parse_test.go
+++ b/internal/video/vtt_parse_test.go
@@ -15,7 +15,7 @@ func TestParseVTTTimestamp(t *testing.T) {
 		{"01:02:03.250", 3723.25, true},
 		{"02:03.100", 123.1, true}, // no hours
 		{"garbage", 0, false},
-		{"00:00:01", 0, false},   // missing millis
+		{"00:00:01", 0, false},       // missing millis
 		{"xx:30:45.250", 0, false},   // non-numeric hour must be rejected, not silently 0
 		{"00:3x:00.500", 0, false},   // non-numeric minute rejected
 		{"00:75:00.000", 4500, true}, // out-of-range but numeric: tolerated, not silently zeroed
@@ -225,9 +225,9 @@ func TestParseVTT_Errors(t *testing.T) {
 func TestMergeSegments(t *testing.T) {
 	in := []TranscriptSegment{
 		{Start: 0, End: 1, Text: "Um", Speaker: "A"},
-		{Start: 1.5, End: 2, Text: "yeah", Speaker: "A"},   // gap 0.5s, same speaker -> merge
-		{Start: 2, End: 3, Text: "ok", Speaker: "B"},       // diff speaker -> new
-		{Start: 10, End: 11, Text: "later", Speaker: "B"},  // gap 7s -> new
+		{Start: 1.5, End: 2, Text: "yeah", Speaker: "A"},  // gap 0.5s, same speaker -> merge
+		{Start: 2, End: 3, Text: "ok", Speaker: "B"},      // diff speaker -> new
+		{Start: 10, End: 11, Text: "later", Speaker: "B"}, // gap 7s -> new
 	}
 	got := mergeSegments(in)
 	if len(got) != 3 {


### PR DESCRIPTION
Mechanical `gofmt` (Go 1.26) sweep across the tree — the newer formatter re-aligns struct fields, struct tags, and one-line function columns in 15 base files. No semantic changes. Separated from the security stack so those diffs stayed reviewable.