### PR TITLE
fix: reclaim videos stranded in status='processing' by a killed job

### DIFF
--- a/cmd/sendrec/main.go
+++ b/cmd/sendrec/main.go
@@ -226,6 +226,10 @@ func main() {
 	video.StartDocumentWorker(cleanupCtx, db.Pool, aiClient, 10*time.Second)
 	video.StartDigestWorker(cleanupCtx, db.Pool, emailClient, baseURL)
 	video.StartTranscodeWorker(cleanupCtx, db.Pool, store, 2*time.Minute)
+	// Reclaims videos whose editing job died with the process. Runs more often
+	// than the 15 minute staleness bound so a stranded row is picked up soon
+	// after it becomes eligible.
+	video.StartStuckProcessingWorker(cleanupCtx, db.Pool, 5*time.Minute)
 	video.StartOnboardingWorker(cleanupCtx, db.Pool, emailClient, baseURL)
 	video.StartRetentionWorker(cleanupCtx, db.Pool, emailClient, baseURL)
 

--- a/internal/video/composite.go
+++ b/internal/video/composite.go
@@ -92,7 +92,7 @@ func CompositeWithWebcam(ctx context.Context, db database.DBTX, storage ObjectSt
 
 	setReadyFallback := func() {
 		if _, err := db.Exec(ctx,
-			`UPDATE videos SET status = 'ready', webcam_key = NULL, updated_at = now() WHERE id = $1`,
+			`UPDATE videos SET status = 'ready', webcam_key = NULL, processing_started_at = NULL, updated_at = now() WHERE id = $1`,
 			videoID,
 		); err != nil {
 			slog.Error("composite: failed to set fallback ready status", "video_id", videoID, "error", err)
@@ -196,7 +196,7 @@ func CompositeWithWebcam(ctx context.Context, db database.DBTX, storage ObjectSt
 	}
 
 	if _, err := db.Exec(ctx,
-		`UPDATE videos SET status = 'ready', webcam_key = NULL, updated_at = now() WHERE id = $1`,
+		`UPDATE videos SET status = 'ready', webcam_key = NULL, processing_started_at = NULL, updated_at = now() WHERE id = $1`,
 		videoID,
 	); err != nil {
 		slog.Error("composite: failed to update status", "video_id", videoID, "error", err)

--- a/internal/video/composite_test.go
+++ b/internal/video/composite_test.go
@@ -34,7 +34,7 @@ func TestCompositeWithWebcam_ScreenDownloadError(t *testing.T) {
 	s := &mockStorage{downloadToFileErr: fmt.Errorf("s3 down")}
 
 	// On error, should still set status to "ready" (fallback to screen-only)
-	mock.ExpectExec(`UPDATE videos SET status = 'ready', webcam_key = NULL`).
+	mock.ExpectExec(`UPDATE videos SET status = 'ready', webcam_key = NULL, processing_started_at = NULL`).
 		WithArgs("video-123").
 		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
 
@@ -57,7 +57,7 @@ func TestCompositeWithWebcam_FFmpegFailsFallsBackToReady(t *testing.T) {
 	s := &mockStorage{}
 
 	// On error, should still set status to "ready"
-	mock.ExpectExec(`UPDATE videos SET status = 'ready', webcam_key = NULL`).
+	mock.ExpectExec(`UPDATE videos SET status = 'ready', webcam_key = NULL, processing_started_at = NULL`).
 		WithArgs("video-123").
 		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
 

--- a/internal/video/remove_segments.go
+++ b/internal/video/remove_segments.go
@@ -105,7 +105,7 @@ func (h *Handler) RemoveSegments(w http.ResponseWriter, r *http.Request) {
 
 	updateWhere, updateArgs := orgVideoFilter(r.Context(), videoID, nil, "AND status = 'ready'")
 	tag, err := h.db.Exec(r.Context(),
-		`UPDATE videos SET status = 'processing', updated_at = now() WHERE `+updateWhere, updateArgs...,
+		`UPDATE videos SET status = 'processing', processing_started_at = now(), updated_at = now() WHERE `+updateWhere, updateArgs...,
 	)
 	if err != nil {
 		httputil.WriteError(w, http.StatusInternalServerError, "failed to update video status")
@@ -172,7 +172,7 @@ func RemoveSegmentsAsync(ctx context.Context, db database.DBTX, storage ObjectSt
 
 	setReadyFallback := func() {
 		if _, err := db.Exec(ctx,
-			`UPDATE videos SET status = 'ready', updated_at = now() WHERE id = $1`,
+			`UPDATE videos SET status = 'ready', processing_started_at = NULL, updated_at = now() WHERE id = $1`,
 			videoID,
 		); err != nil {
 			slog.Error("remove-segments: failed to set fallback ready status", "video_id", videoID, "error", err)
@@ -227,7 +227,7 @@ func RemoveSegmentsAsync(ctx context.Context, db database.DBTX, storage ObjectSt
 	newDuration := int(float64(originalDuration) - removedTime)
 
 	if _, err := db.Exec(ctx,
-		`UPDATE videos SET status = 'ready', duration = $1, updated_at = now() WHERE id = $2`,
+		`UPDATE videos SET status = 'ready', duration = $1, processing_started_at = NULL, updated_at = now() WHERE id = $2`,
 		newDuration, videoID,
 	); err != nil {
 		slog.Error("remove-segments: failed to update status", "video_id", videoID, "error", err)

--- a/internal/video/remove_segments_test.go
+++ b/internal/video/remove_segments_test.go
@@ -27,7 +27,7 @@ func TestRemoveSegments_Success(t *testing.T) {
 		WillReturnRows(pgxmock.NewRows([]string{"duration", "file_key", "share_token", "status", "content_type", "user_id"}).
 			AddRow(120, "recordings/user/video.webm", "abc123defghi", "ready", "video/webm", testUserID))
 
-	mock.ExpectExec(`UPDATE videos SET status = 'processing'`).
+	mock.ExpectExec(`UPDATE videos SET status = 'processing', processing_started_at = now\(\)`).
 		WithArgs(videoID, testUserID).
 		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
 
@@ -260,7 +260,7 @@ func TestRemoveSegments_ConcurrentProcessing(t *testing.T) {
 		WillReturnRows(pgxmock.NewRows([]string{"duration", "file_key", "share_token", "status", "content_type", "user_id"}).
 			AddRow(120, "recordings/user/video.webm", "abc123defghi", "ready", "video/webm", testUserID))
 
-	mock.ExpectExec(`UPDATE videos SET status = 'processing'`).
+	mock.ExpectExec(`UPDATE videos SET status = 'processing', processing_started_at = now\(\)`).
 		WithArgs(videoID, testUserID).
 		WillReturnResult(pgxmock.NewResult("UPDATE", 0))
 

--- a/internal/video/stuck_processing.go
+++ b/internal/video/stuck_processing.go
@@ -1,0 +1,75 @@
+package video
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	"github.com/sendrec/sendrec/internal/database"
+)
+
+// stuckProcessingAfter is how long a video may sit in status='processing'
+// before the owning job is presumed dead. Composite, trim and remove-segments
+// all run under a 10 minute context, so anything past this bound belongs to a
+// process that can no longer finish it.
+const stuckProcessingAfter = "15 minutes"
+
+// resetStuckProcessing does what the in-process setReadyFallback would have
+// done for rows whose owner never got the chance.
+//
+// Every editing job flips the row to 'processing', works, then flips it back on
+// success or via setReadyFallback on error. That covers Go error returns and
+// nothing else: a SIGKILL, an OOM, an evicted pod or a node drain skips the
+// fallback entirely and strands the row. Nothing else looks at 'processing'
+// rows — the transcode and normalize workers both filter on 'ready' — so
+// without this sweep the video shows the processing overlay forever and both
+// edit endpoints reject it with 409.
+//
+// Resetting is safe because all three jobs upload only after ffmpeg succeeds:
+// a row abandoned mid-job still has its original object at file_key and its
+// original duration. The row is the only thing that is wrong.
+//
+// The deadline is keyed on processing_started_at rather than updated_at because
+// updated_at moves for unrelated writes (a title edit, say), which would push
+// the deadline out indefinitely on exactly the rows that need sweeping. A NULL
+// processing_started_at means the row was stranded before this column existed,
+// so those are swept on the first pass.
+//
+// webcam_key is cleared to match composite's own fallback: an abandoned overlay
+// leaves a webcam object that will never be composited, and leaving the key set
+// would keep the watch page waiting on it.
+func resetStuckProcessing(ctx context.Context, db database.DBTX) {
+	tag, err := db.Exec(ctx,
+		`UPDATE videos SET status = 'ready', webcam_key = NULL, processing_started_at = NULL, updated_at = now()
+		 WHERE status = 'processing'
+		   AND (processing_started_at < now() - INTERVAL '`+stuckProcessingAfter+`' OR processing_started_at IS NULL)`,
+	)
+	if err != nil {
+		slog.Error("stuck-processing: failed to reset abandoned jobs", "error", err)
+		return
+	}
+	if n := tag.RowsAffected(); n > 0 {
+		slog.Warn("stuck-processing: reset abandoned jobs to ready", "count", n, "older_than", stuckProcessingAfter)
+	}
+}
+
+// StartStuckProcessingWorker sweeps once at startup — the pod that died is
+// usually the pod that comes back — and then on every tick, which also covers
+// node-level failures where a different pod inherits the work.
+func StartStuckProcessingWorker(ctx context.Context, db database.DBTX, interval time.Duration) {
+	go func() {
+		resetStuckProcessing(ctx, db)
+
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				slog.Info("stuck-processing: shutting down")
+				return
+			case <-ticker.C:
+				resetStuckProcessing(ctx, db)
+			}
+		}
+	}()
+}

--- a/internal/video/stuck_processing_test.go
+++ b/internal/video/stuck_processing_test.go
@@ -1,0 +1,102 @@
+package video
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/pashagolub/pgxmock/v4"
+)
+
+func TestResetStuckProcessing_ResetsAbandonedRows(t *testing.T) {
+	mock, err := pgxmock.NewPool()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer mock.Close()
+
+	mock.ExpectExec(`UPDATE videos SET status = 'ready'`).
+		WillReturnResult(pgxmock.NewResult("UPDATE", 2))
+
+	resetStuckProcessing(context.Background(), mock)
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet expectations: %v", err)
+	}
+}
+
+// The whole point of the sweep is to undo what setReadyFallback would have done
+// had the process survived: composite's fallback also drops webcam_key, so a row
+// abandoned mid-composite must not keep pointing at a webcam file that will never
+// be overlaid.
+func TestResetStuckProcessing_ClearsWebcamKeyAndStartedAt(t *testing.T) {
+	mock, err := pgxmock.NewPool()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer mock.Close()
+
+	mock.ExpectExec(`webcam_key = NULL`).
+		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+
+	resetStuckProcessing(context.Background(), mock)
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet expectations: %v", err)
+	}
+}
+
+// processing_started_at is the ownership clock. Keying off updated_at instead
+// would let any unrelated write to the row push the deadline out forever.
+func TestResetStuckProcessing_KeysOffProcessingStartedAt(t *testing.T) {
+	mock, err := pgxmock.NewPool()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer mock.Close()
+
+	mock.ExpectExec(`processing_started_at < now\(\) - INTERVAL '15 minutes'`).
+		WillReturnResult(pgxmock.NewResult("UPDATE", 0))
+
+	resetStuckProcessing(context.Background(), mock)
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet expectations: %v", err)
+	}
+}
+
+// Rows stuck before this migration shipped have no processing_started_at at all.
+// They are exactly the rows the bug report is about, so they must be swept too.
+func TestResetStuckProcessing_SweepsRowsWithNullStartedAt(t *testing.T) {
+	mock, err := pgxmock.NewPool()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer mock.Close()
+
+	mock.ExpectExec(`processing_started_at IS NULL`).
+		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+
+	resetStuckProcessing(context.Background(), mock)
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet expectations: %v", err)
+	}
+}
+
+func TestResetStuckProcessing_SurvivesQueryFailure(t *testing.T) {
+	mock, err := pgxmock.NewPool()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer mock.Close()
+
+	mock.ExpectExec(`UPDATE videos SET status = 'ready'`).
+		WillReturnError(errors.New("connection refused"))
+
+	resetStuckProcessing(context.Background(), mock)
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet expectations: %v", err)
+	}
+}

--- a/internal/video/trim.go
+++ b/internal/video/trim.go
@@ -64,7 +64,7 @@ func TrimVideoAsync(ctx context.Context, db database.DBTX, storage ObjectStorage
 
 	setReadyFallback := func() {
 		if _, err := db.Exec(ctx,
-			`UPDATE videos SET status = 'ready', updated_at = now() WHERE id = $1`,
+			`UPDATE videos SET status = 'ready', processing_started_at = NULL, updated_at = now() WHERE id = $1`,
 			videoID,
 		); err != nil {
 			slog.Error("trim: failed to set fallback ready status", "video_id", videoID, "error", err)
@@ -112,7 +112,7 @@ func TrimVideoAsync(ctx context.Context, db database.DBTX, storage ObjectStorage
 
 	newDuration := int(endSeconds - startSeconds)
 	if _, err := db.Exec(ctx,
-		`UPDATE videos SET status = 'ready', duration = $1, updated_at = now() WHERE id = $2`,
+		`UPDATE videos SET status = 'ready', duration = $1, processing_started_at = NULL, updated_at = now() WHERE id = $2`,
 		newDuration, videoID,
 	); err != nil {
 		slog.Error("trim: failed to update status", "video_id", videoID, "error", err)

--- a/internal/video/trim_test.go
+++ b/internal/video/trim_test.go
@@ -17,7 +17,7 @@ func TestTrimVideoAsync_DownloadError(t *testing.T) {
 
 	s := &mockStorage{downloadToFileErr: fmt.Errorf("s3 down")}
 
-	mock.ExpectExec(`UPDATE videos SET status = 'ready', updated_at = now\(\) WHERE id =`).
+	mock.ExpectExec(`UPDATE videos SET status = 'ready', processing_started_at = NULL, updated_at = now\(\) WHERE id =`).
 		WithArgs("video-123").
 		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
 
@@ -39,7 +39,7 @@ func TestTrimVideoAsync_FFmpegFailsFallsBackToReady(t *testing.T) {
 
 	s := &mockStorage{}
 
-	mock.ExpectExec(`UPDATE videos SET status = 'ready', updated_at = now\(\) WHERE id =`).
+	mock.ExpectExec(`UPDATE videos SET status = 'ready', processing_started_at = NULL, updated_at = now\(\) WHERE id =`).
 		WithArgs("video-123").
 		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
 
@@ -61,7 +61,7 @@ func TestTrimVideoAsync_UploadError(t *testing.T) {
 
 	s := &mockStorage{uploadFileErr: fmt.Errorf("upload failed")}
 
-	mock.ExpectExec(`UPDATE videos SET status = 'ready', updated_at = now\(\) WHERE id =`).
+	mock.ExpectExec(`UPDATE videos SET status = 'ready', processing_started_at = NULL, updated_at = now\(\) WHERE id =`).
 		WithArgs("video-123").
 		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
 

--- a/internal/video/video_crud.go
+++ b/internal/video/video_crud.go
@@ -357,7 +357,9 @@ func (h *Handler) Update(w http.ResponseWriter, r *http.Request) {
 		}
 
 		tag, err := h.db.Exec(r.Context(),
-			`UPDATE videos SET status = $1, updated_at = now()
+			`UPDATE videos SET status = $1,
+			     processing_started_at = CASE WHEN $1 = 'processing' THEN now() ELSE NULL END,
+			     updated_at = now()
 			 WHERE id = $2 AND user_id = $3 AND status = 'uploading'`,
 			newStatus, videoID, userID,
 		)
@@ -521,7 +523,7 @@ func (h *Handler) Trim(w http.ResponseWriter, r *http.Request) {
 
 	updateWhere, updateArgs := orgVideoFilter(r.Context(), videoID, nil, "AND status = 'ready'")
 	tag, err := h.db.Exec(r.Context(),
-		`UPDATE videos SET status = 'processing', updated_at = now() WHERE `+updateWhere, updateArgs...,
+		`UPDATE videos SET status = 'processing', processing_started_at = now(), updated_at = now() WHERE `+updateWhere, updateArgs...,
 	)
 	if err != nil {
 		httputil.WriteError(w, http.StatusInternalServerError, "failed to update video status")

--- a/internal/video/video_test.go
+++ b/internal/video/video_test.go
@@ -2799,7 +2799,7 @@ func TestTrim_Success(t *testing.T) {
 		WillReturnRows(pgxmock.NewRows([]string{"duration", "file_key", "share_token", "status", "content_type", "user_id"}).
 			AddRow(120, "recordings/user/video.webm", "abc123defghi", "ready", "video/webm", testUserID))
 
-	mock.ExpectExec(`UPDATE videos SET status = 'processing'`).
+	mock.ExpectExec(`UPDATE videos SET status = 'processing', processing_started_at = now\(\)`).
 		WithArgs(videoID, testUserID).
 		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
 
@@ -3019,7 +3019,7 @@ func TestTrim_RaceCondition(t *testing.T) {
 		WillReturnRows(pgxmock.NewRows([]string{"duration", "file_key", "share_token", "status", "content_type", "user_id"}).
 			AddRow(120, "recordings/user/video.webm", "abc123defghi", "ready", "video/webm", testUserID))
 
-	mock.ExpectExec(`UPDATE videos SET status = 'processing'`).
+	mock.ExpectExec(`UPDATE videos SET status = 'processing', processing_started_at = now\(\)`).
 		WithArgs(videoID, testUserID).
 		WillReturnResult(pgxmock.NewResult("UPDATE", 0))
 

--- a/migrations/000060_add_processing_started_at.down.sql
+++ b/migrations/000060_add_processing_started_at.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE videos DROP COLUMN processing_started_at;

--- a/migrations/000060_add_processing_started_at.up.sql
+++ b/migrations/000060_add_processing_started_at.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE videos ADD COLUMN processing_started_at TIMESTAMPTZ;


### PR DESCRIPTION
## What does this PR do?

Fixes #200 — videos stranded in `status='processing'` when the pod handling an edit is OOM-killed, evicted or drained.

`CompositeWithWebcam`, `TrimVideoAsync` and `RemoveSegmentsAsync` each flip the row to `processing` and rely on `setReadyFallback` to flip it back. That only runs on Go error returns. A SIGKILL skips it, and nothing reconciles the row afterwards — `transcodeExistingWebM` and `normalizeExistingVideos` both filter on `status='ready'`, and the job is in-memory only. The watch page shows the processing overlay forever and `/trim` and `/remove-segments` both return 409.

### The fix

New `processing_started_at TIMESTAMPTZ` (migration `000060`), stamped when a job takes ownership and cleared on every path back to `ready`. `StartStuckProcessingWorker` sweeps at startup — the pod that died is usually the pod that comes back — and every 5 minutes after, which also covers node-level failures:

```sql
UPDATE videos SET status = 'ready', webcam_key = NULL, processing_started_at = NULL, updated_at = now()
WHERE status = 'processing'
  AND (processing_started_at < now() - INTERVAL '15 minutes' OR processing_started_at IS NULL)
```

Resetting is safe because all three jobs upload only after ffmpeg succeeds: an abandoned row still has its original object at `file_key` and its original `duration`. The row is the only thing that is wrong.

### Three deviations from the proposal in the issue

- **Keyed on `processing_started_at`, not `updated_at`.** Any unrelated write to the row (a title edit) bumps `updated_at` and would push the deadline out indefinitely on exactly the rows that need sweeping. This mirrors `document_started_at` in `processNextDocument`.
- **Clears `webcam_key`.** Composite's own fallback does, and a row abandoned mid-composite otherwise keeps pointing at a webcam object nothing will ever overlay. The issue covered trim and remove-segments; finalize-with-webcam has the same failure mode and is covered here too.
- **No attempts counter.** The sweep resets to `ready`, it does not re-run ffmpeg, so there is no retry loop to bound. `transcode_attempts` guards a worker that auto-retries; this one does not.

Rows with a NULL `processing_started_at` were stranded before the column existed — including the one in the report — and are swept on the first pass.

### Not in this PR

The OOM itself. A 19-segment `select='not(between(t,a,b)+...)'` chain over 19 terms for video and again for audio, re-encoded with libvpx-vp9, in-process in the pod serving HTTP. This PR stops the row from being stranded when that happens; it does not stop it from happening. Worth a separate issue — moving editing to its own worker, or stream-copying around cut points instead of a full decode/re-encode.

## How to test

`make test`. New tests in `internal/video/stuck_processing_test.go` cover the reset, the `webcam_key`/`processing_started_at` clearing, the `processing_started_at` deadline, NULL-timestamp rows, and query failure. Expectations in `trim_test.go`, `composite_test.go`, `remove_segments_test.go` and `video_test.go` were tightened to assert the new column on every transition — nine of them went red before the implementation landed.

## Checklist

- [x] `make test` passes
- [x] `make build` succeeds
- [x] New code has tests where applicable
- [x] No unrelated changes included
