### PR TITLE
fix(e2e): make rate limiting toggleable, disable in e2e stack

### DIFF
--- a/cmd/sendrec/main.go
+++ b/cmd/sendrec/main.go
@@ -19,6 +19,7 @@ import (
 	"github.com/sendrec/sendrec/internal/email"
 	"github.com/sendrec/sendrec/internal/httputil"
 	"github.com/sendrec/sendrec/internal/plans"
+	"github.com/sendrec/sendrec/internal/ratelimit"
 	"github.com/sendrec/sendrec/internal/server"
 	slackpkg "github.com/sendrec/sendrec/internal/slack"
 	"github.com/sendrec/sendrec/internal/storage"
@@ -48,6 +49,10 @@ func main() {
 	// otherwise any client can forge it and mint a fresh rate-limit bucket
 	// per request. Set TRUSTED_PROXY=true when running behind Caddy/Traefik.
 	httputil.TrustProxyHeaders = getEnv("TRUSTED_PROXY", "false") == "true"
+
+	// Rate limiting is on by default; disable only in test/e2e stacks, where the
+	// whole suite hits from one IP and would otherwise throttle itself.
+	ratelimit.Enabled = getEnv("RATE_LIMIT_ENABLED", "true") == "true"
 
 	// User-configured webhooks may not reach loopback or private ranges unless
 	// a developer explicitly opts in to point one at their own machine.

--- a/docker-compose.e2e.yml
+++ b/docker-compose.e2e.yml
@@ -14,6 +14,9 @@ services:
       - JWT_SECRET=e2e-test-secret
       - BASE_URL=http://localhost:8080
       - MAX_UPLOAD_BYTES=524288000
+      # The whole suite hits from one IP; the real limiter (SR-01) would throttle
+      # it. Off for tests only — production keeps the default (enabled).
+      - RATE_LIMIT_ENABLED=false
       - WEBHOOK_ALLOW_PRIVATE_TARGETS=${WEBHOOK_ALLOW_PRIVATE_TARGETS:-true}
       - AWS_REQUEST_CHECKSUM_CALCULATION=when_required
       - AWS_RESPONSE_CHECKSUM_VALIDATION=when_required

--- a/internal/ratelimit/ratelimit.go
+++ b/internal/ratelimit/ratelimit.go
@@ -8,6 +8,12 @@ import (
 	"github.com/sendrec/sendrec/internal/httputil"
 )
 
+// Enabled gates all rate limiting. It's a deployment-wide switch set once at
+// startup (from RATE_LIMIT_ENABLED) before any request is served. Default on;
+// turned off only in test/e2e stacks, where the whole suite shares one IP and
+// would otherwise throttle itself.
+var Enabled = true
+
 type visitor struct {
 	tokens   float64
 	lastSeen time.Time
@@ -70,6 +76,10 @@ func (l *Limiter) cleanup() {
 
 func (l *Limiter) Middleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !Enabled {
+			next.ServeHTTP(w, r)
+			return
+		}
 		if !l.allow(httputil.ClientIP(r)) {
 			w.Header().Set("Content-Type", "application/json")
 			w.Header().Set("Retry-After", "10")

--- a/internal/ratelimit/ratelimit_test.go
+++ b/internal/ratelimit/ratelimit_test.go
@@ -371,3 +371,25 @@ func TestMiddlewareDoesNotCallNextHandlerWhenRateLimited(t *testing.T) {
 		t.Errorf("expected next handler called 1 time, got %d", callCount)
 	}
 }
+
+// When rate limiting is disabled (e.g. in the e2e stack, where the whole suite
+// hits from one IP), the middleware must pass everything through — no 429s.
+func TestMiddlewarePassesEverythingWhenDisabled(t *testing.T) {
+	Enabled = false
+	t.Cleanup(func() { Enabled = true })
+
+	limiter := NewLimiter(1, 1) // burst 1: the 2nd request would normally 429
+	handler := limiter.Middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	for i := 0; i < 5; i++ {
+		request := httptest.NewRequest(http.MethodGet, "/", nil)
+		request.RemoteAddr = "192.168.1.1:1234"
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, request)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("request %d: expected 200 with limiter disabled, got %d", i+1, rec.Code)
+		}
+	}
+}


### PR DESCRIPTION
## Problem
SR-01 fixed the rate limiter to key on the real client IP (it previously keyed on `ip:port`, so every connection got a fresh bucket — effectively no limiting). The e2e suite hits from a **single IP**, so the now-working `authLimiter` (0.5 rps / burst 5) throttles the whole run — `loginViaUI` has no 429 retry and dies first, cascading into library/upload/logout. This is why every post-remediation `main` commit fails the `e2e` job (which only runs on push-to-main / workflow_dispatch, never on PRs — so it slipped through).

## Fix
Add a `RATE_LIMIT_ENABLED` switch (package-level `ratelimit.Enabled`, set once at startup from env, **default on** — mirrors the existing `TrustProxyHeaders` pattern). Production behavior is unchanged; `docker-compose.e2e.yml` sets it `false`.

## Verification
Triggered full CI (incl. e2e) on this branch via `workflow_dispatch`: **test + docker-build + e2e all green** (run 32073188305). New unit test `TestMiddlewarePassesEverythingWhenDisabled` covers the toggle.