### PR TITLE
ci: add release-to-current upgrade regression coverage

### DIFF
--- a/.github/workflows/upgrade.yml
+++ b/.github/workflows/upgrade.yml
@@ -1,0 +1,31 @@
+name: Upgrade from latest compatible release
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  upgrade:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build Garage initialization helper
+        run: docker build -f upgrade-tests/Dockerfile.garage-init -t sendrec-garage-init:upgradeproof upgrade-tests
+
+      - name: Test published release to current checkout
+        uses: Sam-Hui-dot/upgradeproof@7ec473b9f4643c17615555ce757bc040aad968f4 # v0.1.0
+        with:
+          config: upgradeproof.yml
+
+      - name: Upload UpgradeProof evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: upgradeproof-report
+          path: .upgradeproof/
+          include-hidden-files: true

--- a/.github/workflows/upgrade.yml
+++ b/.github/workflows/upgrade.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Build Garage initialization helper
         run: docker build -f upgrade-tests/Dockerfile.garage-init -t sendrec-garage-init:upgradeproof upgrade-tests
@@ -24,7 +24,7 @@ jobs:
 
       - name: Upload UpgradeProof evidence
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: upgradeproof-report
           path: .upgradeproof/

--- a/compose.upgrade.yaml
+++ b/compose.upgrade.yaml
@@ -1,0 +1,72 @@
+services:
+  sendrec:
+    image: ghcr.io/sendrec/sendrec:${SENDREC_TAG}
+    build:
+      context: .
+      dockerfile: Dockerfile
+      args:
+        VERSION: ${SENDREC_TAG}
+    ports:
+      - "127.0.0.1:18085:8080"
+    environment:
+      DATABASE_URL: postgres://sendrec:sendrec@postgres:5432/sendrec?sslmode=disable
+      JWT_SECRET: upgradeproof-sendrec-jwt-secret
+      BASE_URL: http://127.0.0.1:18085
+      REGISTRATION_ENABLED: "true"
+      RATE_LIMIT_ENABLED: "false"
+      API_DOCS_ENABLED: "false"
+      TRANSCRIPTION_ENABLED: "false"
+      AI_ENABLED: "false"
+      S3_ENDPOINT: http://garage:3900
+      S3_PUBLIC_ENDPOINT: http://127.0.0.1:13900
+      S3_BUCKET: recordings
+      S3_REGION: eu-central-1
+      AWS_REQUEST_CHECKSUM_CALCULATION: when_required
+      AWS_RESPONSE_CHECKSUM_VALIDATION: when_required
+    volumes:
+      - garage-keys:/run/garage-keys:ro
+    depends_on:
+      postgres:
+        condition: service_healthy
+      garage-init:
+        condition: service_completed_successfully
+
+  postgres:
+    image: postgres:18-alpine
+    environment:
+      POSTGRES_USER: sendrec
+      POSTGRES_PASSWORD: sendrec
+      POSTGRES_DB: sendrec
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U sendrec -d sendrec"]
+      interval: 2s
+      timeout: 3s
+      retries: 30
+    volumes:
+      - postgres-data:/var/lib/postgresql
+
+  garage:
+    image: dxflrs/garage:v2.2.0
+    ports:
+      - "127.0.0.1:13900:3900"
+    volumes:
+      - ./garage.toml:/etc/garage.toml:ro
+      - garage-meta:/var/lib/garage/meta
+      - garage-data:/var/lib/garage/data
+
+  garage-init:
+    image: sendrec-garage-init:upgradeproof
+    pull_policy: never
+    network_mode: service:garage
+    depends_on:
+      - garage
+    volumes:
+      - ./garage.toml:/etc/garage.toml:ro
+      - garage-meta:/var/lib/garage/meta:ro
+      - garage-keys:/run/garage-keys
+
+volumes:
+  postgres-data:
+  garage-meta:
+  garage-data:
+  garage-keys:

--- a/upgrade-tests/Dockerfile.garage-init
+++ b/upgrade-tests/Dockerfile.garage-init
@@ -1,0 +1,6 @@
+FROM dxflrs/garage:v2.2.0 AS garage
+
+FROM alpine:3.22
+COPY --from=garage /garage /usr/local/bin/garage
+COPY garage-init.sh /usr/local/bin/garage-init
+ENTRYPOINT ["/usr/local/bin/garage-init"]

--- a/upgrade-tests/Dockerfile.garage-init
+++ b/upgrade-tests/Dockerfile.garage-init
@@ -3,4 +3,5 @@ FROM dxflrs/garage:v2.2.0 AS garage
 FROM alpine:3.22
 COPY --from=garage /garage /usr/local/bin/garage
 COPY garage-init.sh /usr/local/bin/garage-init
+RUN chmod 0555 /usr/local/bin/garage-init
 ENTRYPOINT ["/usr/local/bin/garage-init"]

--- a/upgrade-tests/garage-init.sh
+++ b/upgrade-tests/garage-init.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+set -eu
+
+keys_file=/run/garage-keys/env
+
+until garage status >/dev/null 2>&1; do
+  sleep 1
+done
+
+node_id=$(garage status 2>/dev/null | grep -oE '[a-f0-9]{16}' | head -1)
+garage layout assign -z upgradeproof -c 1G "$node_id" >/dev/null 2>&1 || true
+garage layout apply --version 1 >/dev/null 2>&1 || true
+if [ -f "$keys_file" ]; then
+  . "$keys_file"
+else
+  key_info=$(garage key create upgradeproof)
+  S3_ACCESS_KEY=$(printf '%s\n' "$key_info" | grep -oE 'GK[a-f0-9]{24}' | head -1)
+  S3_SECRET_KEY=$(printf '%s\n' "$key_info" | grep 'Secret key' | sed 's/.*: *//')
+  test -n "$S3_ACCESS_KEY"
+  test -n "$S3_SECRET_KEY"
+  umask 077
+  printf 'S3_ACCESS_KEY=%s\nS3_SECRET_KEY=%s\n' "$S3_ACCESS_KEY" "$S3_SECRET_KEY" > "$keys_file"
+fi
+chmod 0444 "$keys_file"
+garage bucket create recordings >/dev/null 2>&1 || true
+garage bucket allow --read --write --owner recordings --key "$S3_ACCESS_KEY" >/dev/null
+
+echo "Garage upgrade-test bucket is ready."

--- a/upgrade-tests/scenario.py
+++ b/upgrade-tests/scenario.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+import hashlib
+import json
+import os
+import pathlib
+import subprocess
+import sys
+import urllib.request
+
+BASE_URL = "http://127.0.0.1:18085"
+EMAIL = "upgradeproof@example.invalid"
+PASSWORD = "UpgradeProof-Sentinel-2026!"
+NAME = "UpgradeProof Sentinel"
+FOLDER = "Upgrade Evidence"
+TAG = "Persistent"
+TAG_COLOR = "#2563eb"
+TITLE = "UpgradeProof retained recording"
+
+
+def request(path, method="GET", body=None, token=None):
+    data = None if body is None else json.dumps(body).encode()
+    headers = {"Content-Type": "application/json"}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    req = urllib.request.Request(BASE_URL + path, data=data, headers=headers, method=method)
+    with urllib.request.urlopen(req, timeout=30) as response:
+        raw = response.read()
+        return None if not raw else json.loads(raw)
+
+
+def compose(*args):
+    command = ["docker", "compose", "-f", os.environ["UPGRADEPROOF_COMPOSE_FILE"],
+               "-p", os.environ["UPGRADEPROOF_PROJECT"], *args]
+    return subprocess.check_output(command, text=True).strip()
+
+
+def container_evidence(service):
+    container_id = compose("ps", "-q", service)
+    if not container_id:
+        raise AssertionError(f"{service} container is missing")
+    inspected = json.loads(subprocess.check_output(["docker", "inspect", container_id], text=True))[0]
+    return {
+        "container_id": inspected["Id"],
+        "image_ref": inspected["Config"]["Image"],
+        "image_id": inspected["Image"],
+        "mounts": sorted(
+            ({"type": m["Type"], "name": m.get("Name"), "destination": m["Destination"]}
+             for m in inspected["Mounts"]),
+            key=lambda mount: mount["destination"],
+        ),
+    }
+
+
+def login():
+    return request("/api/auth/login", "POST", {"email": EMAIL, "password": PASSWORD})["accessToken"]
+
+
+def migration_state():
+    output = compose("exec", "-T", "postgres", "psql", "-U", "sendrec", "-d", "sendrec",
+                     "-Atc", "SELECT version || ':' || dirty FROM schema_migrations")
+    return output
+
+
+def garage_credentials():
+    raw = compose("exec", "-T", "sendrec", "cat", "/run/garage-keys/env")
+    values = dict(line.split("=", 1) for line in raw.splitlines())
+    return values["S3_ACCESS_KEY"], values["S3_SECRET_KEY"]
+
+
+def write_json(name, value):
+    report_dir = pathlib.Path(os.environ["UPGRADEPROOF_REPORT_DIR"])
+    report_dir.mkdir(parents=True, exist_ok=True)
+    (report_dir / name).write_text(json.dumps(value, indent=2) + "\n", encoding="utf-8")
+
+
+def seed():
+    request("/api/auth/register", "POST", {"email": EMAIL, "password": PASSWORD, "name": NAME})
+    token = login()
+    request("/api/user/", "PATCH", {"retentionDays": 90}, token)
+    folder = request("/api/folders/", "POST", {"name": FOLDER}, token)
+    tag = request("/api/tags/", "POST", {"name": TAG, "color": TAG_COLOR}, token)
+
+    fixture = pathlib.Path("web/e2e/fixtures/test-video.webm").read_bytes()
+    video = request("/api/videos/upload", "POST", {
+        "title": TITLE, "fileSize": len(fixture), "contentType": "video/webm"
+    }, token)
+    upload = urllib.request.Request(video["uploadUrl"], data=fixture,
+                                    headers={"Content-Type": "video/webm"}, method="PUT")
+    with urllib.request.urlopen(upload, timeout=30) as response:
+        if response.status not in (200, 201):
+            raise AssertionError(f"object upload returned {response.status}")
+
+    request(f"/api/videos/{video['id']}/folder", "PUT", {"folderId": folder["id"]}, token)
+    request(f"/api/videos/{video['id']}/tags", "PUT", {"tagIds": [tag["id"]]}, token)
+
+    sentinel = {
+        "user": {"email": EMAIL, "name": NAME, "retentionDays": 90},
+        "folder": {"id": folder["id"], "name": FOLDER},
+        "tag": {"id": tag["id"], "name": TAG, "color": TAG_COLOR},
+        "video": {"id": video["id"], "title": TITLE, "status": "uploading",
+                  "shareToken": video["shareToken"]},
+        "object": {"url": video["uploadUrl"].split("?", 1)[0], "size": len(fixture),
+                   "sha256": hashlib.sha256(fixture).hexdigest()},
+    }
+    write_json("sentinel.json", sentinel)
+    write_json("source-identities.json", {
+        "sendrec": container_evidence("sendrec"),
+        "postgres": container_evidence("postgres"),
+        "garage": container_evidence("garage"),
+        "migration": migration_state(),
+    })
+    print("Seeded a user, retained setting, folder, tag, video metadata, and 1,459-byte Garage object.")
+
+
+def verify():
+    report_dir = pathlib.Path(os.environ["UPGRADEPROOF_REPORT_DIR"])
+    sentinel = json.loads((report_dir / "sentinel.json").read_text(encoding="utf-8"))
+    source = json.loads((report_dir / "source-identities.json").read_text(encoding="utf-8"))
+    token = login()
+
+    user = request("/api/user/", token=token)
+    assert {key: user[key] for key in sentinel["user"]} == sentinel["user"]
+    folders = request("/api/folders/", token=token)
+    assert [(f["id"], f["name"], f["videoCount"]) for f in folders] == [
+        (sentinel["folder"]["id"], FOLDER, 1)]
+    tags = request("/api/tags/", token=token)
+    assert [(t["id"], t["name"], t["color"], t["videoCount"]) for t in tags] == [
+        (sentinel["tag"]["id"], TAG, TAG_COLOR, 1)]
+    videos = request("/api/videos/", token=token)
+    assert len(videos) == 1
+    video = videos[0]
+    for key, expected in sentinel["video"].items():
+        assert video[key] == expected, f"video {key}: expected {expected!r}, got {video[key]!r}"
+    assert video["folderId"] == sentinel["folder"]["id"]
+    assert video["tags"] == [{"id": sentinel["tag"]["id"], "name": TAG, "color": TAG_COLOR}]
+
+    access_key, secret_key = garage_credentials()
+    object_bytes = subprocess.check_output([
+        "curl", "--fail", "--silent", "--show-error", "--aws-sigv4",
+        "aws:amz:eu-central-1:s3", "--user", f"{access_key}:{secret_key}", sentinel["object"]["url"]
+    ])
+    assert len(object_bytes) == sentinel["object"]["size"]
+    assert hashlib.sha256(object_bytes).hexdigest() == sentinel["object"]["sha256"]
+
+    target = {
+        "sendrec": container_evidence("sendrec"),
+        "postgres": container_evidence("postgres"),
+        "garage": container_evidence("garage"),
+        "migration": migration_state(),
+    }
+    assert source["sendrec"]["container_id"] != target["sendrec"]["container_id"]
+    assert source["sendrec"]["image_id"] != target["sendrec"]["image_id"]
+    assert source["postgres"]["container_id"] == target["postgres"]["container_id"]
+    assert source["postgres"]["mounts"] == target["postgres"]["mounts"]
+    assert source["garage"]["container_id"] == target["garage"]["container_id"]
+    assert source["garage"]["mounts"] == target["garage"]["mounts"]
+    assert source["migration"] == "59:false"
+    assert target["migration"] == "59:false"
+    write_json("target-identities.json", target)
+    print("Exact SendRec domain state, PostgreSQL/Garage identity, object bytes, and migration ledger are preserved.")
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2 or sys.argv[1] not in ("seed", "verify"):
+        raise SystemExit("usage: scenario.py seed|verify")
+    globals()[sys.argv[1]]()

--- a/upgradeproof.yml
+++ b/upgradeproof.yml
@@ -1,0 +1,33 @@
+version: 2
+
+compose:
+  file: compose.upgrade.yaml
+
+paths:
+  - name: stable-to-current
+    from:
+      env:
+        SENDREC_TAG: v1.90.3@sha256:cf142fc2bb65df66fe2faf363846f7cf42107a92c0e88afc5469224368707b56
+    to:
+      env:
+        SENDREC_TAG: current
+      build:
+        services:
+          - sendrec
+        tag_env: SENDREC_TAG
+
+health:
+  type: http
+  url: http://127.0.0.1:18085/api/health
+  timeout: 120s
+  interval: 2s
+
+seed:
+  command: python3 upgrade-tests/scenario.py seed
+  timeout: 90s
+
+verify:
+  checks:
+    - name: sendrec-state-and-storage-preserved
+      command: python3 upgrade-tests/scenario.py verify
+      timeout: 90s


### PR DESCRIPTION
## Summary

Adds a focused CI check for upgrading from the published `v1.90.3` release to the current checkout while retaining SendRec's PostgreSQL and Garage state.

The candidate:

- starts the immutable `v1.90.3` SendRec image;
- creates a synthetic user plus persisted settings, folder, tag, video metadata, and a tiny WebM object through SendRec's public APIs;
- upgrades the same Compose project to a locally built current checkout;
- verifies exact application relationships, PostgreSQL/Garage storage identity, the uploaded object's bytes/SHA256, and the migration ledger;
- uploads UpgradeProof JSON/JUnit/log evidence on every run.

No application code or production Compose configuration is changed.

## Validation

GitHub-hosted validation run:
https://github.com/Sam-Hui-dot/sendrec/actions/runs/33381258943

The run completed successfully in about one minute. UpgradeProof is pinned to the immutable v0.1.0 commit `7ec473b9f4643c17615555ce757bc040aad968f4`.

I also negative-tested the semantic check by temporarily changing the expected video title; the upgrade check failed with exit code 1 as expected, and that change was reverted before the candidate commit.

## Scope / limitation

`v1.90.4` currently points at the same product commit as `main`, so this uses the previous published release, `v1.90.3`, as the source.

There is no migration delta on the selected path today; this therefore validates historical-release → current application/state compatibility and will exercise future migrations when they appear.

The video is intentionally kept in the `uploading` state so this remains an upgrade-regression check rather than an ffmpeg/transcription benchmark.

The target Docker build also inherits SendRec's existing mutable `alexneamtu/sendrec-base:latest` dependency.

## Files

- `.github/workflows/upgrade.yml`
- `compose.upgrade.yaml`
- `upgradeproof.yml`
- `upgrade-tests/*`