### PR TITLE
fix: pair the audio codec with the container in remove-segments

### DIFF
--- a/internal/video/remove_segments.go
+++ b/internal/video/remove_segments.go
@@ -133,7 +133,20 @@ func buildSegmentFilter(segments []segmentRange) string {
 	return strings.Join(parts, "+")
 }
 
-func removeSegmentsFromVideo(inputPath, outputPath, contentType string, segments []segmentRange, audioPresent bool) error {
+// audioCodecForContentType pairs the audio codec with the container the output
+// is written to. WebM accepts only Vorbis or Opus, so pairing it with AAC makes
+// ffmpeg refuse at header write — the filter graph re-times audio, so copying
+// the source stream is not an option either.
+func audioCodecForContentType(ct string) string {
+	switch ct {
+	case "video/mp4", "video/quicktime":
+		return "aac"
+	default:
+		return "libopus"
+	}
+}
+
+func buildRemoveSegmentsArgs(inputPath, outputPath, contentType string, segments []segmentRange, audioPresent bool) []string {
 	betweenExpr := buildSegmentFilter(segments)
 
 	var args []string
@@ -146,7 +159,7 @@ func removeSegmentsFromVideo(inputPath, outputPath, contentType string, segments
 		)
 		args = append(args, "-filter_complex", filterComplex)
 		args = append(args, "-map", "[v]", "-map", "[a]")
-		args = append(args, "-c:v", videoCodecForContentType(contentType), "-c:a", "aac")
+		args = append(args, "-c:v", videoCodecForContentType(contentType), "-c:a", audioCodecForContentType(contentType))
 	} else {
 		filterComplex := fmt.Sprintf(
 			"[0:v]select='not(%s)',setpts=N/FRAME_RATE/TB[v]",
@@ -158,6 +171,11 @@ func removeSegmentsFromVideo(inputPath, outputPath, contentType string, segments
 	}
 
 	args = append(args, "-y", outputPath)
+	return args
+}
+
+func removeSegmentsFromVideo(inputPath, outputPath, contentType string, segments []segmentRange, audioPresent bool) error {
+	args := buildRemoveSegmentsArgs(inputPath, outputPath, contentType, segments, audioPresent)
 
 	cmd := exec.Command("ffmpeg", args...)
 	output, err := cmd.CombinedOutput()

--- a/internal/video/remove_segments_args_test.go
+++ b/internal/video/remove_segments_args_test.go
@@ -1,0 +1,72 @@
+package video
+
+import (
+	"slices"
+	"testing"
+)
+
+func codecPair(args []string) (video, audio string) {
+	if i := slices.Index(args, "-c:v"); i != -1 && i+1 < len(args) {
+		video = args[i+1]
+	}
+	if i := slices.Index(args, "-c:a"); i != -1 && i+1 < len(args) {
+		audio = args[i+1]
+	}
+	return
+}
+
+// AAC is not a legal codec in a WebM container: ffmpeg refuses at header write
+// with "Only VP8 or VP9 or AV1 video and Vorbis or Opus audio ... are supported
+// for WebM", so remove-segments could never succeed on a WebM with audio.
+func TestBuildRemoveSegmentsArgs_WebMUsesOpus(t *testing.T) {
+	args := buildRemoveSegmentsArgs("in.webm", "out.webm", "video/webm", []segmentRange{{Start: 1, End: 2}}, true)
+
+	v, a := codecPair(args)
+	if v != "libvpx-vp9" {
+		t.Errorf("video codec = %q, want libvpx-vp9", v)
+	}
+	if a != "libopus" {
+		t.Errorf("audio codec = %q, want libopus (aac is invalid in WebM)", a)
+	}
+}
+
+func TestBuildRemoveSegmentsArgs_MP4UsesAAC(t *testing.T) {
+	args := buildRemoveSegmentsArgs("in.mp4", "out.mp4", "video/mp4", []segmentRange{{Start: 1, End: 2}}, true)
+
+	v, a := codecPair(args)
+	if v != "libx264" {
+		t.Errorf("video codec = %q, want libx264", v)
+	}
+	if a != "aac" {
+		t.Errorf("audio codec = %q, want aac", a)
+	}
+}
+
+// The container follows the source, so the codec pair has to follow it too —
+// pairing a vp9 stream with an mp4 muxer or the reverse is the same class of bug.
+func TestBuildRemoveSegmentsArgs_CodecPairMatchesContainer(t *testing.T) {
+	for _, tc := range []struct{ contentType, wantVideo, wantAudio string }{
+		{"video/mp4", "libx264", "aac"},
+		{"video/quicktime", "libx264", "aac"},
+		{"video/webm", "libvpx-vp9", "libopus"},
+		{"", "libvpx-vp9", "libopus"},
+	} {
+		args := buildRemoveSegmentsArgs("in", "out", tc.contentType, []segmentRange{{Start: 1, End: 2}}, true)
+		v, a := codecPair(args)
+		if v != tc.wantVideo || a != tc.wantAudio {
+			t.Errorf("contentType %q: got %s/%s, want %s/%s", tc.contentType, v, a, tc.wantVideo, tc.wantAudio)
+		}
+	}
+}
+
+// Silent sources take the -an branch, which has no audio codec to get wrong.
+func TestBuildRemoveSegmentsArgs_NoAudioStream(t *testing.T) {
+	args := buildRemoveSegmentsArgs("in.webm", "out.webm", "video/webm", []segmentRange{{Start: 1, End: 2}}, false)
+
+	if !slices.Contains(args, "-an") {
+		t.Error("expected -an when the source has no audio stream")
+	}
+	if slices.Contains(args, "-c:a") {
+		t.Error("expected no audio codec when the source has no audio stream")
+	}
+}


### PR DESCRIPTION
## What does this PR do?

Fixes #203. `removeSegmentsFromVideo` hardcoded `-c:a aac` for its filtered audio output, while the container follows the source. For a WebM source that means a `.webm` output, and AAC is not a legal codec in WebM, so ffmpeg refused before writing the header.

**Scope: remove-segments on a WebM source that has an audio track.** Everything else was already fine — silent WebM takes the existing `-an` branch, `video/quicktime` resolves to libx264/AAC like mp4, and WebM trim works because `trimVideo` uses `-c:a copy` on the same branch. Only this one path was broken.

`setReadyFallback` swallowed the ffmpeg failure, so the user saw the video return to `ready` unchanged with no error. The only trace was `remove-segments: ffmpeg failed` in the logs.

### Reachability

Finalization sets `ready` and enqueues transcode asynchronously, and `transcodeExistingWebM` skips videos younger than five minutes, so a fresh recording is editable as WebM for a window after upload. A video that exhausts `transcode_attempts` stays WebM indefinitely, and remove-segments-with-audio stays broken on it — though trim and silent remove-segments continue to work.

### The fix

Pick the audio codec from the content type the way the video codec already is. Copying the source stream is not an option: `aselect` re-times the audio, and ffmpeg cannot combine filtering with stream copy.

`buildRemoveSegmentsArgs` is extracted so the codec pairing is testable without invoking ffmpeg, matching the existing `buildTranscodeArgs` and `buildNormalizeArgs`.

## How to test

`make test` — four new tests in `internal/video/remove_segments_args_test.go` cover the WebM pairing, the mp4 pairing, the full container/codec matrix including `video/quicktime`, and the silent-source `-an` branch.

Verified against ffmpeg 7.1 on a VP9+Opus file, using the argument lists the code produces before and after:

```
OLD:  [webm] Only VP8 or VP9 or AV1 video and Vorbis or Opus audio and WebVTT
             subtitles are supported for WebM.
      Could not write header (incorrect codec parameters ?): Invalid argument
NEW:  ok - duration 57.508s, audio codec opus
```

A 60s source with 1.0s and 1.5s removed is 57.5s, so the output is correct and not merely well-formed.

## Checklist

- [x] `make test` passes
- [x] `make build` succeeds
- [x] New code has tests where applicable
- [x] No unrelated changes included