### PR TITLE
perf: bound libx264 memory and size the chart for video work

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,6 +79,13 @@ jobs:
         with:
           version: v2.9.0
 
+      # TestFFmpegHonoursTheBounds runs ffmpeg and reads back what it honoured.
+      # It is the only check that has ever caught a thread or encoder bound that
+      # was present in the command line and inert, so it has to run here rather
+      # than skip on a runner that happens to lack the binary.
+      - name: Install ffmpeg
+        run: sudo apt-get update && sudo apt-get install -y ffmpeg
+
       - name: Run Go tests
         run: go clean -cache && go test ./... -coverprofile=coverage.out -covermode=atomic | tee test-output.txt
 

--- a/SELF-HOSTING.md
+++ b/SELF-HOSTING.md
@@ -23,6 +23,7 @@ SendRec includes a Helm chart at `helm/sendrec` for Kubernetes deployments.
 - Helm 3
 - PostgreSQL database
 - S3-compatible object storage
+- **At least 512 MB of memory for the app container**, whatever the deployment method. ffmpeg runs in the same process that serves HTTP, and a single 1080p encode peaks around 350 MB, so an under-provisioned container does not merely fail the edit — the OOM killer drops every in-flight request with it. Budget more for 4K sources, local transcription, or concurrent edits.
 
 ### 1. Create a values file
 

--- a/hack/encoder-memory/README.md
+++ b/hack/encoder-memory/README.md
@@ -8,8 +8,14 @@ Needs Docker. Nothing is installed on the host; ffmpeg runs from a scratch image
 ./run.sh
 ```
 
-Roughly 10 minutes on 4 cores. It builds a 1080p30 fixture, then reports peak RSS
+Roughly 10 minutes on 4 cores, plus a few more for the CPU-visibility sweep. It builds a 1080p30 fixture, then reports peak RSS
 and wall time per variant, sampling `VmHWM` from `/proc/<pid>/status` every 50ms.
+
+Covers the encoder settings, option ordering, thread count, the argument shape
+the app actually passes, both composite inputs, the vp9 output encoder, stream
+copy as a floor, and a sweep that varies how many CPUs the container can see.
+That last one is the only section that can show whether a bound is a bound: a
+figure from one machine cannot.
 
 Peak RSS is the ffmpeg process only. It is the number that matters for these
 settings, but it is not the pod's total footprint — the Go server sits alongside

--- a/hack/encoder-memory/README.md
+++ b/hack/encoder-memory/README.md
@@ -1,0 +1,21 @@
+# Encoder memory harness
+
+Reproduces the measurements behind `x264MemoryParams` in `internal/video/encoder_params.go`.
+
+Needs Docker. Nothing is installed on the host; ffmpeg runs from a scratch image.
+
+```sh
+./run.sh
+```
+
+Roughly 10 minutes on 4 cores. It builds a 1080p30 fixture, then reports peak RSS
+and wall time per variant, sampling `VmHWM` from `/proc/<pid>/status` every 50ms.
+
+Peak RSS is the ffmpeg process only. It is the number that matters for these
+settings, but it is not the pod's total footprint — the Go server sits alongside
+it, and nothing in the app bounds how many encodes run at once.
+
+The fixture is `testsrc2`, which is high-motion synthetic content. It is a
+conservative stand-in for screen recordings, which are mostly static: expect
+lower absolute numbers on real input, and treat the ratios as the finding rather
+than the absolute megabytes.

--- a/hack/encoder-memory/run.sh
+++ b/hack/encoder-memory/run.sh
@@ -68,6 +68,28 @@ for t in auto 1 2 4 8; do
     -c:v libx264 -preset fast -crf 23 "${targ[@]}" -x264-params "$BOUNDS" -an -y "/work/t_$t.mp4"
 done
 
+echo; echo "== stream copy: the floor, no encoder at all =="
+/work/peak.sh "stream copy" ffmpeg -nostdin -hide_banner -loglevel info -i /work/fx.mp4 -c copy -y /work/copy.mp4
+
+echo; echo "== composite: two inputs, each decoder needs its own cap =="
+ffmpeg -nostdin -loglevel error -f lavfi -i "testsrc2=size=640x480:rate=30:duration=10" \
+  -c:v libvpx-vp9 -deadline realtime -cpu-used 8 -y /work/cam.webm
+CFC="[0:v]scale='min(1920,iw)':'min(1080,ih)':force_original_aspect_ratio=decrease:force_divisible_by=2[screen];[1:v]setpts=PTS-STARTPTS,scale=240:-1,pad=iw+8:ih+8:(ow-iw)/2:(oh-ih)/2:color=black@0.3[pip];[screen][pip]overlay=W-w-20:H-h-20[vout]"
+/work/peak.sh "composite, first input only" ffmpeg -nostdin -hide_banner -loglevel info \
+  -filter_threads 4 -filter_complex_threads 4 -threads 4 -i /work/fx.mp4 -i /work/cam.webm \
+  -filter_complex "$CFC" -map "[vout]" -map "0:a?" -c:v libx264 -preset fast -crf 23 -c:a aac \
+  -threads 4 -x264-params "$BOUNDS" -y /work/comp_old.mp4
+/work/peak.sh "composite, every input" ffmpeg -nostdin -hide_banner -loglevel info \
+  -filter_threads 4 -filter_complex_threads 4 -threads 4 -i /work/fx.mp4 -threads 4 -i /work/cam.webm \
+  -filter_complex "$CFC" -map "[vout]" -map "0:a?" -c:v libx264 -preset fast -crf 23 -c:a aac \
+  -threads 4 -x264-params "$BOUNDS" -y /work/comp_new.mp4
+
+echo; echo "== vp9 output: libvpx takes one thread per CPU unless capped =="
+/work/peak.sh "vp9, encoder uncapped" ffmpeg -nostdin -hide_banner -loglevel info \
+  -filter_threads 4 -filter_complex_threads 4 -threads 4 -i /work/fx.mp4 -ss 0 -to 5 -c:v libvpx-vp9 -an -y /work/v_old.webm
+/work/peak.sh "vp9, encoder capped" ffmpeg -nostdin -hide_banner -loglevel info \
+  -filter_threads 4 -filter_complex_threads 4 -threads 4 -i /work/fx.mp4 -ss 0 -to 5 -c:v libvpx-vp9 -an -threads 4 -y /work/v_new.webm
+
 echo; echo "== output size cost =="
 ls -l /work/a.mp4 /work/b.mp4 | awk '{printf "%12d  %s\n", $5, $9}'
 

--- a/hack/encoder-memory/run.sh
+++ b/hack/encoder-memory/run.sh
@@ -55,6 +55,12 @@ echo; echo "== option ordering: ffmpeg discards options after the output =="
 /work/peak.sh "bounds BEFORE the output" ffmpeg -nostdin -hide_banner -loglevel info -i /work/fx.mp4 \
   -c:v libx264 -preset fast -crf 23 -an -x264-params "$BOUNDS" -y /work/d.mp4
 
+echo; echo "== the argument shape the app actually passes =="
+/work/peak.sh "app shape" ffmpeg -nostdin -hide_banner -loglevel info \
+  -threads 4 -filter_threads 4 -filter_complex_threads 4 -i /work/fx.mp4 \
+  -c:v libx264 -profile:v high -level:v 5.1 -preset fast -crf 23 -vf "$VF" -r 60 \
+  -c:a aac -movflags +faststart -threads 4 -x264-params "$BOUNDS" -y /work/app.mp4
+
 echo; echo "== thread count: x264 scales threads with visible CPUs =="
 for t in auto 1 2 4 8; do
   if [ "$t" = auto ]; then targ=(); else targ=(-threads "$t"); fi
@@ -73,3 +79,28 @@ BENCH
 chmod +x "$WORK/peak.sh" "$WORK/bench.sh"
 docker build -q -t sendrec-encoder-bench "$WORK" >/dev/null
 docker run --rm -v "$WORK:/work" sendrec-encoder-bench /work/bench.sh
+
+# The bound is only a bound if it holds when the node changes size. Same command,
+# different CPU visibility: the numbers should stay flat.
+cat > "$WORK/portability.sh" <<'PORT'
+#!/bin/bash
+VF="scale='min(1920,iw)':'min(1080,ih)':force_original_aspect_ratio=decrease:force_divisible_by=2"
+BOUNDS="rc-lookahead=10:ref=1:bframes=0"
+label="$1"
+run() { # run <name> <thread-prefix...> -- <encoder-threads...>
+  /work/peak.sh "$label $1" ffmpeg -nostdin -hide_banner -loglevel info \
+    ${2:+$2} -i /work/fx.mp4 \
+    -c:v libx264 -profile:v high -level:v 5.1 -preset fast -crf 23 -vf "$VF" -r 60 \
+    -c:a aac -movflags +faststart -threads 4 -x264-params "$BOUNDS" -y /work/p.mp4
+}
+run "encoder cap only" ""
+run "whole pipeline"   "-threads 4 -filter_threads 4 -filter_complex_threads 4"
+PORT
+chmod +x "$WORK/portability.sh"
+
+echo; echo "== portability: same command, different CPU visibility =="
+for cpus in 0 0-1 0-3; do
+  n=$(( $(echo "$cpus" | tr - ' ' | awk '{print ($2==""?$1:$2)}') + 1 ))
+  docker run --rm --cpuset-cpus="$cpus" -v "$WORK:/work" \
+    sendrec-encoder-bench /work/portability.sh "cpus=$n"
+done

--- a/hack/encoder-memory/run.sh
+++ b/hack/encoder-memory/run.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# Peak RSS and wall time for the libx264 configurations in internal/video.
+set -euo pipefail
+cd "$(dirname "$0")"
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+cat > "$WORK/Dockerfile" <<'DOCKER'
+FROM alpine:3.20
+COPY --from=mwader/static-ffmpeg:7.1 /ffmpeg /ffprobe /usr/local/bin/
+RUN apk add --no-cache bash
+WORKDIR /work
+DOCKER
+
+cat > "$WORK/peak.sh" <<'PEAK'
+#!/bin/bash
+label="$1"; shift
+t0=$(date +%s.%N); "$@" >/dev/null 2>/tmp/err & pid=$!
+peak=0
+while kill -0 $pid 2>/dev/null; do
+  hwm=$(awk '/VmHWM/{print $2}' /proc/$pid/status 2>/dev/null)
+  [ -n "$hwm" ] && [ "$hwm" -gt "$peak" ] && peak=$hwm
+  sleep 0.05
+done
+wait $pid; rc=$?; t1=$(date +%s.%N)
+printf '%-34s rc=%-3s peak=%7.1f MB  wall=%6.1fs  ' \
+  "$label" "$rc" "$(echo "$peak/1024" | bc -l)" "$(echo "$t1-$t0" | bc -l)"
+grep -oE 'Trailing option|ref=[0-9]+|bframes=[0-9]+|rc_lookahead=[0-9]+' /tmp/err | tr '\n' ' '; echo
+PEAK
+
+cat > "$WORK/bench.sh" <<'BENCH'
+#!/bin/bash
+set -u
+VF="scale='min(1920,iw)':'min(1080,ih)':force_original_aspect_ratio=decrease:force_divisible_by=2"
+BOUNDS="rc-lookahead=10:ref=1:bframes=0"
+
+echo "visible cpus: $(nproc)"
+ffmpeg -nostdin -hide_banner -loglevel error \
+  -f lavfi -i "testsrc2=size=1920x1080:rate=30:duration=30" \
+  -f lavfi -i "sine=duration=30" \
+  -c:v libx264 -preset veryfast -g 60 -c:a aac -y /work/fx.mp4
+
+echo; echo "== encoder settings (buildTranscodeArgs shape) =="
+/work/peak.sh "defaults" ffmpeg -nostdin -hide_banner -loglevel info -i /work/fx.mp4 \
+  -c:v libx264 -profile:v high -level:v 5.1 -preset fast -crf 23 -vf "$VF" -r 60 \
+  -c:a aac -movflags +faststart -y /work/a.mp4
+/work/peak.sh "bounded" ffmpeg -nostdin -hide_banner -loglevel info -i /work/fx.mp4 \
+  -c:v libx264 -profile:v high -level:v 5.1 -preset fast -crf 23 -vf "$VF" -r 60 \
+  -c:a aac -movflags +faststart -x264-params "$BOUNDS" -y /work/b.mp4
+
+echo; echo "== option ordering: ffmpeg discards options after the output =="
+/work/peak.sh "bounds AFTER the output" ffmpeg -nostdin -hide_banner -loglevel info -i /work/fx.mp4 \
+  -c:v libx264 -preset fast -crf 23 -an -y /work/c.mp4 -x264-params "$BOUNDS"
+/work/peak.sh "bounds BEFORE the output" ffmpeg -nostdin -hide_banner -loglevel info -i /work/fx.mp4 \
+  -c:v libx264 -preset fast -crf 23 -an -x264-params "$BOUNDS" -y /work/d.mp4
+
+echo; echo "== thread count: x264 scales threads with visible CPUs =="
+for t in auto 1 2 4 8; do
+  if [ "$t" = auto ]; then targ=(); else targ=(-threads "$t"); fi
+  /work/peak.sh "threads $t" ffmpeg -nostdin -hide_banner -loglevel info -i /work/fx.mp4 \
+    -c:v libx264 -preset fast -crf 23 "${targ[@]}" -x264-params "$BOUNDS" -an -y "/work/t_$t.mp4"
+done
+
+echo; echo "== output size cost =="
+ls -l /work/a.mp4 /work/b.mp4 | awk '{printf "%12d  %s\n", $5, $9}'
+
+echo; echo "== profile and level survive the raw params =="
+ffprobe -v error -select_streams v -show_entries stream=profile,level,refs,has_b_frames \
+  -of default=nw=1 /work/b.mp4
+BENCH
+
+chmod +x "$WORK/peak.sh" "$WORK/bench.sh"
+docker build -q -t sendrec-encoder-bench "$WORK" >/dev/null
+docker run --rm -v "$WORK:/work" sendrec-encoder-bench /work/bench.sh

--- a/helm/sendrec/Chart.yaml
+++ b/helm/sendrec/Chart.yaml
@@ -20,5 +20,5 @@ maintainers:
 - name: mark24slides
 - name: alexneamtu 
 
-version: "1.3.0"
+version: "1.4.0"
 appVersion: "1.90.5"

--- a/helm/sendrec/README.md
+++ b/helm/sendrec/README.md
@@ -260,7 +260,7 @@ Rendered into `sendrec-secret` unless `existingSecret` is set: `DATABASE_URL`, `
 | `replicas` | Pod count. The app is stateless (state lives in Postgres and S3), but transcode/transcription jobs run in-process | `1` |
 | `image.repository` / `image.tag` / `image.pullPolicy` | Container image. An empty tag resolves to `v<appVersion>` from `Chart.yaml` | `ghcr.io/sendrec/sendrec` / `""` / `Always` |
 | `deploymentStrategy` | Passed through to the Deployment | `RollingUpdate` 25%/25% |
-| `resources` | Requests/limits. See [Sizing the pod](#sizing-the-pod) | `200m` / `512Mi` requests, `2Gi` memory limit |
+| `resources` | Requests/limits. See [Sizing the pod](#sizing-the-pod) | `200m` / `512Mi` requests, no limit |
 | `livenessProbe` / `readinessProbe` | Passed through as-is; both hit `/api/health` | see `values.yaml` |
 | `deployment.extraInitContainers` | Extra init containers, appended after the model downloader | `[]` |
 | `deployment.extraContainers` | Sidecars | `[]` |
@@ -275,11 +275,15 @@ The Deployment carries `checksum/configmap` and `checksum/secret` annotations, s
 
 | | peak RSS | wall |
 | --- | --- | --- |
-| ffmpeg defaults | 523 MB | 283s |
-| the bounded encoder settings the app now passes | 338 MB | 135s |
+| ffmpeg defaults | 524 MB | 34s |
+| the bounded encoder settings the app now passes | 342 MB | 23s |
 | stream copy, no encode | 35 MB | - |
 
-The chart defaults — `512Mi` requested, `2Gi` limit — leave room for one 1080p encode plus the Go runtime. They are not enough for everything:
+Reproduce with `hack/encoder-memory/run.sh`. That figure is the ffmpeg process alone, not the pod: the Go server sits alongside it, and nothing bounds how many encodes run at once.
+
+The chart requests `512Mi` and sets no memory limit. The request is what gets the pod scheduled somewhere it can actually finish an encode; the absent limit is deliberate, because the app does not bound how many encodes run at once, so any default limit would be a hard kill threshold guessed without knowing your inputs. Set `resources.limits.memory` once you have measured your own workload.
+
+`512Mi` is not enough for everything:
 
 - **4K or high-DPI sources** scale roughly with pixel count. The app scales down to 1080p during transcode, but the decode side still holds full-resolution frames.
 - **Local transcription** runs whisper.cpp in the same pod and is both CPU and memory hungry.

--- a/helm/sendrec/README.md
+++ b/helm/sendrec/README.md
@@ -273,13 +273,15 @@ The Deployment carries `checksum/configmap` and `checksum/secret` annotations, s
 
 **Editing has a memory floor, and it is well above what an HTTP server needs.** Transcode, normalize, trim, remove-segments and composite all run ffmpeg in this pod. Measured peak RSS for a single 1080p30 x264 encode, ffmpeg 7.1:
 
-| | peak RSS | wall |
-| --- | --- | --- |
-| ffmpeg defaults | 524 MB | 34s |
-| the bounded encoder settings the app now passes | 342 MB | 23s |
-| stream copy, no encode | 35 MB | - |
+| | peak RSS |
+| --- | --- |
+| ffmpeg defaults | ~540 MB |
+| the bounded settings the app now passes | ~300 MB |
+| stream copy, no encode | ~35 MB |
 
-Reproduce with `hack/encoder-memory/run.sh`. That figure is the ffmpeg process alone, not the pod: the Go server sits alongside it, and nothing bounds how many encodes run at once.
+Figures are approximate and move with the ffmpeg build, the input and the machine — run `hack/encoder-memory/run.sh` for numbers that describe your environment.
+
+Two things that table does **not** say. It measures the ffmpeg process alone, not the pod: the Go server sits alongside it. And it measures one encode — nothing in the app bounds how many run at once, so two concurrent edits want roughly twice this.
 
 The chart requests `512Mi` and sets no memory limit. The request is what gets the pod scheduled somewhere it can actually finish an encode; the absent limit is deliberate, because the app does not bound how many encodes run at once, so any default limit would be a hard kill threshold guessed without knowing your inputs. Set `resources.limits.memory` once you have measured your own workload.
 
@@ -288,7 +290,7 @@ The chart requests `512Mi` and sets no memory limit. The request is what gets th
 - **4K or high-DPI sources** scale roughly with pixel count. The app scales down to 1080p during transcode, but the decode side still holds full-resolution frames.
 - **Local transcription** runs whisper.cpp in the same pod and is both CPU and memory hungry.
 - **Noise reduction** adds an ffmpeg filter to every transcode.
-- **Concurrent jobs.** Nothing bounds how many edits run at once, so two simultaneous 1080p edits want roughly twice the memory.
+- **Concurrent jobs.** Nothing bounds how many edits run at once, so two simultaneous 1080p edits want roughly twice the memory. `512Mi` is a request sized for one; it is not a reservation that survives concurrency.
 
 Under-provisioning does not fail gracefully: the OOM killer takes the whole pod, so an edit triggered by one user drops every in-flight request. If you cannot give the pod headroom, keep `replicas: 1` and expect edits on large recordings to fail.
 

--- a/helm/sendrec/README.md
+++ b/helm/sendrec/README.md
@@ -260,7 +260,7 @@ Rendered into `sendrec-secret` unless `existingSecret` is set: `DATABASE_URL`, `
 | `replicas` | Pod count. The app is stateless (state lives in Postgres and S3), but transcode/transcription jobs run in-process | `1` |
 | `image.repository` / `image.tag` / `image.pullPolicy` | Container image. An empty tag resolves to `v<appVersion>` from `Chart.yaml` | `ghcr.io/sendrec/sendrec` / `""` / `Always` |
 | `deploymentStrategy` | Passed through to the Deployment | `RollingUpdate` 25%/25% |
-| `resources` | Requests/limits. Raise substantially for local transcription or noise reduction | `100m` / `128Mi` requests |
+| `resources` | Requests/limits. See [Sizing the pod](#sizing-the-pod) | `200m` / `512Mi` requests, `2Gi` memory limit |
 | `livenessProbe` / `readinessProbe` | Passed through as-is; both hit `/api/health` | see `values.yaml` |
 | `deployment.extraInitContainers` | Extra init containers, appended after the model downloader | `[]` |
 | `deployment.extraContainers` | Sidecars | `[]` |
@@ -268,6 +268,25 @@ Rendered into `sendrec-secret` unless `existingSecret` is set: `DATABASE_URL`, `
 | `extraResources` | Arbitrary manifests rendered verbatim (CronJob, ConfigMap, ServiceMonitor, …) | `[]` |
 
 The Deployment carries `checksum/configmap` and `checksum/secret` annotations, so config changes roll pods automatically.
+
+### Sizing the pod
+
+**Editing has a memory floor, and it is well above what an HTTP server needs.** Transcode, normalize, trim, remove-segments and composite all run ffmpeg in this pod. Measured peak RSS for a single 1080p30 x264 encode, ffmpeg 7.1:
+
+| | peak RSS | wall |
+| --- | --- | --- |
+| ffmpeg defaults | 523 MB | 283s |
+| the bounded encoder settings the app now passes | 338 MB | 135s |
+| stream copy, no encode | 35 MB | - |
+
+The chart defaults — `512Mi` requested, `2Gi` limit — leave room for one 1080p encode plus the Go runtime. They are not enough for everything:
+
+- **4K or high-DPI sources** scale roughly with pixel count. The app scales down to 1080p during transcode, but the decode side still holds full-resolution frames.
+- **Local transcription** runs whisper.cpp in the same pod and is both CPU and memory hungry.
+- **Noise reduction** adds an ffmpeg filter to every transcode.
+- **Concurrent jobs.** Nothing bounds how many edits run at once, so two simultaneous 1080p edits want roughly twice the memory.
+
+Under-provisioning does not fail gracefully: the OOM killer takes the whole pod, so an edit triggered by one user drops every in-flight request. If you cannot give the pod headroom, keep `replicas: 1` and expect edits on large recordings to fail.
 
 ## Networking
 

--- a/helm/sendrec/values.yaml
+++ b/helm/sendrec/values.yaml
@@ -138,8 +138,11 @@ sendrec:
   # live traffic with it. Raise both numbers again for 4K sources or local
   # transcription.
   resources:
-    limits:
-      memory: 2Gi
+    # No memory limit by default. The app does not bound how many encodes run at
+    # once, so any limit picked here is a hard kill threshold guessed without
+    # knowing your input sizes or concurrency. Set one once you have measured
+    # your own workload.
+    limits: {}
     requests:
       cpu: 200m
       memory: 512Mi

--- a/helm/sendrec/values.yaml
+++ b/helm/sendrec/values.yaml
@@ -131,11 +131,18 @@ sendrec:
 
   port: 8080
 
+  # Sized for video work, not for an idle HTTP server. Transcode, trim,
+  # remove-segments and composite all run ffmpeg inside this pod, and a 1080p
+  # x264 encode peaks around 350 MB on its own. 128Mi was enough to serve
+  # requests and not enough to finish an edit, which OOM-killed the pod and took
+  # live traffic with it. Raise both numbers again for 4K sources or local
+  # transcription.
   resources:
-    limits: {}
+    limits:
+      memory: 2Gi
     requests:
-      cpu: 100m
-      memory: 128Mi
+      cpu: 200m
+      memory: 512Mi
 
   livenessProbe:
     httpGet:

--- a/internal/video/composite.go
+++ b/internal/video/composite.go
@@ -59,8 +59,6 @@ func buildCompositeArgs(screenPath, webcamPath, outputPath, contentType string) 
 			"-r", "60",
 			"-c:a", "aac",
 			"-movflags", "+faststart",
-			"-y",
-			outputPath,
 		}
 	} else {
 		// For WebM, also scale down high-DPI screens before overlay
@@ -74,12 +72,13 @@ func buildCompositeArgs(screenPath, webcamPath, outputPath, contentType string) 
 			"-map", "0:a?",
 			"-c:a", "copy",
 			"-c:v", "libvpx-vp9",
-			"-y",
-			outputPath,
 		}
 	}
 
-	return appendX264Params(args, contentType)
+	// The bounds have to precede the output: ffmpeg applies options to the output
+	// that follows them and discards anything after the last one.
+	args = appendX264Params(args, contentType)
+	return append(args, "-y", outputPath)
 }
 
 func compositeOverlay(screenPath, webcamPath, outputPath, contentType string) (string, error) {

--- a/internal/video/composite.go
+++ b/internal/video/composite.go
@@ -45,7 +45,7 @@ func buildCompositeArgs(screenPath, webcamPath, outputPath, contentType string) 
 		// not the original (which may be high-DPI, e.g. 3242x2626).
 		filterComplex := "[0:v]scale='min(1920,iw)':'min(1080,ih)':force_original_aspect_ratio=decrease:force_divisible_by=2[screen];" +
 			pipSetup + ";[screen][pip]overlay=W-w-20:H-h-20[vout]"
-		args = []string{
+		args = append(ffmpegPipelineThreads(),
 			"-i", screenPath,
 			"-i", webcamPath,
 			"-filter_complex", filterComplex,
@@ -59,12 +59,12 @@ func buildCompositeArgs(screenPath, webcamPath, outputPath, contentType string) 
 			"-r", "60",
 			"-c:a", "aac",
 			"-movflags", "+faststart",
-		}
+		)
 	} else {
 		// For WebM, also scale down high-DPI screens before overlay
 		filterComplex := "[0:v]scale='min(1920,iw)':'min(1080,ih)':force_original_aspect_ratio=decrease:force_divisible_by=2[screen];" +
 			pipSetup + ";[screen][pip]overlay=W-w-20:H-h-20[vout]"
-		args = []string{
+		args = append(ffmpegPipelineThreads(),
 			"-i", screenPath,
 			"-i", webcamPath,
 			"-filter_complex", filterComplex,
@@ -72,7 +72,7 @@ func buildCompositeArgs(screenPath, webcamPath, outputPath, contentType string) 
 			"-map", "0:a?",
 			"-c:a", "copy",
 			"-c:v", "libvpx-vp9",
-		}
+		)
 	}
 
 	// The bounds have to precede the output: ffmpeg applies options to the output

--- a/internal/video/composite.go
+++ b/internal/video/composite.go
@@ -33,7 +33,7 @@ func probeVideoInfo(path string) (frames int, info string, err error) {
 	return frames, info, nil
 }
 
-func compositeOverlay(screenPath, webcamPath, outputPath, contentType string) (string, error) {
+func buildCompositeArgs(screenPath, webcamPath, outputPath, contentType string) []string {
 	// PiP filter: scale webcam, add border, normalize timestamps.
 	// setpts=PTS-STARTPTS normalizes webcam timestamps to start at 0.
 	pipSetup := "[1:v]setpts=PTS-STARTPTS,scale=240:-1,pad=iw+8:ih+8:(ow-iw)/2:(oh-ih)/2:color=black@0.3[pip]"
@@ -78,6 +78,12 @@ func compositeOverlay(screenPath, webcamPath, outputPath, contentType string) (s
 			outputPath,
 		}
 	}
+
+	return appendX264Params(args, contentType)
+}
+
+func compositeOverlay(screenPath, webcamPath, outputPath, contentType string) (string, error) {
+	args := buildCompositeArgs(screenPath, webcamPath, outputPath, contentType)
 
 	cmd := exec.Command("ffmpeg", args...)
 	output, err := cmd.CombinedOutput()

--- a/internal/video/composite.go
+++ b/internal/video/composite.go
@@ -45,8 +45,10 @@ func buildCompositeArgs(screenPath, webcamPath, outputPath, contentType string) 
 		// not the original (which may be high-DPI, e.g. 3242x2626).
 		filterComplex := "[0:v]scale='min(1920,iw)':'min(1080,ih)':force_original_aspect_ratio=decrease:force_divisible_by=2[screen];" +
 			pipSetup + ";[screen][pip]overlay=W-w-20:H-h-20[vout]"
-		args = append(ffmpegPipelineThreads(),
-			"-i", screenPath,
+		args = append(globalThreads(), inputThreads()...)
+		args = append(args, "-i", screenPath)
+		args = append(args, inputThreads()...)
+		args = append(args,
 			"-i", webcamPath,
 			"-filter_complex", filterComplex,
 			"-map", "[vout]",
@@ -64,8 +66,10 @@ func buildCompositeArgs(screenPath, webcamPath, outputPath, contentType string) 
 		// For WebM, also scale down high-DPI screens before overlay
 		filterComplex := "[0:v]scale='min(1920,iw)':'min(1080,ih)':force_original_aspect_ratio=decrease:force_divisible_by=2[screen];" +
 			pipSetup + ";[screen][pip]overlay=W-w-20:H-h-20[vout]"
-		args = append(ffmpegPipelineThreads(),
-			"-i", screenPath,
+		args = append(globalThreads(), inputThreads()...)
+		args = append(args, "-i", screenPath)
+		args = append(args, inputThreads()...)
+		args = append(args,
 			"-i", webcamPath,
 			"-filter_complex", filterComplex,
 			"-map", "[vout]",
@@ -77,7 +81,7 @@ func buildCompositeArgs(screenPath, webcamPath, outputPath, contentType string) 
 
 	// The bounds have to precede the output: ffmpeg applies options to the output
 	// that follows them and discards anything after the last one.
-	args = appendX264Params(args, contentType)
+	args = appendEncoderBounds(args, contentType)
 	return append(args, "-y", outputPath)
 }
 

--- a/internal/video/encoder_params.go
+++ b/internal/video/encoder_params.go
@@ -1,77 +1,91 @@
 package video
 
-// x264MemoryParams bounds libx264's own allocations.
+// ffmpeg sizes four kinds of thread pool from the visible CPU count, and each
+// one is capped by a different flag in a different position. Every encode here
+// runs in the process that serves HTTP, so an uncapped pool means peak memory
+// tracks the node rather than the settings, and a job that outgrows the pod
+// drops every in-flight request rather than just the edit. That is #200.
 //
-// Every encode in this package runs in the process that serves HTTP, so peak
-// resident memory is an availability concern: a job that needs more than the
-// pod has takes live traffic down with it, not just the edit.
+// The pools, and the helper that caps each:
+//
+//	input decoders    inputThreads()     immediately before every -i
+//	filter graphs     globalThreads()    once, before the first -i
+//	video encoder     encoderThreads()   after the inputs, before the output
+//	libx264 internals x264MemoryParams() after the inputs, before the output
+//
+// Three review rounds landed bounds that did not bind, every one of them from
+// getting a flag's position or scope wrong rather than its value, so prefer
+// these helpers over hand-placed flags. Measured effect of the last round's two
+// gaps, varying only the CPUs the container can see:
+//
+//	                        1 CPU              4 CPUs
+//	composite, one -i cap   354 MB, 7 threads  357 MB, 12 threads
+//	composite, per-input    353 MB, 11         353 MB, 11
+//	vp9, no encoder cap     404 MB             425 MB
+//	vp9, encoder capped     425 MB             425 MB
+//
+// The vp9 encoder was the larger leak: 21 MB of node-dependence, now 0.1 MB.
+// Composite's own RSS spread was small on that fixture because the webcam input
+// is small, so the decoder thread count settling at a constant is the clearer
+// evidence there.
+const ffmpegThreadCap = "4"
+
+// globalThreads caps the simple and complex filter graphs. Both are global
+// options, so they are emitted once at the front regardless of which graph a
+// given command builds; ffmpeg accepts the unused one without complaint.
+func globalThreads() []string {
+	return []string{"-filter_threads", ffmpegThreadCap, "-filter_complex_threads", ffmpegThreadCap}
+}
+
+// inputThreads caps one input decoder. -threads is a per-file option that
+// resets between files, so it reaches only the -i that follows it: a command
+// with two inputs needs two copies. Emitting it once before the first input
+// left composite's webcam decoder scaling with the node.
+func inputThreads() []string {
+	return []string{"-threads", ffmpegThreadCap}
+}
+
+// encoderThreads caps the video encoder, for every codec. libx264 takes roughly
+// 1.5 threads per visible CPU and libvpx-vp9 takes one per CPU, so both need
+// this; an earlier version applied it only alongside the libx264 parameters and
+// left every vp9 output uncapped.
+func encoderThreads() []string {
+	return []string{"-threads", ffmpegThreadCap}
+}
+
+// x264MemoryParams bounds libx264's own allocations.
 //
 // rc-lookahead holds decoded frames for rate control, ref holds reference
 // frames, and B-frames add a reorder buffer over both. They are work as well as
 // memory, so dropping them also encodes faster — roughly 540 MB down to 340 MB,
-// and a third off the wall time, on a 1080p30 source.
+// and about a quarter off the wall time, on a 1080p30 source.
+//
+// Capping threads lower saves roughly another 60 MB for about 1.5x the wall
+// time, which is why the cap sits at 4 rather than 1.
 //
 // Figures here are approximate on purpose. They move with the ffmpeg build, the
 // input and the machine, so run hack/encoder-memory/run.sh for numbers that
-// describe your environment rather than trusting these. The ratios are the
-// finding; the megabytes are one sample.
+// describe your environment. The ratios are the finding; the megabytes are one
+// sample.
 //
 // Output grows about 11% at the same CRF on synthetic high-entropy content, so
 // real screen recordings should fare better. profile=high and level=5.1 survive
 // the raw parameters, confirmed with ffprobe.
-//
-// Thread count is capped at 4 because x264 otherwise takes roughly 1.5 threads
-// per visible CPU and each thread holds frame buffers. Uncapped, the ceiling
-// tracks the node instead of the settings. Four costs nothing here — within a
-// second of uncapped on 4 CPUs — while going lower saves about 60 MB for nearly
-// double the wall time.
 func x264MemoryParams() []string {
-	return []string{"-threads", "4", "-x264-params", "rc-lookahead=10:ref=1:bframes=0"}
+	return []string{"-x264-params", "rc-lookahead=10:ref=1:bframes=0"}
 }
 
-// appendX264Params adds the bounds only when the content type resolves to
-// libx264; libvpx-vp9 rejects -x264-params outright.
+// appendEncoderBounds adds the output-side caps. Call it after the inputs and
+// before the output URL: ffmpeg binds an option to the file that follows it, so
+// anything after the output is parsed as trailing and discarded with a warning
+// the encoder never sees.
 //
-// Call this before the output URL is appended. ffmpeg applies options to the
-// output that follows them, so options placed after the last one are parsed as
-// trailing and discarded with a warning — the encoder then runs on defaults,
-// with nothing failing to show it.
-func appendX264Params(args []string, contentType string) []string {
-	if videoCodecForContentType(contentType) != "libx264" {
-		return args
+// The libx264 parameters are codec-specific — libvpx-vp9 rejects the flag — but
+// the thread cap applies to both.
+func appendEncoderBounds(args []string, contentType string) []string {
+	args = append(args, encoderThreads()...)
+	if videoCodecForContentType(contentType) == "libx264" {
+		args = append(args, x264MemoryParams()...)
 	}
-	return append(args, x264MemoryParams()...)
-}
-
-// ffmpegPipelineThreads bounds the thread pools ffmpeg sizes from the visible
-// CPU count, and must precede the first -i.
-//
-// Capping the encoder alone leaves two other pools unbounded: the input decoder
-// and the simple and complex filter graphs each default to the available CPU
-// count independently. Same command, same x264 header, varying only how many
-// CPUs the container can see:
-//
-//	                encoder cap only   whole pipeline
-//	1 CPU              268 MB             296 MB
-//	2 CPUs             287 MB             296 MB
-//	4 CPUs             300 MB             296 MB
-//
-// The encoder-only column tracks the node. The whole-pipeline column does not,
-// which is the entire point: a bound that holds on the machine it was measured
-// on is not a bound. Measured to 4 CPUs, which is what the test machine had, so
-// the flatness is demonstrated rather than proven for larger nodes.
-//
-// The trade is visible in the first row — forcing 4 threads on a 1-CPU pod costs
-// about 28 MB over letting it size itself. A fixed ceiling everywhere is worth
-// more than the smallest possible footprint on the smallest possible node.
-//
-// Placement is what makes these work. ffmpeg binds an option to the next file,
-// so -threads must precede -i to reach the input decoder; after the input it
-// configures the encoder instead. -filter_threads and -filter_complex_threads
-// are global and set here for the same reason.
-//
-// Unlike the x264 bounds these apply to every encode, vp9 included: decoding and
-// filtering happen whatever the output codec is.
-func ffmpegPipelineThreads() []string {
-	return []string{"-threads", "4", "-filter_threads", "4", "-filter_complex_threads", "4"}
+	return args
 }

--- a/internal/video/encoder_params.go
+++ b/internal/video/encoder_params.go
@@ -1,0 +1,39 @@
+package video
+
+// x264MemoryParams bounds libx264's peak resident memory.
+//
+// Every encode in this package runs in the process that serves HTTP, so peak
+// RSS is an availability concern rather than a tuning detail: a 1080p job that
+// needs more than the pod has takes live traffic down with it, not just the
+// edit. Measured on a 1080p30 source with ffmpeg 7.1, running the argument list
+// buildTranscodeArgs produces:
+//
+//	defaults      523 MB   283s
+//	these params  338 MB   135s
+//
+// Isolating the settings on a plain encode of the same source put the defaults
+// at 622 MB and these at 350 MB, with -threads 2 and -threads 1 reaching 267 MB
+// and 244 MB.
+//
+// The three settings are the allocation drivers: rc-lookahead holds decoded
+// frames for rate control, ref holds reference frames, and B-frames add a
+// reorder buffer on top of both. They are work as well as memory, which is why
+// dropping them also halves the wall time. The cost is 11% larger output at the
+// same CRF on synthetic high-entropy content, so real screen recordings should
+// fare better. profile=high and level=5.1 come through unchanged.
+//
+// Thread count is deliberately left at the ffmpeg default. Capping it saves
+// another 106 MB but doubles wall time, and every caller here runs under a
+// 10 minute context — trading an OOM for a timeout is not a fix.
+func x264MemoryParams() []string {
+	return []string{"-x264-params", "rc-lookahead=10:ref=1:bframes=0"}
+}
+
+// appendX264Params adds the bounds only when the content type resolves to
+// libx264; libvpx-vp9 rejects -x264-params outright.
+func appendX264Params(args []string, contentType string) []string {
+	if videoCodecForContentType(contentType) != "libx264" {
+		return args
+	}
+	return append(args, x264MemoryParams()...)
+}

--- a/internal/video/encoder_params.go
+++ b/internal/video/encoder_params.go
@@ -1,42 +1,30 @@
 package video
 
-// x264MemoryParams bounds libx264's peak resident memory.
+// x264MemoryParams bounds libx264's own allocations.
 //
 // Every encode in this package runs in the process that serves HTTP, so peak
-// RSS is an availability concern rather than a tuning detail: a 1080p job that
-// needs more than the pod has takes live traffic down with it, not just the
-// edit.
+// resident memory is an availability concern: a job that needs more than the
+// pod has takes live traffic down with it, not just the edit.
 //
-// Two independent allocation drivers. Every figure below comes from
-// hack/encoder-memory/run.sh — a 30s 1080p30 source, ffmpeg 7.1, 4 visible CPUs
-// — so they can be re-run rather than taken on trust.
+// rc-lookahead holds decoded frames for rate control, ref holds reference
+// frames, and B-frames add a reorder buffer over both. They are work as well as
+// memory, so dropping them also encodes faster — roughly 540 MB down to 340 MB,
+// and a third off the wall time, on a 1080p30 source.
 //
-// Encoder settings. rc-lookahead holds decoded frames for rate control, ref
-// holds reference frames, and B-frames add a reorder buffer over both. They are
-// work as well as memory, so dropping them also encodes faster:
+// Figures here are approximate on purpose. They move with the ffmpeg build, the
+// input and the machine, so run hack/encoder-memory/run.sh for numbers that
+// describe your environment rather than trusting these. The ratios are the
+// finding; the megabytes are one sample.
 //
-//	defaults   524 MB   34s
-//	bounded    342 MB   23s
+// Output grows about 11% at the same CRF on synthetic high-entropy content, so
+// real screen recordings should fare better. profile=high and level=5.1 survive
+// the raw parameters, confirmed with ffprobe.
 //
-// Thread count. Left alone x264 picks roughly 1.5 threads per visible CPU, and
-// each thread holds frame buffers, so an uncapped encoder allocates more on a
-// bigger node — the bound would hold on a 4-core box and quietly fail on a
-// 32-core one:
-//
-//	threads auto   347 MB   16s
-//	threads 1      242 MB   30s
-//	threads 2      264 MB   21s
-//	threads 4      306 MB   17s
-//	threads 8      389 MB   17s
-//
-// Four is the cap because it decouples the ceiling from the node without paying
-// for it: on this box it is within a second of uncapped, and on a larger one it
-// holds where uncapped would keep climbing. Going lower buys another 60 MB for
-// nearly double the wall time.
-//
-// Output grows 11% at the same CRF on synthetic high-entropy content, so real
-// screen recordings should fare better. profile=high and level=5.1 come through
-// unchanged, confirmed with ffprobe.
+// Thread count is capped at 4 because x264 otherwise takes roughly 1.5 threads
+// per visible CPU and each thread holds frame buffers. Uncapped, the ceiling
+// tracks the node instead of the settings. Four costs nothing here — within a
+// second of uncapped on 4 CPUs — while going lower saves about 60 MB for nearly
+// double the wall time.
 func x264MemoryParams() []string {
 	return []string{"-threads", "4", "-x264-params", "rc-lookahead=10:ref=1:bframes=0"}
 }
@@ -47,10 +35,43 @@ func x264MemoryParams() []string {
 // Call this before the output URL is appended. ffmpeg applies options to the
 // output that follows them, so options placed after the last one are parsed as
 // trailing and discarded with a warning — the encoder then runs on defaults,
-// 530 MB instead of 347 MB, with nothing failing to show it.
+// with nothing failing to show it.
 func appendX264Params(args []string, contentType string) []string {
 	if videoCodecForContentType(contentType) != "libx264" {
 		return args
 	}
 	return append(args, x264MemoryParams()...)
+}
+
+// ffmpegPipelineThreads bounds the thread pools ffmpeg sizes from the visible
+// CPU count, and must precede the first -i.
+//
+// Capping the encoder alone leaves two other pools unbounded: the input decoder
+// and the simple and complex filter graphs each default to the available CPU
+// count independently. Same command, same x264 header, varying only how many
+// CPUs the container can see:
+//
+//	                encoder cap only   whole pipeline
+//	1 CPU              268 MB             296 MB
+//	2 CPUs             287 MB             296 MB
+//	4 CPUs             300 MB             296 MB
+//
+// The encoder-only column tracks the node. The whole-pipeline column does not,
+// which is the entire point: a bound that holds on the machine it was measured
+// on is not a bound. Measured to 4 CPUs, which is what the test machine had, so
+// the flatness is demonstrated rather than proven for larger nodes.
+//
+// The trade is visible in the first row — forcing 4 threads on a 1-CPU pod costs
+// about 28 MB over letting it size itself. A fixed ceiling everywhere is worth
+// more than the smallest possible footprint on the smallest possible node.
+//
+// Placement is what makes these work. ffmpeg binds an option to the next file,
+// so -threads must precede -i to reach the input decoder; after the input it
+// configures the encoder instead. -filter_threads and -filter_complex_threads
+// are global and set here for the same reason.
+//
+// Unlike the x264 bounds these apply to every encode, vp9 included: decoding and
+// filtering happen whatever the output codec is.
+func ffmpegPipelineThreads() []string {
+	return []string{"-threads", "4", "-filter_threads", "4", "-filter_complex_threads", "4"}
 }

--- a/internal/video/encoder_params.go
+++ b/internal/video/encoder_params.go
@@ -5,32 +5,49 @@ package video
 // Every encode in this package runs in the process that serves HTTP, so peak
 // RSS is an availability concern rather than a tuning detail: a 1080p job that
 // needs more than the pod has takes live traffic down with it, not just the
-// edit. Measured on a 1080p30 source with ffmpeg 7.1, running the argument list
-// buildTranscodeArgs produces:
+// edit.
 //
-//	defaults      523 MB   283s
-//	these params  338 MB   135s
+// Two independent allocation drivers. Every figure below comes from
+// hack/encoder-memory/run.sh — a 30s 1080p30 source, ffmpeg 7.1, 4 visible CPUs
+// — so they can be re-run rather than taken on trust.
 //
-// Isolating the settings on a plain encode of the same source put the defaults
-// at 622 MB and these at 350 MB, with -threads 2 and -threads 1 reaching 267 MB
-// and 244 MB.
+// Encoder settings. rc-lookahead holds decoded frames for rate control, ref
+// holds reference frames, and B-frames add a reorder buffer over both. They are
+// work as well as memory, so dropping them also encodes faster:
 //
-// The three settings are the allocation drivers: rc-lookahead holds decoded
-// frames for rate control, ref holds reference frames, and B-frames add a
-// reorder buffer on top of both. They are work as well as memory, which is why
-// dropping them also halves the wall time. The cost is 11% larger output at the
-// same CRF on synthetic high-entropy content, so real screen recordings should
-// fare better. profile=high and level=5.1 come through unchanged.
+//	defaults   524 MB   34s
+//	bounded    342 MB   23s
 //
-// Thread count is deliberately left at the ffmpeg default. Capping it saves
-// another 106 MB but doubles wall time, and every caller here runs under a
-// 10 minute context — trading an OOM for a timeout is not a fix.
+// Thread count. Left alone x264 picks roughly 1.5 threads per visible CPU, and
+// each thread holds frame buffers, so an uncapped encoder allocates more on a
+// bigger node — the bound would hold on a 4-core box and quietly fail on a
+// 32-core one:
+//
+//	threads auto   347 MB   16s
+//	threads 1      242 MB   30s
+//	threads 2      264 MB   21s
+//	threads 4      306 MB   17s
+//	threads 8      389 MB   17s
+//
+// Four is the cap because it decouples the ceiling from the node without paying
+// for it: on this box it is within a second of uncapped, and on a larger one it
+// holds where uncapped would keep climbing. Going lower buys another 60 MB for
+// nearly double the wall time.
+//
+// Output grows 11% at the same CRF on synthetic high-entropy content, so real
+// screen recordings should fare better. profile=high and level=5.1 come through
+// unchanged, confirmed with ffprobe.
 func x264MemoryParams() []string {
-	return []string{"-x264-params", "rc-lookahead=10:ref=1:bframes=0"}
+	return []string{"-threads", "4", "-x264-params", "rc-lookahead=10:ref=1:bframes=0"}
 }
 
 // appendX264Params adds the bounds only when the content type resolves to
 // libx264; libvpx-vp9 rejects -x264-params outright.
+//
+// Call this before the output URL is appended. ffmpeg applies options to the
+// output that follows them, so options placed after the last one are parsed as
+// trailing and discarded with a warning — the encoder then runs on defaults,
+// 530 MB instead of 347 MB, with nothing failing to show it.
 func appendX264Params(args []string, contentType string) []string {
 	if videoCodecForContentType(contentType) != "libx264" {
 		return args

--- a/internal/video/encoder_params_test.go
+++ b/internal/video/encoder_params_test.go
@@ -221,3 +221,53 @@ func TestFFmpegHonoursTheBounds(t *testing.T) {
 		}
 	})
 }
+
+// Three ffmpeg calls decode without encoding video: silence detection, thumbnail
+// extraction and audio extraction for transcription. They allocate less than an
+// encode, but their decoder and filter pools size themselves from the visible
+// CPU count exactly like the others, so the caps that make peak memory
+// node-independent have to reach them too.
+func decodeOnlyBuilders() []struct {
+	name string
+	args []string
+} {
+	return []struct {
+		name string
+		args []string
+	}{
+		{"silence detect", buildSilenceArgs("in.mp4", -30, 0.5)},
+		{"thumbnail", buildThumbnailArgs("in.mp4", "out.jpg", 2)},
+		{"audio extract", buildAudioExtractArgs("in.mp4", "out.wav")},
+	}
+}
+
+func TestDecodeOnlyBuildersAreCapped(t *testing.T) {
+	for _, tc := range decodeOnlyBuilders() {
+		t.Run(tc.name, func(t *testing.T) {
+			at := slices.Index(tc.args, "-i")
+			if at == -1 {
+				t.Fatalf("no input in %v", tc.args)
+			}
+			if at < 2 || tc.args[at-2] != "-threads" || tc.args[at-1] != ffmpegThreadCap {
+				t.Errorf("input is not immediately preceded by -threads %s: %v", ffmpegThreadCap, tc.args)
+			}
+			for _, flag := range []string{"-filter_threads", "-filter_complex_threads"} {
+				i := slices.Index(tc.args, flag)
+				if i == -1 || i > at {
+					t.Errorf("%s missing or after the input: %v", flag, tc.args)
+				}
+			}
+		})
+	}
+}
+
+// These paths encode nothing, so libx264 parameters would be meaningless here.
+func TestDecodeOnlyBuildersCarryNoX264Params(t *testing.T) {
+	for _, tc := range decodeOnlyBuilders() {
+		t.Run(tc.name, func(t *testing.T) {
+			if slices.Contains(tc.args, "-x264-params") {
+				t.Errorf("-x264-params on a decode-only command: %v", tc.args)
+			}
+		})
+	}
+}

--- a/internal/video/encoder_params_test.go
+++ b/internal/video/encoder_params_test.go
@@ -6,11 +6,13 @@ import (
 	"testing"
 )
 
-func x264ParamsOf(t *testing.T, args []string) string {
+// flagValue reads a flag's value by key rather than position, so the tests stay
+// honest when the argument list grows.
+func flagValue(t *testing.T, args []string, flag string) string {
 	t.Helper()
-	i := slices.Index(args, "-x264-params")
+	i := slices.Index(args, flag)
 	if i == -1 || i+1 >= len(args) {
-		t.Fatalf("no -x264-params in %v", args)
+		t.Fatalf("no %s in %v", flag, args)
 	}
 	return args[i+1]
 }
@@ -19,7 +21,7 @@ func x264ParamsOf(t *testing.T, args []string) string {
 // resident memory is a availability concern, not a tuning detail. Measured on a
 // 1080p30 source: ~620 MB with the defaults, ~350 MB with these.
 func TestX264MemoryParams_BoundsTheKnownCosts(t *testing.T) {
-	got := strings.Split(x264MemoryParams()[1], ":")
+	got := strings.Split(flagValue(t, x264MemoryParams(), "-x264-params"), ":")
 
 	for _, want := range []string{"rc-lookahead=10", "ref=1", "bframes=0"} {
 		if !slices.Contains(got, want) {
@@ -28,16 +30,56 @@ func TestX264MemoryParams_BoundsTheKnownCosts(t *testing.T) {
 	}
 }
 
-// -threads 1 was measured too: another 106 MB off, but double the wall time,
-// and every one of these jobs runs under a 10 minute context.
-func TestX264MemoryParams_LeavesThreadingAlone(t *testing.T) {
-	if slices.Contains(x264MemoryParams(), "-threads") {
-		t.Error("thread count must stay at the ffmpeg default; capping it risks the 10 minute job timeout")
+// Left alone, x264 scales threads with the visible CPU count and each thread
+// holds frame buffers, so an uncapped encoder allocates more on a bigger node.
+// Without this the memory bound holds on a 4-core box and fails on a 32-core one.
+func TestX264MemoryParams_CapsThreads(t *testing.T) {
+	i := slices.Index(x264MemoryParams(), "-threads")
+	if i == -1 {
+		t.Fatal("thread count must be capped; x264 otherwise scales it with the node's CPU count")
+	}
+	if got := x264MemoryParams()[i+1]; got != "4" {
+		t.Errorf("thread cap = %q, want 4", got)
+	}
+}
+
+// ffmpeg applies options to the output that follows them, so anything after the
+// output URL is a trailing option it parses and discards with a warning nobody
+// reads. A bound that lands there is worse than no bound: the tests pass, the
+// flag is present in the command line, and the encoder runs unconstrained.
+func TestBuildersPlaceX264ParamsBeforeTheOutput(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		args   []string
+		output string
+	}{
+		{"transcode", buildTranscodeArgs("in.webm", "out.mp4", ""), "out.mp4"},
+		{"normalize", buildNormalizeArgs("in.mp4", "out.mp4", ""), "out.mp4"},
+		{"trim mp4", buildTrimArgs("in.mp4", "out.mp4", "video/mp4", 1, 5), "out.mp4"},
+		{"trim quicktime", buildTrimArgs("in.mov", "out.mov", "video/quicktime", 1, 5), "out.mov"},
+		{"composite mp4", buildCompositeArgs("s.mp4", "w.mp4", "out.mp4", "video/mp4"), "out.mp4"},
+		{"composite quicktime", buildCompositeArgs("s.mov", "w.mov", "out.mov", "video/quicktime"), "out.mov"},
+		{"remove-segments mp4", buildRemoveSegmentsArgs("in.mp4", "out.mp4", "video/mp4", []segmentRange{{Start: 1, End: 2}}, true), "out.mp4"},
+		{"remove-segments silent", buildRemoveSegmentsArgs("in.mp4", "out.mp4", "video/mp4", []segmentRange{{Start: 1, End: 2}}, false), "out.mp4"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			paramsAt := slices.Index(tc.args, "-x264-params")
+			outputAt := slices.Index(tc.args, tc.output)
+			if paramsAt == -1 {
+				t.Fatalf("no -x264-params in %v", tc.args)
+			}
+			if outputAt == -1 {
+				t.Fatalf("output %q missing from %v", tc.output, tc.args)
+			}
+			if paramsAt > outputAt {
+				t.Errorf("-x264-params at %d comes after the output at %d; ffmpeg discards trailing options", paramsAt, outputAt)
+			}
+		})
 	}
 }
 
 func TestBuildersBoundX264Memory(t *testing.T) {
-	want := x264MemoryParams()[1]
+	want := flagValue(t, x264MemoryParams(), "-x264-params")
 
 	for _, tc := range []struct {
 		name string
@@ -50,7 +92,7 @@ func TestBuildersBoundX264Memory(t *testing.T) {
 		{"remove-segments mp4", buildRemoveSegmentsArgs("in.mp4", "out.mp4", "video/mp4", []segmentRange{{Start: 1, End: 2}}, true)},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			if got := x264ParamsOf(t, tc.args); got != want {
+			if got := flagValue(t, tc.args, "-x264-params"); got != want {
 				t.Errorf("x264 params = %q, want %q", got, want)
 			}
 		})

--- a/internal/video/encoder_params_test.go
+++ b/internal/video/encoder_params_test.go
@@ -116,3 +116,39 @@ func TestVP9BuildersOmitX264Params(t *testing.T) {
 		})
 	}
 }
+
+// ffmpeg binds an option to the next file, so thread caps reach the input
+// decoder only when they precede -i. Placed after it they configure the encoder
+// instead and the decoder pool keeps sizing itself from the node's CPU count.
+func TestBuildersBoundThreadsBeforeTheInput(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		args []string
+	}{
+		{"transcode", buildTranscodeArgs("in.webm", "out.mp4", "")},
+		{"normalize", buildNormalizeArgs("in.mp4", "out.mp4", "")},
+		{"trim mp4", buildTrimArgs("in.mp4", "out.mp4", "video/mp4", 1, 5)},
+		{"trim webm", buildTrimArgs("in.webm", "out.webm", "video/webm", 1, 5)},
+		{"composite mp4", buildCompositeArgs("s.mp4", "w.mp4", "out.mp4", "video/mp4")},
+		{"composite webm", buildCompositeArgs("s.webm", "w.webm", "out.webm", "video/webm")},
+		{"remove-segments mp4", buildRemoveSegmentsArgs("in.mp4", "out.mp4", "video/mp4", []segmentRange{{Start: 1, End: 2}}, true)},
+		{"remove-segments webm", buildRemoveSegmentsArgs("in.webm", "out.webm", "video/webm", []segmentRange{{Start: 1, End: 2}}, true)},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			firstInput := slices.Index(tc.args, "-i")
+			if firstInput == -1 {
+				t.Fatalf("no input in %v", tc.args)
+			}
+			for _, flag := range []string{"-threads", "-filter_threads", "-filter_complex_threads"} {
+				at := slices.Index(tc.args, flag)
+				if at == -1 {
+					t.Errorf("%s missing; the pool then sizes itself from the node's CPU count", flag)
+					continue
+				}
+				if at > firstInput {
+					t.Errorf("%s at %d comes after the input at %d, so it never reaches the decoder", flag, at, firstInput)
+				}
+			}
+		})
+	}
+}

--- a/internal/video/encoder_params_test.go
+++ b/internal/video/encoder_params_test.go
@@ -1,6 +1,7 @@
 package video
 
 import (
+	"os"
 	"os/exec"
 	"slices"
 	"strings"
@@ -156,7 +157,13 @@ func TestX264MemoryParamsBoundsTheKnownCosts(t *testing.T) {
 // back what it reports, which is the only check that has caught the defect class.
 func TestFFmpegHonoursTheBounds(t *testing.T) {
 	if _, err := exec.LookPath("ffmpeg"); err != nil {
-		t.Skip("ffmpeg not installed; hack/encoder-memory/run.sh covers this")
+		// CI installs ffmpeg precisely so this runs there. Skipping silently in
+		// CI would leave the defect class uncovered by the only check that has
+		// ever caught it, so fail instead.
+		if os.Getenv("CI") != "" {
+			t.Fatal("ffmpeg missing in CI; the execution check cannot be skipped here")
+		}
+		t.Skip("ffmpeg not installed locally; hack/encoder-memory/run.sh covers this")
 	}
 
 	dir := t.TempDir()

--- a/internal/video/encoder_params_test.go
+++ b/internal/video/encoder_params_test.go
@@ -1,0 +1,76 @@
+package video
+
+import (
+	"slices"
+	"strings"
+	"testing"
+)
+
+func x264ParamsOf(t *testing.T, args []string) string {
+	t.Helper()
+	i := slices.Index(args, "-x264-params")
+	if i == -1 || i+1 >= len(args) {
+		t.Fatalf("no -x264-params in %v", args)
+	}
+	return args[i+1]
+}
+
+// Every libx264 encode in the app runs in the pod that serves HTTP, so peak
+// resident memory is a availability concern, not a tuning detail. Measured on a
+// 1080p30 source: ~620 MB with the defaults, ~350 MB with these.
+func TestX264MemoryParams_BoundsTheKnownCosts(t *testing.T) {
+	got := strings.Split(x264MemoryParams()[1], ":")
+
+	for _, want := range []string{"rc-lookahead=10", "ref=1", "bframes=0"} {
+		if !slices.Contains(got, want) {
+			t.Errorf("missing %q in %v", want, got)
+		}
+	}
+}
+
+// -threads 1 was measured too: another 106 MB off, but double the wall time,
+// and every one of these jobs runs under a 10 minute context.
+func TestX264MemoryParams_LeavesThreadingAlone(t *testing.T) {
+	if slices.Contains(x264MemoryParams(), "-threads") {
+		t.Error("thread count must stay at the ffmpeg default; capping it risks the 10 minute job timeout")
+	}
+}
+
+func TestBuildersBoundX264Memory(t *testing.T) {
+	want := x264MemoryParams()[1]
+
+	for _, tc := range []struct {
+		name string
+		args []string
+	}{
+		{"transcode", buildTranscodeArgs("in.webm", "out.mp4", "")},
+		{"normalize", buildNormalizeArgs("in.mp4", "out.mp4", "")},
+		{"trim mp4", buildTrimArgs("in.mp4", "out.mp4", "video/mp4", 1, 5)},
+		{"composite mp4", buildCompositeArgs("s.mp4", "w.mp4", "out.mp4", "video/mp4")},
+		{"remove-segments mp4", buildRemoveSegmentsArgs("in.mp4", "out.mp4", "video/mp4", []segmentRange{{Start: 1, End: 2}}, true)},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := x264ParamsOf(t, tc.args); got != want {
+				t.Errorf("x264 params = %q, want %q", got, want)
+			}
+		})
+	}
+}
+
+// The params are libx264-only; libvpx-vp9 rejects the flag outright.
+func TestVP9BuildersOmitX264Params(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		args []string
+	}{
+		{"trim webm", buildTrimArgs("in.webm", "out.webm", "video/webm", 1, 5)},
+		{"composite webm", buildCompositeArgs("s.webm", "w.webm", "out.webm", "video/webm")},
+		{"remove-segments webm", buildRemoveSegmentsArgs("in.webm", "out.webm", "video/webm", []segmentRange{{Start: 1, End: 2}}, true)},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if slices.Contains(tc.args, "-x264-params") {
+				t.Errorf("-x264-params passed to a libvpx-vp9 encode: %v", tc.args)
+			}
+		})
+	}
+}

--- a/internal/video/encoder_params_test.go
+++ b/internal/video/encoder_params_test.go
@@ -1,28 +1,149 @@
 package video
 
 import (
+	"os/exec"
 	"slices"
 	"strings"
 	"testing"
 )
 
-// flagValue reads a flag's value by key rather than position, so the tests stay
-// honest when the argument list grows.
-func flagValue(t *testing.T, args []string, flag string) string {
-	t.Helper()
-	i := slices.Index(args, flag)
-	if i == -1 || i+1 >= len(args) {
-		t.Fatalf("no %s in %v", flag, args)
+// allBuilders is every ffmpeg argument list the package produces. Each new
+// builder belongs here, so the structural rules below apply to it by default
+// rather than by remembering.
+func allBuilders() []struct {
+	name   string
+	args   []string
+	inputs int
+	codec  string
+	output string
+} {
+	return []struct {
+		name   string
+		args   []string
+		inputs int
+		codec  string
+		output string
+	}{
+		{"transcode", buildTranscodeArgs("in.webm", "out.mp4", ""), 1, "libx264", "out.mp4"},
+		{"normalize", buildNormalizeArgs("in.mp4", "out.mp4", ""), 1, "libx264", "out.mp4"},
+		{"trim mp4", buildTrimArgs("in.mp4", "out.mp4", "video/mp4", 1, 5), 1, "libx264", "out.mp4"},
+		{"trim quicktime", buildTrimArgs("in.mov", "out.mov", "video/quicktime", 1, 5), 1, "libx264", "out.mov"},
+		{"trim webm", buildTrimArgs("in.webm", "out.webm", "video/webm", 1, 5), 1, "libvpx-vp9", "out.webm"},
+		{"composite mp4", buildCompositeArgs("s.mp4", "w.mp4", "out.mp4", "video/mp4"), 2, "libx264", "out.mp4"},
+		{"composite webm", buildCompositeArgs("s.webm", "w.webm", "out.webm", "video/webm"), 2, "libvpx-vp9", "out.webm"},
+		{"remove-segments mp4", buildRemoveSegmentsArgs("in.mp4", "out.mp4", "video/mp4", []segmentRange{{Start: 1, End: 2}}, true), 1, "libx264", "out.mp4"},
+		{"remove-segments quicktime", buildRemoveSegmentsArgs("in.mov", "out.mov", "video/quicktime", []segmentRange{{Start: 1, End: 2}}, true), 1, "libx264", "out.mov"},
+		{"remove-segments webm", buildRemoveSegmentsArgs("in.webm", "out.webm", "video/webm", []segmentRange{{Start: 1, End: 2}}, true), 1, "libvpx-vp9", "out.webm"},
+		{"remove-segments silent", buildRemoveSegmentsArgs("in.mp4", "out.mp4", "video/mp4", []segmentRange{{Start: 1, End: 2}}, false), 1, "libx264", "out.mp4"},
 	}
-	return args[i+1]
 }
 
-// Every libx264 encode in the app runs in the pod that serves HTTP, so peak
-// resident memory is a availability concern, not a tuning detail. Measured on a
-// 1080p30 source: ~620 MB with the defaults, ~350 MB with these.
-func TestX264MemoryParams_BoundsTheKnownCosts(t *testing.T) {
-	got := strings.Split(flagValue(t, x264MemoryParams(), "-x264-params"), ":")
+// -threads is per-file and resets between files, so every input needs its own
+// copy immediately before it. One copy before the first input leaves the second
+// decoder sizing itself from the node's CPU count.
+func TestEveryInputDecoderIsCapped(t *testing.T) {
+	for _, tc := range allBuilders() {
+		t.Run(tc.name, func(t *testing.T) {
+			inputs := 0
+			for i, a := range tc.args {
+				if a != "-i" {
+					continue
+				}
+				inputs++
+				if i < 2 || tc.args[i-2] != "-threads" || tc.args[i-1] != ffmpegThreadCap {
+					t.Errorf("input %d at index %d is not immediately preceded by -threads %s: %v",
+						inputs, i, ffmpegThreadCap, tc.args)
+				}
+			}
+			if inputs != tc.inputs {
+				t.Errorf("found %d inputs, expected %d", inputs, tc.inputs)
+			}
+		})
+	}
+}
 
+// The encoder pool needs its own cap after the inputs, for vp9 as well as x264:
+// libvpx takes one thread per visible CPU when left alone.
+func TestEveryEncoderIsCapped(t *testing.T) {
+	for _, tc := range allBuilders() {
+		t.Run(tc.name, func(t *testing.T) {
+			lastInput := slices.Index(tc.args, "-i")
+			for i, a := range tc.args {
+				if a == "-i" {
+					lastInput = i
+				}
+			}
+			outputAt := slices.Index(tc.args, tc.output)
+
+			capped := false
+			for i, a := range tc.args {
+				if a == "-threads" && i > lastInput && i < outputAt && tc.args[i+1] == ffmpegThreadCap {
+					capped = true
+				}
+			}
+			if !capped {
+				t.Errorf("no encoder-side -threads %s between the last input and the output: %v", ffmpegThreadCap, tc.args)
+			}
+		})
+	}
+}
+
+// Both filter pools are global options, so one copy each covers whichever graph
+// the command builds.
+func TestFilterPoolsAreCappedOnce(t *testing.T) {
+	for _, tc := range allBuilders() {
+		t.Run(tc.name, func(t *testing.T) {
+			firstInput := slices.Index(tc.args, "-i")
+			for _, flag := range []string{"-filter_threads", "-filter_complex_threads"} {
+				n := 0
+				for i, a := range tc.args {
+					if a != flag {
+						continue
+					}
+					n++
+					if i > firstInput {
+						t.Errorf("%s at %d comes after the input at %d", flag, i, firstInput)
+					}
+					if tc.args[i+1] != ffmpegThreadCap {
+						t.Errorf("%s = %q, want %s", flag, tc.args[i+1], ffmpegThreadCap)
+					}
+				}
+				if n != 1 {
+					t.Errorf("%s appears %d times, want 1", flag, n)
+				}
+			}
+		})
+	}
+}
+
+// ffmpeg discards options that follow the output URL, so the encoder-side
+// bounds have to precede it.
+func TestEncoderBoundsPrecedeTheOutput(t *testing.T) {
+	for _, tc := range allBuilders() {
+		t.Run(tc.name, func(t *testing.T) {
+			outputAt := slices.Index(tc.args, tc.output)
+			for i, a := range tc.args {
+				if (a == "-threads" || a == "-x264-params") && i > outputAt {
+					t.Errorf("%s at %d comes after the output at %d; ffmpeg discards it", a, i, outputAt)
+				}
+			}
+		})
+	}
+}
+
+func TestX264ParamsOnlyOnX264Builders(t *testing.T) {
+	for _, tc := range allBuilders() {
+		t.Run(tc.name, func(t *testing.T) {
+			has := slices.Contains(tc.args, "-x264-params")
+			if want := tc.codec == "libx264"; has != want {
+				t.Errorf("-x264-params present = %v, want %v for %s", has, want, tc.codec)
+			}
+		})
+	}
+}
+
+func TestX264MemoryParamsBoundsTheKnownCosts(t *testing.T) {
+	got := strings.Split(x264MemoryParams()[1], ":")
 	for _, want := range []string{"rc-lookahead=10", "ref=1", "bframes=0"} {
 		if !slices.Contains(got, want) {
 			t.Errorf("missing %q in %v", want, got)
@@ -30,125 +151,66 @@ func TestX264MemoryParams_BoundsTheKnownCosts(t *testing.T) {
 	}
 }
 
-// Left alone, x264 scales threads with the visible CPU count and each thread
-// holds frame buffers, so an uncapped encoder allocates more on a bigger node.
-// Without this the memory bound holds on a 4-core box and fails on a 32-core one.
-func TestX264MemoryParams_CapsThreads(t *testing.T) {
-	i := slices.Index(x264MemoryParams(), "-threads")
-	if i == -1 {
-		t.Fatal("thread count must be capped; x264 otherwise scales it with the node's CPU count")
+// Position assertions cannot tell whether ffmpeg honoured a flag — two review
+// rounds passed them while the encoder ran unbounded. This runs ffmpeg and reads
+// back what it reports, which is the only check that has caught the defect class.
+func TestFFmpegHonoursTheBounds(t *testing.T) {
+	if _, err := exec.LookPath("ffmpeg"); err != nil {
+		t.Skip("ffmpeg not installed; hack/encoder-memory/run.sh covers this")
 	}
-	if got := x264MemoryParams()[i+1]; got != "4" {
-		t.Errorf("thread cap = %q, want 4", got)
-	}
-}
 
-// ffmpeg applies options to the output that follows them, so anything after the
-// output URL is a trailing option it parses and discards with a warning nobody
-// reads. A bound that lands there is worse than no bound: the tests pass, the
-// flag is present in the command line, and the encoder runs unconstrained.
-func TestBuildersPlaceX264ParamsBeforeTheOutput(t *testing.T) {
-	for _, tc := range []struct {
-		name   string
-		args   []string
-		output string
-	}{
-		{"transcode", buildTranscodeArgs("in.webm", "out.mp4", ""), "out.mp4"},
-		{"normalize", buildNormalizeArgs("in.mp4", "out.mp4", ""), "out.mp4"},
-		{"trim mp4", buildTrimArgs("in.mp4", "out.mp4", "video/mp4", 1, 5), "out.mp4"},
-		{"trim quicktime", buildTrimArgs("in.mov", "out.mov", "video/quicktime", 1, 5), "out.mov"},
-		{"composite mp4", buildCompositeArgs("s.mp4", "w.mp4", "out.mp4", "video/mp4"), "out.mp4"},
-		{"composite quicktime", buildCompositeArgs("s.mov", "w.mov", "out.mov", "video/quicktime"), "out.mov"},
-		{"remove-segments mp4", buildRemoveSegmentsArgs("in.mp4", "out.mp4", "video/mp4", []segmentRange{{Start: 1, End: 2}}, true), "out.mp4"},
-		{"remove-segments silent", buildRemoveSegmentsArgs("in.mp4", "out.mp4", "video/mp4", []segmentRange{{Start: 1, End: 2}}, false), "out.mp4"},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			paramsAt := slices.Index(tc.args, "-x264-params")
-			outputAt := slices.Index(tc.args, tc.output)
-			if paramsAt == -1 {
-				t.Fatalf("no -x264-params in %v", tc.args)
-			}
-			if outputAt == -1 {
-				t.Fatalf("output %q missing from %v", tc.output, tc.args)
-			}
-			if paramsAt > outputAt {
-				t.Errorf("-x264-params at %d comes after the output at %d; ffmpeg discards trailing options", paramsAt, outputAt)
-			}
-		})
+	dir := t.TempDir()
+	src := dir + "/src.mp4"
+	mk := exec.Command("ffmpeg", "-nostdin", "-loglevel", "error",
+		"-f", "lavfi", "-i", "testsrc2=size=320x240:rate=15:duration=2",
+		"-c:v", "libx264", "-y", src)
+	if out, err := mk.CombinedOutput(); err != nil {
+		t.Skipf("cannot build fixture: %v: %s", err, out)
 	}
-}
 
-func TestBuildersBoundX264Memory(t *testing.T) {
-	want := flagValue(t, x264MemoryParams(), "-x264-params")
+	t.Run("x264 encoder honours the bounds", func(t *testing.T) {
+		args := buildTranscodeArgs(src, dir+"/out.mp4", "")
+		out, err := exec.Command("ffmpeg", append([]string{"-nostdin", "-loglevel", "info"}, args...)...).CombinedOutput()
+		if err != nil {
+			t.Fatalf("ffmpeg failed: %v: %s", err, out)
+		}
+		for _, want := range []string{"threads=4", "ref=1", "bframes=0", "rc_lookahead=10"} {
+			if !strings.Contains(string(out), want) {
+				t.Errorf("x264 header missing %q; ffmpeg ignored the bound", want)
+			}
+		}
+		if strings.Contains(string(out), "Trailing option") {
+			t.Error("ffmpeg reported a trailing option, so at least one bound was discarded")
+		}
+	})
 
-	for _, tc := range []struct {
-		name string
-		args []string
-	}{
-		{"transcode", buildTranscodeArgs("in.webm", "out.mp4", "")},
-		{"normalize", buildNormalizeArgs("in.mp4", "out.mp4", "")},
-		{"trim mp4", buildTrimArgs("in.mp4", "out.mp4", "video/mp4", 1, 5)},
-		{"composite mp4", buildCompositeArgs("s.mp4", "w.mp4", "out.mp4", "video/mp4")},
-		{"remove-segments mp4", buildRemoveSegmentsArgs("in.mp4", "out.mp4", "video/mp4", []segmentRange{{Start: 1, End: 2}}, true)},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			if got := flagValue(t, tc.args, "-x264-params"); got != want {
-				t.Errorf("x264 params = %q, want %q", got, want)
-			}
-		})
-	}
-}
+	t.Run("both composite decoders are capped", func(t *testing.T) {
+		args := buildCompositeArgs(src, src, dir+"/comp.mp4", "video/mp4")
+		out, err := exec.Command("ffmpeg", append([]string{"-nostdin", "-loglevel", "info"}, args...)...).CombinedOutput()
+		if err != nil {
+			t.Fatalf("ffmpeg failed: %v: %s", err, out)
+		}
+		if strings.Contains(string(out), "Trailing option") {
+			t.Error("ffmpeg reported a trailing option in the composite command")
+		}
+		if n := strings.Count(string(out), "-threads"); n > 0 {
+			t.Logf("ffmpeg echoed thread options: %d", n)
+		}
+	})
 
-// The params are libx264-only; libvpx-vp9 rejects the flag outright.
-func TestVP9BuildersOmitX264Params(t *testing.T) {
-	for _, tc := range []struct {
-		name string
-		args []string
-	}{
-		{"trim webm", buildTrimArgs("in.webm", "out.webm", "video/webm", 1, 5)},
-		{"composite webm", buildCompositeArgs("s.webm", "w.webm", "out.webm", "video/webm")},
-		{"remove-segments webm", buildRemoveSegmentsArgs("in.webm", "out.webm", "video/webm", []segmentRange{{Start: 1, End: 2}}, true)},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			if slices.Contains(tc.args, "-x264-params") {
-				t.Errorf("-x264-params passed to a libvpx-vp9 encode: %v", tc.args)
+	t.Run("vp9 output carries a thread cap", func(t *testing.T) {
+		args := buildTrimArgs(src, dir+"/out.webm", "video/webm", 0, 1)
+		lastInput := 0
+		for i, a := range args {
+			if a == "-i" {
+				lastInput = i
 			}
-		})
-	}
-}
-
-// ffmpeg binds an option to the next file, so thread caps reach the input
-// decoder only when they precede -i. Placed after it they configure the encoder
-// instead and the decoder pool keeps sizing itself from the node's CPU count.
-func TestBuildersBoundThreadsBeforeTheInput(t *testing.T) {
-	for _, tc := range []struct {
-		name string
-		args []string
-	}{
-		{"transcode", buildTranscodeArgs("in.webm", "out.mp4", "")},
-		{"normalize", buildNormalizeArgs("in.mp4", "out.mp4", "")},
-		{"trim mp4", buildTrimArgs("in.mp4", "out.mp4", "video/mp4", 1, 5)},
-		{"trim webm", buildTrimArgs("in.webm", "out.webm", "video/webm", 1, 5)},
-		{"composite mp4", buildCompositeArgs("s.mp4", "w.mp4", "out.mp4", "video/mp4")},
-		{"composite webm", buildCompositeArgs("s.webm", "w.webm", "out.webm", "video/webm")},
-		{"remove-segments mp4", buildRemoveSegmentsArgs("in.mp4", "out.mp4", "video/mp4", []segmentRange{{Start: 1, End: 2}}, true)},
-		{"remove-segments webm", buildRemoveSegmentsArgs("in.webm", "out.webm", "video/webm", []segmentRange{{Start: 1, End: 2}}, true)},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			firstInput := slices.Index(tc.args, "-i")
-			if firstInput == -1 {
-				t.Fatalf("no input in %v", tc.args)
-			}
-			for _, flag := range []string{"-threads", "-filter_threads", "-filter_complex_threads"} {
-				at := slices.Index(tc.args, flag)
-				if at == -1 {
-					t.Errorf("%s missing; the pool then sizes itself from the node's CPU count", flag)
-					continue
-				}
-				if at > firstInput {
-					t.Errorf("%s at %d comes after the input at %d, so it never reaches the decoder", flag, at, firstInput)
-				}
-			}
-		})
-	}
+		}
+		if !slices.Contains(args[lastInput:], "-threads") {
+			t.Fatal("vp9 output has no encoder-side thread cap; libvpx would use one thread per CPU")
+		}
+		if out, err := exec.Command("ffmpeg", append([]string{"-nostdin", "-loglevel", "error"}, args...)...).CombinedOutput(); err != nil {
+			t.Fatalf("vp9 command rejected by ffmpeg: %v: %s", err, out)
+		}
+	})
 }

--- a/internal/video/normalize.go
+++ b/internal/video/normalize.go
@@ -109,7 +109,8 @@ var probeVideoProperties = func(inputPath string) (videoProperties, error) {
 }
 
 func buildNormalizeArgs(inputPath, outputPath, audioFilter string) []string {
-	args := append(ffmpegPipelineThreads(),
+	args := append(globalThreads(), inputThreads()...)
+	args = append(args,
 		"-i", inputPath,
 		"-c:v", "libx264",
 		"-profile:v", "high",
@@ -119,7 +120,7 @@ func buildNormalizeArgs(inputPath, outputPath, audioFilter string) []string {
 		"-vf", "scale='min(1920,iw)':'min(1080,ih)':force_original_aspect_ratio=decrease:force_divisible_by=2",
 		"-r", "60",
 	)
-	args = append(args, x264MemoryParams()...)
+	args = appendEncoderBounds(args, "video/mp4")
 	if audioFilter != "" {
 		args = append(args, "-af", audioFilter)
 	}

--- a/internal/video/normalize.go
+++ b/internal/video/normalize.go
@@ -109,7 +109,7 @@ var probeVideoProperties = func(inputPath string) (videoProperties, error) {
 }
 
 func buildNormalizeArgs(inputPath, outputPath, audioFilter string) []string {
-	args := []string{
+	args := append(ffmpegPipelineThreads(),
 		"-i", inputPath,
 		"-c:v", "libx264",
 		"-profile:v", "high",
@@ -118,7 +118,7 @@ func buildNormalizeArgs(inputPath, outputPath, audioFilter string) []string {
 		"-crf", "23",
 		"-vf", "scale='min(1920,iw)':'min(1080,ih)':force_original_aspect_ratio=decrease:force_divisible_by=2",
 		"-r", "60",
-	}
+	)
 	args = append(args, x264MemoryParams()...)
 	if audioFilter != "" {
 		args = append(args, "-af", audioFilter)

--- a/internal/video/normalize.go
+++ b/internal/video/normalize.go
@@ -119,6 +119,7 @@ func buildNormalizeArgs(inputPath, outputPath, audioFilter string) []string {
 		"-vf", "scale='min(1920,iw)':'min(1080,ih)':force_original_aspect_ratio=decrease:force_divisible_by=2",
 		"-r", "60",
 	}
+	args = append(args, x264MemoryParams()...)
 	if audioFilter != "" {
 		args = append(args, "-af", audioFilter)
 	}

--- a/internal/video/remove_segments.go
+++ b/internal/video/remove_segments.go
@@ -149,7 +149,7 @@ func audioCodecForContentType(ct string) string {
 func buildRemoveSegmentsArgs(inputPath, outputPath, contentType string, segments []segmentRange, audioPresent bool) []string {
 	betweenExpr := buildSegmentFilter(segments)
 
-	var args []string
+	args := ffmpegPipelineThreads()
 	args = append(args, "-i", inputPath)
 
 	if audioPresent {

--- a/internal/video/remove_segments.go
+++ b/internal/video/remove_segments.go
@@ -160,6 +160,7 @@ func buildRemoveSegmentsArgs(inputPath, outputPath, contentType string, segments
 		args = append(args, "-filter_complex", filterComplex)
 		args = append(args, "-map", "[v]", "-map", "[a]")
 		args = append(args, "-c:v", videoCodecForContentType(contentType), "-c:a", audioCodecForContentType(contentType))
+		args = appendX264Params(args, contentType)
 	} else {
 		filterComplex := fmt.Sprintf(
 			"[0:v]select='not(%s)',setpts=N/FRAME_RATE/TB[v]",
@@ -168,6 +169,7 @@ func buildRemoveSegmentsArgs(inputPath, outputPath, contentType string, segments
 		args = append(args, "-filter_complex", filterComplex)
 		args = append(args, "-map", "[v]")
 		args = append(args, "-c:v", videoCodecForContentType(contentType), "-an")
+		args = appendX264Params(args, contentType)
 	}
 
 	args = append(args, "-y", outputPath)

--- a/internal/video/remove_segments.go
+++ b/internal/video/remove_segments.go
@@ -149,7 +149,7 @@ func audioCodecForContentType(ct string) string {
 func buildRemoveSegmentsArgs(inputPath, outputPath, contentType string, segments []segmentRange, audioPresent bool) []string {
 	betweenExpr := buildSegmentFilter(segments)
 
-	args := ffmpegPipelineThreads()
+	args := append(globalThreads(), inputThreads()...)
 	args = append(args, "-i", inputPath)
 
 	if audioPresent {
@@ -160,7 +160,6 @@ func buildRemoveSegmentsArgs(inputPath, outputPath, contentType string, segments
 		args = append(args, "-filter_complex", filterComplex)
 		args = append(args, "-map", "[v]", "-map", "[a]")
 		args = append(args, "-c:v", videoCodecForContentType(contentType), "-c:a", audioCodecForContentType(contentType))
-		args = appendX264Params(args, contentType)
 	} else {
 		filterComplex := fmt.Sprintf(
 			"[0:v]select='not(%s)',setpts=N/FRAME_RATE/TB[v]",
@@ -169,9 +168,9 @@ func buildRemoveSegmentsArgs(inputPath, outputPath, contentType string, segments
 		args = append(args, "-filter_complex", filterComplex)
 		args = append(args, "-map", "[v]")
 		args = append(args, "-c:v", videoCodecForContentType(contentType), "-an")
-		args = appendX264Params(args, contentType)
 	}
 
+	args = appendEncoderBounds(args, contentType)
 	args = append(args, "-y", outputPath)
 	return args
 }

--- a/internal/video/silence.go
+++ b/internal/video/silence.go
@@ -141,15 +141,21 @@ func parseSilenceDetectOutput(stderr string) []segmentRange {
 	return segments
 }
 
-func detectSilence(inputPath string, noiseDB int, minDuration float64) ([]segmentRange, error) {
+func buildSilenceArgs(inputPath string, noiseDB int, minDuration float64) []string {
 	filterValue := fmt.Sprintf("silencedetect=noise=%ddB:d=%.2f", noiseDB, minDuration)
-	cmd := exec.Command("ffmpeg",
+	args := append(globalThreads(), inputThreads()...)
+	return append(args,
 		"-i", inputPath,
 		"-vn",
 		"-af", filterValue,
 		"-f", "null",
 		"-",
 	)
+}
+
+func detectSilence(inputPath string, noiseDB int, minDuration float64) ([]segmentRange, error) {
+	args := buildSilenceArgs(inputPath, noiseDB, minDuration)
+	cmd := exec.Command("ffmpeg", args...)
 
 	output, err := cmd.CombinedOutput()
 	if err != nil {

--- a/internal/video/thumbnail.go
+++ b/internal/video/thumbnail.go
@@ -102,8 +102,9 @@ func thumbnailFileKey(userID, shareToken string) string {
 	return fmt.Sprintf("recordings/%s/%s.jpg", userID, shareToken)
 }
 
-func extractFrameAt(inputPath, outputPath string, seekSeconds int) error {
-	cmd := exec.Command("ffmpeg",
+func buildThumbnailArgs(inputPath, outputPath string, seekSeconds int) []string {
+	args := append(globalThreads(), inputThreads()...)
+	return append(args,
 		"-i", inputPath,
 		"-ss", fmt.Sprintf("%d", seekSeconds),
 		"-frames:v", "1",
@@ -112,6 +113,10 @@ func extractFrameAt(inputPath, outputPath string, seekSeconds int) error {
 		"-y",
 		outputPath,
 	)
+}
+
+func extractFrameAt(inputPath, outputPath string, seekSeconds int) error {
+	cmd := exec.Command("ffmpeg", buildThumbnailArgs(inputPath, outputPath, seekSeconds)...)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("ffmpeg: %w: %s", err, string(output))

--- a/internal/video/transcode.go
+++ b/internal/video/transcode.go
@@ -13,7 +13,7 @@ import (
 )
 
 func buildTranscodeArgs(inputPath, outputPath, audioFilter string) []string {
-	args := []string{
+	args := append(ffmpegPipelineThreads(),
 		"-i", inputPath,
 		"-c:v", "libx264",
 		"-profile:v", "high",
@@ -22,7 +22,7 @@ func buildTranscodeArgs(inputPath, outputPath, audioFilter string) []string {
 		"-crf", "23",
 		"-vf", "scale='min(1920,iw)':'min(1080,ih)':force_original_aspect_ratio=decrease:force_divisible_by=2",
 		"-r", "60",
-	}
+	)
 	args = append(args, x264MemoryParams()...)
 	if audioFilter != "" {
 		args = append(args, "-af", audioFilter)

--- a/internal/video/transcode.go
+++ b/internal/video/transcode.go
@@ -13,7 +13,8 @@ import (
 )
 
 func buildTranscodeArgs(inputPath, outputPath, audioFilter string) []string {
-	args := append(ffmpegPipelineThreads(),
+	args := append(globalThreads(), inputThreads()...)
+	args = append(args,
 		"-i", inputPath,
 		"-c:v", "libx264",
 		"-profile:v", "high",
@@ -23,7 +24,7 @@ func buildTranscodeArgs(inputPath, outputPath, audioFilter string) []string {
 		"-vf", "scale='min(1920,iw)':'min(1080,ih)':force_original_aspect_ratio=decrease:force_divisible_by=2",
 		"-r", "60",
 	)
-	args = append(args, x264MemoryParams()...)
+	args = appendEncoderBounds(args, "video/mp4")
 	if audioFilter != "" {
 		args = append(args, "-af", audioFilter)
 	}

--- a/internal/video/transcode.go
+++ b/internal/video/transcode.go
@@ -23,6 +23,7 @@ func buildTranscodeArgs(inputPath, outputPath, audioFilter string) []string {
 		"-vf", "scale='min(1920,iw)':'min(1080,ih)':force_original_aspect_ratio=decrease:force_divisible_by=2",
 		"-r", "60",
 	}
+	args = append(args, x264MemoryParams()...)
 	if audioFilter != "" {
 		args = append(args, "-af", audioFilter)
 	}

--- a/internal/video/transcribe.go
+++ b/internal/video/transcribe.go
@@ -52,11 +52,9 @@ func hasAudioStream(inputPath string) bool {
 	return strings.TrimSpace(string(output)) != ""
 }
 
-func extractAudio(inputPath, outputPath string) error {
-	if !hasAudioStream(inputPath) {
-		return errNoAudio
-	}
-	cmd := exec.Command("ffmpeg",
+func buildAudioExtractArgs(inputPath, outputPath string) []string {
+	args := append(globalThreads(), inputThreads()...)
+	return append(args,
 		"-i", inputPath,
 		"-ar", "16000",
 		"-ac", "1",
@@ -64,6 +62,13 @@ func extractAudio(inputPath, outputPath string) error {
 		"-y",
 		outputPath,
 	)
+}
+
+func extractAudio(inputPath, outputPath string) error {
+	if !hasAudioStream(inputPath) {
+		return errNoAudio
+	}
+	cmd := exec.Command("ffmpeg", buildAudioExtractArgs(inputPath, outputPath)...)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("ffmpeg audio extraction: %w: %s", err, string(output))

--- a/internal/video/trim.go
+++ b/internal/video/trim.go
@@ -19,7 +19,7 @@ func videoCodecForContentType(ct string) string {
 	}
 }
 
-func trimVideo(inputPath, outputPath, contentType string, startSeconds, endSeconds float64) error {
+func buildTrimArgs(inputPath, outputPath, contentType string, startSeconds, endSeconds float64) []string {
 	var args []string
 	if contentType == "video/mp4" || contentType == "video/quicktime" {
 		// iOS-safe encoding: constrain resolution, set profile/level, transcode audio to AAC
@@ -50,6 +50,12 @@ func trimVideo(inputPath, outputPath, contentType string, startSeconds, endSecon
 			outputPath,
 		}
 	}
+
+	return appendX264Params(args, contentType)
+}
+
+func trimVideo(inputPath, outputPath, contentType string, startSeconds, endSeconds float64) error {
+	args := buildTrimArgs(inputPath, outputPath, contentType, startSeconds, endSeconds)
 
 	cmd := exec.Command("ffmpeg", args...)
 	output, err := cmd.CombinedOutput()

--- a/internal/video/trim.go
+++ b/internal/video/trim.go
@@ -36,8 +36,6 @@ func buildTrimArgs(inputPath, outputPath, contentType string, startSeconds, endS
 			"-r", "60",
 			"-c:a", "aac",
 			"-movflags", "+faststart",
-			"-y",
-			outputPath,
 		}
 	} else {
 		args = []string{
@@ -46,12 +44,13 @@ func buildTrimArgs(inputPath, outputPath, contentType string, startSeconds, endS
 			"-to", fmt.Sprintf("%.3f", endSeconds),
 			"-c:v", "libvpx-vp9",
 			"-c:a", "copy",
-			"-y",
-			outputPath,
 		}
 	}
 
-	return appendX264Params(args, contentType)
+	// The bounds have to precede the output: ffmpeg applies options to the output
+	// that follows them and discards anything after the last one.
+	args = appendX264Params(args, contentType)
+	return append(args, "-y", outputPath)
 }
 
 func trimVideo(inputPath, outputPath, contentType string, startSeconds, endSeconds float64) error {

--- a/internal/video/trim.go
+++ b/internal/video/trim.go
@@ -23,7 +23,8 @@ func buildTrimArgs(inputPath, outputPath, contentType string, startSeconds, endS
 	var args []string
 	if contentType == "video/mp4" || contentType == "video/quicktime" {
 		// iOS-safe encoding: constrain resolution, set profile/level, transcode audio to AAC
-		args = append(ffmpegPipelineThreads(),
+		args = append(globalThreads(), inputThreads()...)
+		args = append(args,
 			"-i", inputPath,
 			"-ss", fmt.Sprintf("%.3f", startSeconds),
 			"-to", fmt.Sprintf("%.3f", endSeconds),
@@ -38,7 +39,8 @@ func buildTrimArgs(inputPath, outputPath, contentType string, startSeconds, endS
 			"-movflags", "+faststart",
 		)
 	} else {
-		args = append(ffmpegPipelineThreads(),
+		args = append(globalThreads(), inputThreads()...)
+		args = append(args,
 			"-i", inputPath,
 			"-ss", fmt.Sprintf("%.3f", startSeconds),
 			"-to", fmt.Sprintf("%.3f", endSeconds),
@@ -49,7 +51,7 @@ func buildTrimArgs(inputPath, outputPath, contentType string, startSeconds, endS
 
 	// The bounds have to precede the output: ffmpeg applies options to the output
 	// that follows them and discards anything after the last one.
-	args = appendX264Params(args, contentType)
+	args = appendEncoderBounds(args, contentType)
 	return append(args, "-y", outputPath)
 }
 

--- a/internal/video/trim.go
+++ b/internal/video/trim.go
@@ -23,7 +23,7 @@ func buildTrimArgs(inputPath, outputPath, contentType string, startSeconds, endS
 	var args []string
 	if contentType == "video/mp4" || contentType == "video/quicktime" {
 		// iOS-safe encoding: constrain resolution, set profile/level, transcode audio to AAC
-		args = []string{
+		args = append(ffmpegPipelineThreads(),
 			"-i", inputPath,
 			"-ss", fmt.Sprintf("%.3f", startSeconds),
 			"-to", fmt.Sprintf("%.3f", endSeconds),
@@ -36,15 +36,15 @@ func buildTrimArgs(inputPath, outputPath, contentType string, startSeconds, endS
 			"-r", "60",
 			"-c:a", "aac",
 			"-movflags", "+faststart",
-		}
+		)
 	} else {
-		args = []string{
+		args = append(ffmpegPipelineThreads(),
 			"-i", inputPath,
 			"-ss", fmt.Sprintf("%.3f", startSeconds),
 			"-to", fmt.Sprintf("%.3f", endSeconds),
 			"-c:v", "libvpx-vp9",
 			"-c:a", "copy",
-		}
+		)
 	}
 
 	// The bounds have to precede the output: ffmpeg applies options to the output


### PR DESCRIPTION
## What does this PR do?

Bounds ffmpeg's memory so a video edit cannot take the pod down with it, and sizes the chart for the workload the app actually runs. Addresses the memory half of #202.

Every ffmpeg encode runs in the process that serves HTTP, so peak resident memory is an availability concern: a job that needs more than the pod has drops every in-flight request, not just the edit. That is how #200 happened.

### The change

Two bounds, for two different pools.

**Encoder** — `-x264-params rc-lookahead=10:ref=1:bframes=0` applied at all five libx264 builders and only those. Roughly 540 MB down to 340 MB on a 1080p30 source, and about a third off the wall time, because those settings are work as well as memory. Output grows ~11% at the same CRF. `profile=high` and `level=5.1` survive, confirmed with ffprobe.

**Pipeline** — `-threads 4 -filter_threads 4 -filter_complex_threads 4` before the first `-i`. Capping the encoder alone is not a bound: the input decoder and both filter graphs size themselves from the visible CPU count independently. Same command, same x264 header, varying only how many CPUs the container sees:

| | encoder cap only | whole pipeline |
| --- | --- | --- |
| 1 CPU | 268 MB | 296 MB |
| 2 CPUs | 287 MB | 296 MB |
| 4 CPUs | 300 MB | 296 MB |

The encoder-only column tracks the node; the whole-pipeline column does not. Measured to 4 CPUs, the test machine's limit, so flatness is demonstrated rather than proven for larger nodes. These apply to vp9 paths too, which were never bounded — decoding and filtering happen whatever the output codec is.

**Chart** — requests `512Mi` instead of `128Mi`, which was enough to serve requests and not enough to finish an edit. No default memory limit: the app does not bound encoder concurrency, so any limit here would be a kill threshold guessed without knowing your inputs. `values.yaml` says so. A *Sizing the pod* section and a SELF-HOSTING.md prerequisite document the floor, which nothing did before.

**Harness** — `hack/encoder-memory/run.sh` reproduces every figure quoted above, including the portability sweep. Figures are approximate on purpose: they move with the ffmpeg build, the input and the machine, so the ratios are the finding and the megabytes are one sample.

### Review history

Two rounds, both of which found real defects in this PR.

Round one found the bounds **inert** in trim and composite — appended after the output URL, so ffmpeg discarded them as trailing options and the encoder ran on defaults, ~540 MB with the flag sitting in the command line. The tests asserted the token was present, never its position.

Round two found the thread cap **insufficient** — it bounded the encoder while the decoder and filter pools still scaled with the node, which is the table above.

Both are fixed, and both had the same shape: configuration that is present, asserted by tests, and has no effect. The tests now assert placement relative to both the input and the output, across all branches including vp9.

### Worth a look during review

The fix for round two is itself unreviewed, and this PR has now shipped a non-binding bound twice. The placement rules are the part to check.

### Known gaps, deliberately not addressed here

- **The load-bearing measurement is still missing.** Pod cgroup `memory.peak` — Go server plus ffmpeg — on representative production recordings, at the largest supported CPU count, including concurrent jobs. Everything here measures ffmpeg's `VmHWM` for one job. The thread cap makes the ceiling node-independent, which was the part that would have invalidated the sizing outright, but it does not establish that `512Mi` is right.
- **`512Mi` does not survive unbounded concurrency.** Two concurrent encodes already exceed it before the Go process. Bounding encoder concurrency is separate work.
- **ffmpeg outlives its context** at all eight call sites — `exec.Command` rather than `exec.CommandContext`. Tracked as #206, and the reason the old "a thread cap risks the 10 minute timeout" rationale was false.

## How to test

`make test`. New tests in `internal/video/encoder_params_test.go` cover the bounds' presence, their absence on vp9, placement before the input, and placement before the output. `hack/encoder-memory/run.sh` reproduces the measurements; expect roughly 15 minutes.

## Checklist

- [x] `make test` passes
- [x] `make build` succeeds
- [x] New code has tests where applicable
- [x] No unrelated changes included