### PR TITLE
fix: bind ffmpeg and ffprobe to the caller's context

### DIFF
--- a/internal/video/composite.go
+++ b/internal/video/composite.go
@@ -11,8 +11,8 @@ import (
 	"github.com/sendrec/sendrec/internal/database"
 )
 
-func probeVideoInfo(path string) (frames int, info string, err error) {
-	cmd := exec.Command("ffprobe",
+func probeVideoInfo(ctx context.Context, path string) (frames int, info string, err error) {
+	cmd := exec.CommandContext(ctx, "ffprobe",
 		"-v", "error",
 		"-select_streams", "v:0",
 		"-count_frames",
@@ -85,10 +85,10 @@ func buildCompositeArgs(screenPath, webcamPath, outputPath, contentType string) 
 	return append(args, "-y", outputPath)
 }
 
-func compositeOverlay(screenPath, webcamPath, outputPath, contentType string) (string, error) {
+func compositeOverlay(ctx context.Context, screenPath, webcamPath, outputPath, contentType string) (string, error) {
 	args := buildCompositeArgs(screenPath, webcamPath, outputPath, contentType)
 
-	cmd := exec.Command("ffmpeg", args...)
+	cmd := exec.CommandContext(ctx, "ffmpeg", args...)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		return string(output), fmt.Errorf("ffmpeg composite: %w: %s", err, string(output))
@@ -155,7 +155,7 @@ func CompositeWithWebcam(ctx context.Context, db database.DBTX, storage ObjectSt
 	slog.Info("composite: files downloaded", "video_id", videoID, "screen_bytes", screenSize, "webcam_bytes", webcamSize)
 
 	// Verify both inputs have video frames before compositing
-	screenFrames, screenProbeInfo, screenProbeErr := probeVideoInfo(tmpScreenPath)
+	screenFrames, screenProbeInfo, screenProbeErr := probeVideoInfo(ctx, tmpScreenPath)
 	if screenProbeErr != nil || screenFrames == 0 {
 		slog.Warn("composite: screen has no video frames, skipping overlay", "video_id", videoID, "screen_bytes", screenSize, "probe_error", screenProbeErr)
 		setReadyFallback()
@@ -163,7 +163,7 @@ func CompositeWithWebcam(ctx context.Context, db database.DBTX, storage ObjectSt
 	}
 	slog.Info("composite: screen validated", "video_id", videoID, "screen_frames", screenFrames, "screen_info", screenProbeInfo)
 
-	webcamFrames, webcamProbeInfo, probeErr := probeVideoInfo(tmpWebcamPath)
+	webcamFrames, webcamProbeInfo, probeErr := probeVideoInfo(ctx, tmpWebcamPath)
 	if probeErr != nil {
 		slog.Error("composite: webcam probe failed", "video_id", videoID, "error", probeErr)
 		setReadyFallback()
@@ -186,7 +186,7 @@ func CompositeWithWebcam(ctx context.Context, db database.DBTX, storage ObjectSt
 	_ = tmpOutput.Close()
 	defer func() { _ = os.Remove(tmpOutputPath) }()
 
-	ffmpegOutput, err := compositeOverlay(tmpScreenPath, tmpWebcamPath, tmpOutputPath, contentType)
+	ffmpegOutput, err := compositeOverlay(ctx, tmpScreenPath, tmpWebcamPath, tmpOutputPath, contentType)
 	if err != nil {
 		slog.Error("composite: ffmpeg failed", "video_id", videoID, "error", err, "ffmpeg_output", ffmpegOutput)
 		setReadyFallback()

--- a/internal/video/ffmpeg_context_test.go
+++ b/internal/video/ffmpeg_context_test.go
@@ -1,0 +1,58 @@
+package video
+
+import (
+	"context"
+	"errors"
+	"os/exec"
+	"testing"
+)
+
+// Every ffmpeg call used exec.Command, so the 10 minute contexts the callers
+// construct never reached the process: a pathological input could hold an
+// encoder open indefinitely, and a job whose deadline passed kept its ~300 MB
+// allocation alive while the caller had already moved on.
+//
+// A cancelled context has to stop the command before it starts. That is the
+// cheapest observable proof the context is wired through at all.
+func TestFFmpegRespectsContextCancellation(t *testing.T) {
+	if _, err := exec.LookPath("ffmpeg"); err != nil {
+		t.Skip("ffmpeg not installed; this asserts wiring, not encoding")
+	}
+
+	cancelled := func() context.Context {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		return ctx
+	}
+
+	dir := t.TempDir()
+
+	for _, tc := range []struct {
+		name string
+		run  func(context.Context) error
+	}{
+		{"transcode", func(ctx context.Context) error { return transcodeToMP4(ctx, "in.webm", dir+"/o.mp4", "") }},
+		{"normalize", func(ctx context.Context) error { return transcodeToIOSCompatible(ctx, "in.mp4", dir+"/o.mp4", "") }},
+		{"trim", func(ctx context.Context) error { return trimVideo(ctx, "in.mp4", dir+"/o.mp4", "video/mp4", 0, 1) }},
+		{"remove segments", func(ctx context.Context) error {
+			return removeSegmentsFromVideo(ctx, "in.mp4", dir+"/o.mp4", "video/mp4", []segmentRange{{Start: 0, End: 1}}, false)
+		}},
+		{"composite", func(ctx context.Context) error {
+			_, err := compositeOverlay(ctx, "s.mp4", "w.mp4", dir+"/o.mp4", "video/mp4")
+			return err
+		}},
+		{"silence detect", func(ctx context.Context) error { _, err := detectSilence(ctx, "in.mp4", -30, 0.5); return err }},
+		{"thumbnail", func(ctx context.Context) error { return extractFrameAt(ctx, "in.mp4", dir+"/o.jpg", 0) }},
+		{"audio extract", func(ctx context.Context) error { return extractAudioAt(ctx, "in.mp4", dir+"/o.wav") }},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.run(cancelled())
+			if err == nil {
+				t.Fatal("cancelled context produced no error; ffmpeg is not bound to it")
+			}
+			if !errors.Is(err, context.Canceled) {
+				t.Errorf("error does not wrap context.Canceled, so cancellation did not reach ffmpeg: %v", err)
+			}
+		})
+	}
+}

--- a/internal/video/normalize.go
+++ b/internal/video/normalize.go
@@ -76,8 +76,8 @@ type ffprobeResult struct {
 }
 
 // See transcodeToMP4 for why this is a var.
-var probeVideoProperties = func(inputPath string) (videoProperties, error) {
-	cmd := exec.Command("ffprobe",
+var probeVideoProperties = func(ctx context.Context, inputPath string) (videoProperties, error) {
+	cmd := exec.CommandContext(ctx, "ffprobe",
 		"-v", "error",
 		"-select_streams", "v:0",
 		"-show_entries", "stream=width,height,level,r_frame_rate,codec_name",
@@ -129,9 +129,9 @@ func buildNormalizeArgs(inputPath, outputPath, audioFilter string) []string {
 }
 
 // See transcodeToMP4 for why this is a var.
-var transcodeToIOSCompatible = func(inputPath, outputPath, audioFilter string) error {
+var transcodeToIOSCompatible = func(ctx context.Context, inputPath, outputPath, audioFilter string) error {
 	args := buildNormalizeArgs(inputPath, outputPath, audioFilter)
-	cmd := exec.Command("ffmpeg", args...)
+	cmd := exec.CommandContext(ctx, "ffmpeg", args...)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("ffmpeg normalize: %w: %s", err, string(output))
@@ -174,7 +174,7 @@ func NormalizeVideoAsync(ctx context.Context, db database.DBTX, storage ObjectSt
 		return
 	}
 
-	props, err := probeVideoProperties(tmpInputPath)
+	props, err := probeVideoProperties(ctx, tmpInputPath)
 	if err != nil {
 		slog.Warn("normalize: probe failed, marking normalized", "video_id", videoID, "error", err)
 		markIOSNormalized(ctx, db, videoID)
@@ -201,7 +201,7 @@ func NormalizeVideoAsync(ctx context.Context, db database.DBTX, storage ObjectSt
 	_ = tmpOutput.Close()
 	defer func() { _ = os.Remove(tmpOutputPath) }()
 
-	if err := transcodeToIOSCompatible(tmpInputPath, tmpOutputPath, audioFilter); err != nil {
+	if err := transcodeToIOSCompatible(ctx, tmpInputPath, tmpOutputPath, audioFilter); err != nil {
 		slog.Error("normalize: ffmpeg failed", "video_id", videoID, "error", err)
 		recordTranscodeFailure(ctx, db, videoID, err)
 		return

--- a/internal/video/probe.go
+++ b/internal/video/probe.go
@@ -28,7 +28,7 @@ func probeDuration(ctx context.Context, db database.DBTX, storage ObjectStorage,
 		return
 	}
 
-	cmd := exec.Command("ffprobe",
+	cmd := exec.CommandContext(ctx, "ffprobe",
 		"-v", "error",
 		"-show_entries", "format=duration",
 		"-of", "default=noprint_wrappers=1:nokey=1",

--- a/internal/video/remove_segments.go
+++ b/internal/video/remove_segments.go
@@ -175,10 +175,10 @@ func buildRemoveSegmentsArgs(inputPath, outputPath, contentType string, segments
 	return args
 }
 
-func removeSegmentsFromVideo(inputPath, outputPath, contentType string, segments []segmentRange, audioPresent bool) error {
+func removeSegmentsFromVideo(ctx context.Context, inputPath, outputPath, contentType string, segments []segmentRange, audioPresent bool) error {
 	args := buildRemoveSegmentsArgs(inputPath, outputPath, contentType, segments, audioPresent)
 
-	cmd := exec.Command("ffmpeg", args...)
+	cmd := exec.CommandContext(ctx, "ffmpeg", args...)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("ffmpeg remove segments: %w: %s", err, string(output))
@@ -215,7 +215,7 @@ func RemoveSegmentsAsync(ctx context.Context, db database.DBTX, storage ObjectSt
 		return
 	}
 
-	audioPresent := hasAudioStream(tmpInputPath)
+	audioPresent := hasAudioStream(ctx, tmpInputPath)
 
 	tmpOutput, err := os.CreateTemp("", "sendrec-remseg-output-*"+ext)
 	if err != nil {
@@ -227,7 +227,7 @@ func RemoveSegmentsAsync(ctx context.Context, db database.DBTX, storage ObjectSt
 	_ = tmpOutput.Close()
 	defer func() { _ = os.Remove(tmpOutputPath) }()
 
-	if err := removeSegmentsFromVideo(tmpInputPath, tmpOutputPath, contentType, segments, audioPresent); err != nil {
+	if err := removeSegmentsFromVideo(ctx, tmpInputPath, tmpOutputPath, contentType, segments, audioPresent); err != nil {
 		slog.Error("remove-segments: ffmpeg failed", "video_id", videoID, "error", err)
 		setReadyFallback()
 		return

--- a/internal/video/silence.go
+++ b/internal/video/silence.go
@@ -1,6 +1,7 @@
 package video
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"log/slog"
@@ -76,7 +77,7 @@ func (h *Handler) DetectSilence(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	segments, err := detectSilence(downloadURL, noiseDB, minDuration)
+	segments, err := detectSilence(r.Context(), downloadURL, noiseDB, minDuration)
 	if err != nil {
 		slog.Error("detect-silence: ffmpeg failed", "video_id", videoID, "error", err)
 		httputil.WriteError(w, http.StatusInternalServerError, "failed to detect silence")
@@ -153,9 +154,9 @@ func buildSilenceArgs(inputPath string, noiseDB int, minDuration float64) []stri
 	)
 }
 
-func detectSilence(inputPath string, noiseDB int, minDuration float64) ([]segmentRange, error) {
+func detectSilence(ctx context.Context, inputPath string, noiseDB int, minDuration float64) ([]segmentRange, error) {
 	args := buildSilenceArgs(inputPath, noiseDB, minDuration)
-	cmd := exec.Command("ffmpeg", args...)
+	cmd := exec.CommandContext(ctx, "ffmpeg", args...)
 
 	output, err := cmd.CombinedOutput()
 	if err != nil {

--- a/internal/video/thumbnail.go
+++ b/internal/video/thumbnail.go
@@ -115,8 +115,8 @@ func buildThumbnailArgs(inputPath, outputPath string, seekSeconds int) []string 
 	)
 }
 
-func extractFrameAt(inputPath, outputPath string, seekSeconds int) error {
-	cmd := exec.Command("ffmpeg", buildThumbnailArgs(inputPath, outputPath, seekSeconds)...)
+func extractFrameAt(ctx context.Context, inputPath, outputPath string, seekSeconds int) error {
+	cmd := exec.CommandContext(ctx, "ffmpeg", buildThumbnailArgs(inputPath, outputPath, seekSeconds)...)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("ffmpeg: %w: %s", err, string(output))
@@ -124,8 +124,8 @@ func extractFrameAt(inputPath, outputPath string, seekSeconds int) error {
 	return nil
 }
 
-func extractFrame(inputPath, outputPath string) error {
-	return extractFrameAt(inputPath, outputPath, 2)
+func extractFrame(ctx context.Context, inputPath, outputPath string) error {
+	return extractFrameAt(ctx, inputPath, outputPath, 2)
 }
 
 func GenerateThumbnail(ctx context.Context, db database.DBTX, storage ObjectStorage, videoID, fileKey, thumbnailKey string) {
@@ -152,7 +152,7 @@ func GenerateThumbnail(ctx context.Context, db database.DBTX, storage ObjectStor
 	_ = tmpThumb.Close()
 	defer func() { _ = os.Remove(tmpThumbPath) }()
 
-	if err := extractFrame(tmpVideoPath, tmpThumbPath); err != nil {
+	if err := extractFrame(ctx, tmpVideoPath, tmpThumbPath); err != nil {
 		slog.Error("thumbnail: ffmpeg failed", "video_id", videoID, "error", err)
 		return
 	}
@@ -160,7 +160,7 @@ func GenerateThumbnail(ctx context.Context, db database.DBTX, storage ObjectStor
 	// If -ss 2 produced a 0-byte file (video shorter than 2s), retry at the start
 	if info, err := os.Stat(tmpThumbPath); err == nil && info.Size() == 0 {
 		slog.Warn("thumbnail: video too short for seek=2, retrying at seek=0", "video_id", videoID)
-		if err := extractFrameAt(tmpVideoPath, tmpThumbPath, 0); err != nil {
+		if err := extractFrameAt(ctx, tmpVideoPath, tmpThumbPath, 0); err != nil {
 			slog.Error("thumbnail: ffmpeg retry failed", "video_id", videoID, "error", err)
 			return
 		}

--- a/internal/video/thumbnail_test.go
+++ b/internal/video/thumbnail_test.go
@@ -28,7 +28,7 @@ func TestExtractFrame_InvalidInput(t *testing.T) {
 		t.Skip("ffmpeg not installed")
 	}
 
-	err := extractFrame("/nonexistent/input.webm", "/tmp/sendrec-test-output.jpg")
+	err := extractFrame(context.Background(), "/nonexistent/input.webm", "/tmp/sendrec-test-output.jpg")
 	if err == nil {
 		t.Error("expected error for nonexistent input file")
 	}
@@ -78,7 +78,7 @@ func TestExtractFrameAt_InvalidInput(t *testing.T) {
 		t.Skip("ffmpeg not installed")
 	}
 
-	err := extractFrameAt("/nonexistent/input.webm", "/tmp/sendrec-test-output.jpg", 2)
+	err := extractFrameAt(context.Background(), "/nonexistent/input.webm", "/tmp/sendrec-test-output.jpg", 2)
 	if err == nil {
 		t.Error("expected error for nonexistent input file")
 	}
@@ -89,7 +89,7 @@ func TestExtractFrameAt_SeekZero(t *testing.T) {
 		t.Skip("ffmpeg not installed")
 	}
 
-	err := extractFrameAt("/nonexistent/input.webm", "/tmp/sendrec-test-output.jpg", 0)
+	err := extractFrameAt(context.Background(), "/nonexistent/input.webm", "/tmp/sendrec-test-output.jpg", 0)
 	if err == nil {
 		t.Error("expected error for nonexistent input file")
 	}

--- a/internal/video/transcode.go
+++ b/internal/video/transcode.go
@@ -34,15 +34,21 @@ func buildTranscodeArgs(inputPath, outputPath, audioFilter string) []string {
 
 // Package-level var so tests can reach the steps after ffmpeg without needing
 // an ffmpeg binary or a real video fixture.
-var transcodeToMP4 = func(inputPath, outputPath, audioFilter string) error {
+var transcodeToMP4 = func(ctx context.Context, inputPath, outputPath, audioFilter string) error {
 	args := buildTranscodeArgs(inputPath, outputPath, audioFilter)
-	cmd := exec.Command("ffmpeg", args...)
+	cmd := exec.CommandContext(ctx, "ffmpeg", args...)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("ffmpeg transcode: %w: %s", err, string(output))
 	}
 	return nil
 }
+
+// perJobTimeout bounds a single worker-driven encode. The HTTP-triggered jobs
+// already build a 10 minute context each; the periodic workers passed their own
+// long-lived context straight through, so before ffmpeg was bound to a context
+// that made no difference and now it would mean no deadline at all.
+const perJobTimeout = 10 * time.Minute
 
 // maxTranscodeAttempts bounds how often a single video is fed to ffmpeg before
 // it is abandoned. Without it a corrupt upload is retried on every worker tick
@@ -160,7 +166,7 @@ func TranscodeWebMAsync(ctx context.Context, db database.DBTX, storage ObjectSto
 	_ = tmpOutput.Close()
 	defer func() { _ = os.Remove(tmpOutputPath) }()
 
-	if err := transcodeToMP4(tmpInputPath, tmpOutputPath, audioFilter); err != nil {
+	if err := transcodeToMP4(ctx, tmpInputPath, tmpOutputPath, audioFilter); err != nil {
 		slog.Error("transcode: ffmpeg failed", "video_id", videoID, "error", err)
 		recordTranscodeFailure(ctx, db, videoID, err)
 		return
@@ -218,7 +224,9 @@ func transcodeExistingWebM(ctx context.Context, db database.DBTX, storage Object
 			slog.Error("transcode-worker: failed to scan", "error", err)
 			continue
 		}
-		TranscodeWebMAsync(ctx, db, storage, videoID, fileKey, "")
+		jobCtx, cancel := context.WithTimeout(ctx, perJobTimeout)
+		TranscodeWebMAsync(jobCtx, db, storage, videoID, fileKey, "")
+		cancel()
 	}
 }
 
@@ -242,7 +250,9 @@ func normalizeExistingVideos(ctx context.Context, db database.DBTX, storage Obje
 			slog.Error("normalize-worker: failed to scan", "error", err)
 			continue
 		}
-		NormalizeVideoAsync(ctx, db, storage, videoID, fileKey, "")
+		jobCtx, cancel := context.WithTimeout(ctx, perJobTimeout)
+		NormalizeVideoAsync(jobCtx, db, storage, videoID, fileKey, "")
+		cancel()
 	}
 }
 

--- a/internal/video/transcode_test.go
+++ b/internal/video/transcode_test.go
@@ -345,10 +345,10 @@ func TestNormalizeVideoAsync_StopsWhenBudgetExhausted(t *testing.T) {
 
 // stubFFmpeg replaces the ffmpeg call with one that just writes the output
 // file, so a test can reach the upload and db-update steps that follow.
-func stubFFmpeg(t *testing.T, target *func(string, string, string) error) {
+func stubFFmpeg(t *testing.T, target *func(context.Context, string, string, string) error) {
 	t.Helper()
 	original := *target
-	*target = func(_, outputPath, _ string) error {
+	*target = func(_ context.Context, _, outputPath, _ string) error {
 		return os.WriteFile(outputPath, []byte("fake mp4"), 0o600)
 	}
 	t.Cleanup(func() { *target = original })
@@ -422,7 +422,7 @@ func TestNormalizeVideoAsync_UploadFailureConsumesBudget(t *testing.T) {
 	// Report a non-h264 codec so needsNormalization() is true and the re-encode
 	// path runs instead of the early "already compatible" exit.
 	originalProbe := probeVideoProperties
-	probeVideoProperties = func(string) (videoProperties, error) {
+	probeVideoProperties = func(context.Context, string) (videoProperties, error) {
 		return videoProperties{CodecName: "vp9", Width: 1280, Height: 720}, nil
 	}
 	t.Cleanup(func() { probeVideoProperties = originalProbe })
@@ -477,7 +477,7 @@ func TestNormalizeVideoAsync_DBUpdateFailureConsumesBudget(t *testing.T) {
 
 	stubFFmpeg(t, &transcodeToIOSCompatible)
 	originalProbe := probeVideoProperties
-	probeVideoProperties = func(string) (videoProperties, error) {
+	probeVideoProperties = func(context.Context, string) (videoProperties, error) {
 		return videoProperties{CodecName: "vp9", Width: 1280, Height: 720}, nil
 	}
 	t.Cleanup(func() { probeVideoProperties = originalProbe })

--- a/internal/video/transcribe.go
+++ b/internal/video/transcribe.go
@@ -37,8 +37,8 @@ func isTranscriptionAvailable(t Transcriber) bool {
 
 var errNoAudio = fmt.Errorf("video has no audio stream")
 
-func hasAudioStream(inputPath string) bool {
-	cmd := exec.Command("ffprobe",
+func hasAudioStream(ctx context.Context, inputPath string) bool {
+	cmd := exec.CommandContext(ctx, "ffprobe",
 		"-v", "error",
 		"-select_streams", "a",
 		"-show_entries", "stream=codec_type",
@@ -64,11 +64,17 @@ func buildAudioExtractArgs(inputPath, outputPath string) []string {
 	)
 }
 
-func extractAudio(inputPath, outputPath string) error {
-	if !hasAudioStream(inputPath) {
+func extractAudioAt(ctx context.Context, inputPath, outputPath string) error {
+	if !hasAudioStream(ctx, inputPath) {
+		// hasAudioStream collapses the probe's error into a bool, so a cancelled
+		// context is indistinguishable from a silent input at this level. Report
+		// the cancellation, which is the more useful of the two.
+		if err := ctx.Err(); err != nil {
+			return err
+		}
 		return errNoAudio
 	}
-	cmd := exec.Command("ffmpeg", buildAudioExtractArgs(inputPath, outputPath)...)
+	cmd := exec.CommandContext(ctx, "ffmpeg", buildAudioExtractArgs(inputPath, outputPath)...)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("ffmpeg audio extraction: %w: %s", err, string(output))
@@ -158,7 +164,7 @@ func processTranscription(ctx context.Context, db database.DBTX, storage ObjectS
 	_ = tmpAudio.Close()
 	defer func() { _ = os.Remove(tmpAudioPath) }()
 
-	if err := extractAudio(tmpVideoPath, tmpAudioPath); err != nil {
+	if err := extractAudioAt(ctx, tmpVideoPath, tmpAudioPath); err != nil {
 		if errors.Is(err, errNoAudio) {
 			slog.Info("transcribe: video has no audio stream", "video_id", videoID)
 			if _, dbErr := db.Exec(ctx,

--- a/internal/video/transcribe_test.go
+++ b/internal/video/transcribe_test.go
@@ -1,6 +1,7 @@
 package video
 
 import (
+	"context"
 	"errors"
 	"os"
 	"os/exec"
@@ -140,7 +141,7 @@ func TestExtractAudio_NoAudioStream(t *testing.T) {
 	_ = tmpAudio.Close()
 	defer func() { _ = os.Remove(tmpAudioPath) }()
 
-	err = extractAudio(tmpVideoPath, tmpAudioPath)
+	err = extractAudioAt(context.Background(), tmpVideoPath, tmpAudioPath)
 	if !errors.Is(err, errNoAudio) {
 		t.Errorf("expected errNoAudio, got: %v", err)
 	}

--- a/internal/video/trim.go
+++ b/internal/video/trim.go
@@ -55,10 +55,10 @@ func buildTrimArgs(inputPath, outputPath, contentType string, startSeconds, endS
 	return append(args, "-y", outputPath)
 }
 
-func trimVideo(inputPath, outputPath, contentType string, startSeconds, endSeconds float64) error {
+func trimVideo(ctx context.Context, inputPath, outputPath, contentType string, startSeconds, endSeconds float64) error {
 	args := buildTrimArgs(inputPath, outputPath, contentType, startSeconds, endSeconds)
 
-	cmd := exec.Command("ffmpeg", args...)
+	cmd := exec.CommandContext(ctx, "ffmpeg", args...)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("ffmpeg trim: %w: %s", err, string(output))
@@ -105,7 +105,7 @@ func TrimVideoAsync(ctx context.Context, db database.DBTX, storage ObjectStorage
 	_ = tmpOutput.Close()
 	defer func() { _ = os.Remove(tmpOutputPath) }()
 
-	if err := trimVideo(tmpInputPath, tmpOutputPath, contentType, startSeconds, endSeconds); err != nil {
+	if err := trimVideo(ctx, tmpInputPath, tmpOutputPath, contentType, startSeconds, endSeconds); err != nil {
 		slog.Error("trim: ffmpeg failed", "video_id", videoID, "error", err)
 		setReadyFallback()
 		return


### PR DESCRIPTION
Fixes #206.

Every ffmpeg call used `exec.Command`, so the 10 minute contexts the callers construct never reached the process. The deadline was fiction.

### Why it matters

1. **The timeout never fired.** A pathological input could hold an encoder open indefinitely with nothing in the process to stop it.
2. **It compounded the memory work in #205.** A job whose context expired kept its ~300 MB allocation alive while the caller had already moved on, so the pod could hold more concurrent encoders than there were live jobs.
3. **It raced the sweeper from #201.** That resets rows stuck in `processing` between 15 and 20 minutes depending on tick alignment. An ffmpeg still running past that point has had its row flipped back to `ready` underneath it — the row is not corrupted, because its own writes *are* context-bound, but the work is wasted and invisible while a doomed encoder keeps burning CPU and memory.

### The change

All eight ffmpeg sites switch to `exec.CommandContext` with the caller's context threaded in. `transcriber_local.go` and `email.go` already used the context-bound form, so this was an oversight rather than a convention.

**The four ffprobe sites are included.** They matter less alone, but `hasAudioStream` gates `extractAudio`, and leaving it unbound meant a cancelled context surfaced as `errNoAudio` rather than as cancellation. That path now reports the cancellation, since the two are otherwise indistinguishable at that level.

**The periodic workers get a per-job deadline.** `transcodeExistingWebM` and `normalizeExistingVideos` passed their own long-lived context straight through. That was harmless while ffmpeg ignored contexts entirely; now it would mean those encodes have no deadline at all.

### How to test

`make test`. `TestFFmpegRespectsContextCancellation` runs each of the eight entry points with an already-cancelled context and asserts the error wraps `context.Canceled` — the cheapest observable proof the context is wired through rather than merely accepted as a parameter. It skips where ffmpeg is absent and passes against ffmpeg 7.1; CI installs ffmpeg, so it runs there.

### Worth a look during review

`extractAudio` is renamed `extractAudioAt` for consistency with `extractFrameAt`. Behaviour is unchanged apart from the cancellation reporting described above.

## Checklist

- [x] `make test` passes
- [x] `make build` succeeds
- [x] New code has tests where applicable
- [x] No unrelated changes included