### PR TITLE
perf: bound how many ffmpeg encodes run at once

### DIFF
--- a/cmd/sendrec/main.go
+++ b/cmd/sendrec/main.go
@@ -225,6 +225,11 @@ func main() {
 	video.StartSummaryWorker(cleanupCtx, db.Pool, aiClient, 10*time.Second)
 	video.StartDocumentWorker(cleanupCtx, db.Pool, aiClient, 10*time.Second)
 	video.StartDigestWorker(cleanupCtx, db.Pool, emailClient, baseURL)
+	// Bounds how many ffmpeg encodes run at once. Each 1080p encode peaks around
+	// 300 MB inside this process, so concurrency multiplies peak memory directly;
+	// raise it together with the pod's memory, not on its own.
+	video.SetEncoderConcurrency(int(getEnvInt64("MAX_CONCURRENT_ENCODES", video.DefaultEncoderConcurrency)))
+
 	video.StartTranscodeWorker(cleanupCtx, db.Pool, store, 2*time.Minute)
 	// Reclaims videos whose editing job died with the process. Runs more often
 	// than the 15 minute staleness bound so a stranded row is picked up soon

--- a/cmd/sendrec/main.go
+++ b/cmd/sendrec/main.go
@@ -210,6 +210,12 @@ func main() {
 		slog.Info("AI summaries enabled", "model", getEnv("AI_MODEL", "mistral-small-latest"), "timeout", aiTimeout.String())
 	}
 
+	// Bounds how many ffmpeg encodes run at once. Each 1080p encode peaks around
+	// 300 MB inside this process, so concurrency multiplies peak memory directly;
+	// raise it together with the pod's memory, not on its own. Set before any
+	// worker starts: it replaces a package-level value those goroutines read.
+	video.SetEncoderConcurrency(int(getEnvInt64("MAX_CONCURRENT_ENCODES", video.DefaultEncoderConcurrency)))
+
 	cleanupCtx, cleanupCancel := context.WithCancel(context.Background())
 	defer cleanupCancel()
 	video.StartCleanupLoop(cleanupCtx, db.Pool, store, 10*time.Minute)
@@ -225,11 +231,6 @@ func main() {
 	video.StartSummaryWorker(cleanupCtx, db.Pool, aiClient, 10*time.Second)
 	video.StartDocumentWorker(cleanupCtx, db.Pool, aiClient, 10*time.Second)
 	video.StartDigestWorker(cleanupCtx, db.Pool, emailClient, baseURL)
-	// Bounds how many ffmpeg encodes run at once. Each 1080p encode peaks around
-	// 300 MB inside this process, so concurrency multiplies peak memory directly;
-	// raise it together with the pod's memory, not on its own.
-	video.SetEncoderConcurrency(int(getEnvInt64("MAX_CONCURRENT_ENCODES", video.DefaultEncoderConcurrency)))
-
 	video.StartTranscodeWorker(cleanupCtx, db.Pool, store, 2*time.Minute)
 	// Reclaims videos whose editing job died with the process. Runs more often
 	// than the 15 minute staleness bound so a stranded row is picked up soon

--- a/helm/sendrec/README.md
+++ b/helm/sendrec/README.md
@@ -115,6 +115,7 @@ Set any of these to `"0"` for unlimited. The chart ships `"0"` for all three, so
 | `env.maxVideosPerMonth` | `MAX_VIDEOS_PER_MONTH` | Videos a user may create per month | `0` (app: free plan, `25`) |
 | `env.maxVideoDurationSeconds` | `MAX_VIDEO_DURATION_SECONDS` | Max recording length | `0` (app: free plan, `300`) |
 | `env.maxPlaylists` | `MAX_PLAYLISTS` | Playlists a free-tier user may create | `0` (app: free plan, `3`) |
+| `env.maxConcurrentEncodes` | `MAX_CONCURRENT_ENCODES` | ffmpeg encodes allowed to run at once. Extra edits queue. Each 1080p encode peaks near 300 MB, so raise this and the memory request together | `1` |
 
 ### Features
 
@@ -290,7 +291,7 @@ The chart requests `512Mi` and sets no memory limit. The request is what gets th
 - **4K or high-DPI sources** scale roughly with pixel count. The app scales down to 1080p during transcode, but the decode side still holds full-resolution frames.
 - **Local transcription** runs whisper.cpp in the same pod and is both CPU and memory hungry.
 - **Noise reduction** adds an ffmpeg filter to every transcode.
-- **Concurrent jobs.** Nothing bounds how many edits run at once, so two simultaneous 1080p edits want roughly twice the memory. `512Mi` is a request sized for one; it is not a reservation that survives concurrency.
+- **Concurrent jobs.** `env.maxConcurrentEncodes` defaults to `1`, so extra edits queue instead of running alongside each other. `512Mi` is sized for that one encode. Raising the limit multiplies peak memory, so raise the request with it.
 
 Under-provisioning does not fail gracefully: the OOM killer takes the whole pod, so an edit triggered by one user drops every in-flight request. If you cannot give the pod headroom, keep `replicas: 1` and expect edits on large recordings to fail.
 

--- a/helm/sendrec/README.md
+++ b/helm/sendrec/README.md
@@ -115,7 +115,7 @@ Set any of these to `"0"` for unlimited. The chart ships `"0"` for all three, so
 | `env.maxVideosPerMonth` | `MAX_VIDEOS_PER_MONTH` | Videos a user may create per month | `0` (app: free plan, `25`) |
 | `env.maxVideoDurationSeconds` | `MAX_VIDEO_DURATION_SECONDS` | Max recording length | `0` (app: free plan, `300`) |
 | `env.maxPlaylists` | `MAX_PLAYLISTS` | Playlists a free-tier user may create | `0` (app: free plan, `3`) |
-| `env.maxConcurrentEncodes` | `MAX_CONCURRENT_ENCODES` | ffmpeg encodes allowed to run at once. Extra edits queue. Each 1080p encode peaks near 300 MB, so raise this and the memory request together | `1` |
+| `env.maxConcurrentEncodes` | `MAX_CONCURRENT_ENCODES` | ffmpeg encodes allowed to run at once **per pod**. Extra edits queue, holding their downloaded source on disk while they wait. Each 1080p encode peaks near 300 MB, so raise this and the memory request together | `1` |
 
 ### Features
 

--- a/helm/sendrec/templates/configmap.yaml
+++ b/helm/sendrec/templates/configmap.yaml
@@ -18,6 +18,7 @@ data:
   MAX_VIDEOS_PER_MONTH: {{ .Values.sendrec.env.maxVideosPerMonth | quote }}
   MAX_VIDEO_DURATION_SECONDS: {{ .Values.sendrec.env.maxVideoDurationSeconds | quote }}
   MAX_PLAYLISTS: {{ .Values.sendrec.env.maxPlaylists | quote }}
+  MAX_CONCURRENT_ENCODES: {{ .Values.sendrec.env.maxConcurrentEncodes | quote }}
   API_DOCS_ENABLED: {{ .Values.sendrec.env.apiDocsEnabled | quote }}
   BRANDING_ENABLED: {{ .Values.sendrec.env.brandingEnabled | quote }}
   REGISTRATION_ENABLED: {{ .Values.sendrec.env.registrationEnabled | quote }}

--- a/helm/sendrec/values.yaml
+++ b/helm/sendrec/values.yaml
@@ -38,6 +38,11 @@ sendrec:
     maxVideoDurationSeconds: "0"  # per-recording length cap ("" = free plan, 300s)
     maxPlaylists: "0"             # per-user playlist cap ("" = free plan, 3)
 
+    # How many ffmpeg encodes may run at once in the pod. Each 1080p encode peaks
+    # around 300 MB, so this multiplies peak memory: raise it and resources.requests
+    # together. Extra edits queue rather than fail.
+    maxConcurrentEncodes: "1"
+
     # Features
     apiDocsEnabled: "true"        # serve the OpenAPI/Swagger docs route
     brandingEnabled: "true"       # allow custom logo/colors on watch pages

--- a/internal/video/composite.go
+++ b/internal/video/composite.go
@@ -90,7 +90,7 @@ func compositeOverlay(ctx context.Context, screenPath, webcamPath, outputPath, c
 
 	// Hold a slot only around ffmpeg itself: the download and upload either
 	// side are I/O and would waste the slot.
-	release, err := ffmpegEncoders.acquire(ctx)
+	release, err := encoders().acquire(ctx)
 	if err != nil {
 		return "", err
 	}

--- a/internal/video/composite.go
+++ b/internal/video/composite.go
@@ -88,6 +88,14 @@ func buildCompositeArgs(screenPath, webcamPath, outputPath, contentType string) 
 func compositeOverlay(ctx context.Context, screenPath, webcamPath, outputPath, contentType string) (string, error) {
 	args := buildCompositeArgs(screenPath, webcamPath, outputPath, contentType)
 
+	// Hold a slot only around ffmpeg itself: the download and upload either
+	// side are I/O and would waste the slot.
+	release, err := ffmpegEncoders.acquire(ctx)
+	if err != nil {
+		return "", err
+	}
+	defer release()
+
 	cmd := exec.CommandContext(ctx, "ffmpeg", args...)
 	output, err := cmd.CombinedOutput()
 	if err != nil {

--- a/internal/video/encoder_slots.go
+++ b/internal/video/encoder_slots.go
@@ -1,0 +1,77 @@
+package video
+
+import (
+	"context"
+	"log/slog"
+	"time"
+)
+
+// DefaultEncoderConcurrency is how many ffmpeg encodes may run at once when
+// MAX_CONCURRENT_ENCODES is unset.
+//
+// One, because the deployment is sized for one. A 1080p encode peaks around
+// 300 MB and the chart requests 512Mi, so a second concurrent encode wants
+// memory the pod never reserved. Raise it together with the memory request,
+// not on its own.
+const DefaultEncoderConcurrency = 1
+
+// encoderSlots bounds how many ffmpeg encodes run concurrently in this process.
+//
+// Every encode runs in the process that serves HTTP, so concurrency multiplies
+// peak memory directly: two 1080p edits at once want roughly twice what one
+// does, and the pod is sized for one. Without this the memory bounds in
+// x264MemoryParams and ffmpegPipelineThreads cap a single encode while nothing
+// caps how many there are — a per-encode ceiling with no process-wide one.
+//
+// Queueing is the intended behaviour. An edit that waits is slower; an edit that
+// runs alongside three others takes the pod down with it.
+type encoderSlots struct {
+	tokens chan struct{}
+}
+
+func newEncoderSlots(limit int) *encoderSlots {
+	// A limit below one would block every encode until its deadline, which is
+	// worse than any value an operator could have meant by it.
+	if limit < 1 {
+		limit = 1
+	}
+	return &encoderSlots{tokens: make(chan struct{}, limit)}
+}
+
+// acquire blocks until a slot is free or ctx is done. The returned function
+// returns the slot and must be called exactly once.
+func (s *encoderSlots) acquire(ctx context.Context) (release func(), err error) {
+	waited := time.Now()
+	select {
+	case s.tokens <- struct{}{}:
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+
+	// Queueing is expected under load; queueing for a long time means the pod is
+	// undersized for its edit volume, which is invisible without this line.
+	if held := time.Since(waited); held > 5*time.Second {
+		slog.Info("encoder: waited for a free slot", "waited", held.String(), "limit", cap(s.tokens))
+	}
+
+	var once bool
+	return func() {
+		if once {
+			return
+		}
+		once = true
+		<-s.tokens
+	}, nil
+}
+
+// ffmpegEncoders gates the five encoding paths. Probing, thumbnail extraction
+// and audio extraction stay outside it: they are cheap enough that queueing them
+// behind an encode would cost more than it saves.
+var ffmpegEncoders = newEncoderSlots(DefaultEncoderConcurrency)
+
+// SetEncoderConcurrency replaces the process-wide limit. Called once at startup
+// from MAX_CONCURRENT_ENCODES, before any request is served.
+func SetEncoderConcurrency(limit int) {
+	ffmpegEncoders = newEncoderSlots(limit)
+	slog.Info("encoder concurrency", "limit", cap(ffmpegEncoders.tokens))
+}

--- a/internal/video/encoder_slots.go
+++ b/internal/video/encoder_slots.go
@@ -3,6 +3,7 @@ package video
 import (
 	"context"
 	"log/slog"
+	"sync/atomic"
 	"time"
 )
 
@@ -41,7 +42,7 @@ func newEncoderSlots(limit int) *encoderSlots {
 // acquire blocks until a slot is free or ctx is done. The returned function
 // returns the slot and must be called exactly once.
 func (s *encoderSlots) acquire(ctx context.Context) (release func(), err error) {
-	waited := time.Now()
+	start := time.Now()
 	select {
 	case s.tokens <- struct{}{}:
 	case <-ctx.Done():
@@ -50,8 +51,8 @@ func (s *encoderSlots) acquire(ctx context.Context) (release func(), err error) 
 
 	// Queueing is expected under load; queueing for a long time means the pod is
 	// undersized for its edit volume, which is invisible without this line.
-	if held := time.Since(waited); held > 5*time.Second {
-		slog.Info("encoder: waited for a free slot", "waited", held.String(), "limit", cap(s.tokens))
+	if waited := time.Since(start); waited > 5*time.Second {
+		slog.Info("encoder: waited for a free slot", "waited", waited.String(), "limit", cap(s.tokens))
 	}
 
 	var once bool
@@ -67,11 +68,27 @@ func (s *encoderSlots) acquire(ctx context.Context) (release func(), err error) 
 // ffmpegEncoders gates the five encoding paths. Probing, thumbnail extraction
 // and audio extraction stay outside it: they are cheap enough that queueing them
 // behind an encode would cost more than it saves.
-var ffmpegEncoders = newEncoderSlots(DefaultEncoderConcurrency)
+//
+// An atomic pointer rather than a plain variable, so replacing the gate is safe
+// however many goroutines are reading it. The startup ordering in main.go makes
+// that unnecessary today; this makes it unnecessary to keep remembering.
+var ffmpegEncoders atomic.Pointer[encoderSlots]
 
-// SetEncoderConcurrency replaces the process-wide limit. Called once at startup
-// from MAX_CONCURRENT_ENCODES, before any request is served.
+func init() {
+	ffmpegEncoders.Store(newEncoderSlots(DefaultEncoderConcurrency))
+}
+
+// encoders returns the current process-wide gate.
+func encoders() *encoderSlots {
+	return ffmpegEncoders.Load()
+}
+
+// SetEncoderConcurrency replaces the process-wide limit, from
+// MAX_CONCURRENT_ENCODES at startup. Encodes already holding a slot finish on
+// the gate they acquired from, so a swap mid-flight can briefly allow the old
+// and new limits together; in practice it runs once before any encode exists.
 func SetEncoderConcurrency(limit int) {
-	ffmpegEncoders = newEncoderSlots(limit)
-	slog.Info("encoder concurrency", "limit", cap(ffmpegEncoders.tokens))
+	s := newEncoderSlots(limit)
+	ffmpegEncoders.Store(s)
+	slog.Info("encoder concurrency", "limit", cap(s.tokens))
 }

--- a/internal/video/encoder_slots_test.go
+++ b/internal/video/encoder_slots_test.go
@@ -1,0 +1,101 @@
+package video
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// A 1080p encode peaks around 300 MB and the chart requests 512Mi, so the pod is
+// sized for one at a time. Nothing bounded how many ran at once, which is why
+// #202's sizing could not survive two concurrent edits.
+func TestEncoderSlots_BoundsConcurrency(t *testing.T) {
+	limit := 2
+	slots := newEncoderSlots(limit)
+
+	var running, peak atomic.Int64
+	var wg sync.WaitGroup
+
+	for range 12 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			release, err := slots.acquire(context.Background())
+			if err != nil {
+				t.Errorf("acquire: %v", err)
+				return
+			}
+			defer release()
+
+			now := running.Add(1)
+			for {
+				old := peak.Load()
+				if now <= old || peak.CompareAndSwap(old, now) {
+					break
+				}
+			}
+			time.Sleep(5 * time.Millisecond)
+			running.Add(-1)
+		}()
+	}
+	wg.Wait()
+
+	if got := peak.Load(); got > int64(limit) {
+		t.Errorf("peak concurrency %d exceeded the limit of %d", got, limit)
+	}
+	if running.Load() != 0 {
+		t.Errorf("%d encodes still holding a slot after completion", running.Load())
+	}
+}
+
+// Waiting for a slot has to respect the job's deadline. Otherwise a queue of
+// edits outlives the contexts that were supposed to bound them.
+func TestEncoderSlots_WaitRespectsContext(t *testing.T) {
+	slots := newEncoderSlots(1)
+
+	release, err := slots.acquire(context.Background())
+	if err != nil {
+		t.Fatalf("first acquire: %v", err)
+	}
+	defer release()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancel()
+
+	if _, err := slots.acquire(ctx); !errors.Is(err, context.DeadlineExceeded) {
+		t.Errorf("second acquire returned %v, want context.DeadlineExceeded", err)
+	}
+}
+
+// Releasing has to return the slot, or the pool drains to zero and every later
+// encode blocks until its deadline.
+func TestEncoderSlots_ReleaseReturnsTheSlot(t *testing.T) {
+	slots := newEncoderSlots(1)
+
+	for i := range 3 {
+		release, err := slots.acquire(context.Background())
+		if err != nil {
+			t.Fatalf("acquire %d: %v", i, err)
+		}
+		release()
+	}
+}
+
+// A limit below one would deadlock every encode, so it is clamped rather than
+// trusted: the value reaches here from an env var.
+func TestEncoderSlots_ClampsNonPositiveLimits(t *testing.T) {
+	for _, limit := range []int{0, -1} {
+		slots := newEncoderSlots(limit)
+		ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+		release, err := slots.acquire(ctx)
+		cancel()
+		if err != nil {
+			t.Errorf("limit %d: acquire failed, so the pool deadlocks: %v", limit, err)
+			continue
+		}
+		release()
+	}
+}

--- a/internal/video/encoder_slots_wiring_test.go
+++ b/internal/video/encoder_slots_wiring_test.go
@@ -1,0 +1,50 @@
+package video
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+// Three review rounds on #205 found bounds that were present and inert. The
+// semaphore is only worth anything if every encoding path actually acquires
+// it, so prove that per path: hold the single slot, call the path with a short
+// deadline, and require it to die waiting rather than reach ffmpeg.
+func TestEveryEncodePathAcquiresASlot(t *testing.T) {
+	original := ffmpegEncoders.Load()
+	ffmpegEncoders.Store(newEncoderSlots(1))
+	t.Cleanup(func() { ffmpegEncoders.Store(original) })
+
+	release, err := encoders().acquire(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer release()
+
+	dir := t.TempDir()
+	for _, tc := range []struct {
+		name string
+		run  func(context.Context) error
+	}{
+		{"transcode", func(ctx context.Context) error { return transcodeToMP4(ctx, "in.webm", dir+"/o.mp4", "") }},
+		{"normalize", func(ctx context.Context) error { return transcodeToIOSCompatible(ctx, "in.mp4", dir+"/o.mp4", "") }},
+		{"trim", func(ctx context.Context) error { return trimVideo(ctx, "in.mp4", dir+"/o.mp4", "video/mp4", 0, 1) }},
+		{"remove segments", func(ctx context.Context) error {
+			return removeSegmentsFromVideo(ctx, "in.mp4", dir+"/o.mp4", "video/mp4", []segmentRange{{Start: 0, End: 1}}, false)
+		}},
+		{"composite", func(ctx context.Context) error {
+			_, err := compositeOverlay(ctx, "s.mp4", "w.mp4", dir+"/o.mp4", "video/mp4")
+			return err
+		}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Millisecond)
+			defer cancel()
+			err := tc.run(ctx)
+			if !errors.Is(err, context.DeadlineExceeded) {
+				t.Errorf("did not wait for a slot; got %v — the path is not gated", err)
+			}
+		})
+	}
+}

--- a/internal/video/normalize.go
+++ b/internal/video/normalize.go
@@ -131,6 +131,14 @@ func buildNormalizeArgs(inputPath, outputPath, audioFilter string) []string {
 // See transcodeToMP4 for why this is a var.
 var transcodeToIOSCompatible = func(ctx context.Context, inputPath, outputPath, audioFilter string) error {
 	args := buildNormalizeArgs(inputPath, outputPath, audioFilter)
+	// Hold a slot only around ffmpeg itself: the download and upload either
+	// side are I/O and would waste the slot.
+	release, err := ffmpegEncoders.acquire(ctx)
+	if err != nil {
+		return err
+	}
+	defer release()
+
 	cmd := exec.CommandContext(ctx, "ffmpeg", args...)
 	output, err := cmd.CombinedOutput()
 	if err != nil {

--- a/internal/video/normalize.go
+++ b/internal/video/normalize.go
@@ -133,7 +133,7 @@ var transcodeToIOSCompatible = func(ctx context.Context, inputPath, outputPath, 
 	args := buildNormalizeArgs(inputPath, outputPath, audioFilter)
 	// Hold a slot only around ffmpeg itself: the download and upload either
 	// side are I/O and would waste the slot.
-	release, err := ffmpegEncoders.acquire(ctx)
+	release, err := encoders().acquire(ctx)
 	if err != nil {
 		return err
 	}

--- a/internal/video/remove_segments.go
+++ b/internal/video/remove_segments.go
@@ -180,7 +180,7 @@ func removeSegmentsFromVideo(ctx context.Context, inputPath, outputPath, content
 
 	// Hold a slot only around ffmpeg itself: the download and upload either
 	// side are I/O and would waste the slot.
-	release, err := ffmpegEncoders.acquire(ctx)
+	release, err := encoders().acquire(ctx)
 	if err != nil {
 		return err
 	}

--- a/internal/video/remove_segments.go
+++ b/internal/video/remove_segments.go
@@ -178,6 +178,14 @@ func buildRemoveSegmentsArgs(inputPath, outputPath, contentType string, segments
 func removeSegmentsFromVideo(ctx context.Context, inputPath, outputPath, contentType string, segments []segmentRange, audioPresent bool) error {
 	args := buildRemoveSegmentsArgs(inputPath, outputPath, contentType, segments, audioPresent)
 
+	// Hold a slot only around ffmpeg itself: the download and upload either
+	// side are I/O and would waste the slot.
+	release, err := ffmpegEncoders.acquire(ctx)
+	if err != nil {
+		return err
+	}
+	defer release()
+
 	cmd := exec.CommandContext(ctx, "ffmpeg", args...)
 	output, err := cmd.CombinedOutput()
 	if err != nil {

--- a/internal/video/transcode.go
+++ b/internal/video/transcode.go
@@ -38,7 +38,7 @@ var transcodeToMP4 = func(ctx context.Context, inputPath, outputPath, audioFilte
 	args := buildTranscodeArgs(inputPath, outputPath, audioFilter)
 	// Hold a slot only around ffmpeg itself: the download and upload either
 	// side are I/O and would waste the slot.
-	release, err := ffmpegEncoders.acquire(ctx)
+	release, err := encoders().acquire(ctx)
 	if err != nil {
 		return err
 	}

--- a/internal/video/transcode.go
+++ b/internal/video/transcode.go
@@ -36,6 +36,14 @@ func buildTranscodeArgs(inputPath, outputPath, audioFilter string) []string {
 // an ffmpeg binary or a real video fixture.
 var transcodeToMP4 = func(ctx context.Context, inputPath, outputPath, audioFilter string) error {
 	args := buildTranscodeArgs(inputPath, outputPath, audioFilter)
+	// Hold a slot only around ffmpeg itself: the download and upload either
+	// side are I/O and would waste the slot.
+	release, err := ffmpegEncoders.acquire(ctx)
+	if err != nil {
+		return err
+	}
+	defer release()
+
 	cmd := exec.CommandContext(ctx, "ffmpeg", args...)
 	output, err := cmd.CombinedOutput()
 	if err != nil {

--- a/internal/video/trim.go
+++ b/internal/video/trim.go
@@ -58,6 +58,14 @@ func buildTrimArgs(inputPath, outputPath, contentType string, startSeconds, endS
 func trimVideo(ctx context.Context, inputPath, outputPath, contentType string, startSeconds, endSeconds float64) error {
 	args := buildTrimArgs(inputPath, outputPath, contentType, startSeconds, endSeconds)
 
+	// Hold a slot only around ffmpeg itself: the download and upload either
+	// side are I/O and would waste the slot.
+	release, err := ffmpegEncoders.acquire(ctx)
+	if err != nil {
+		return err
+	}
+	defer release()
+
 	cmd := exec.CommandContext(ctx, "ffmpeg", args...)
 	output, err := cmd.CombinedOutput()
 	if err != nil {

--- a/internal/video/trim.go
+++ b/internal/video/trim.go
@@ -60,7 +60,7 @@ func trimVideo(ctx context.Context, inputPath, outputPath, contentType string, s
 
 	// Hold a slot only around ffmpeg itself: the download and upload either
 	// side are I/O and would waste the slot.
-	release, err := ffmpegEncoders.acquire(ctx)
+	release, err := encoders().acquire(ctx)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Closes the concurrency half of #202. **Stacked on #207** — review that first; this PR targets `fix/ffmpeg-context` and its diff shrinks once #207 merges.

#205 bounded a single encode: thread pools, reference frames, lookahead. Nothing bounded how many encodes there were. A per-encode ceiling with no process-wide one still lets two 1080p edits want twice what the pod reserved, which is exactly why the `512Mi` request could be justified for one job and wrong for the deployment.

### The change

A process-wide semaphore around the five encoding paths — transcode, normalize, trim, remove-segments, composite. Probing, thumbnail extraction and audio extraction stay outside it; queueing work that cheap behind an encode costs more than it saves.

Three details that matter:

- **The slot is held around ffmpeg alone.** Downloads and uploads either side are I/O and would waste it.
- **Waiting respects the caller's context**, so a queued edit dies at its deadline rather than outliving it. That only works because #207 made contexts real.
- **A wait over five seconds is logged.** "The pod is undersized for its edit volume" is otherwise invisible.

`MAX_CONCURRENT_ENCODES` sets the limit, default `1`: a 1080p encode peaks near 300 MB and the chart requests `512Mi`, so the deployment is sized for one. Values below one are clamped — the value arrives from an env var and zero would block every encode until its deadline.

The chart exposes it as `env.maxConcurrentEncodes` and says to raise it together with `resources.requests` rather than on its own.

### Behaviour change worth weighing

**Edits now queue instead of running in parallel.** On an instance with several active users, a second edit waits for the first. That is the intended trade — an edit that waits is slower, an edit that runs alongside three others takes the pod down with it — but it is a throughput reduction on busy instances, and operators who have provisioned generously will want to raise the limit.

### What stays open on #202

The load-bearing measurement: pod cgroup `memory.peak`, Go server plus ffmpeg, on representative production recordings at the largest supported CPU count. Everything measured so far is ffmpeg's `VmHWM` for one job on a 4-core box. This PR makes the single-job figure meaningful by ensuring there *is* one job at a time, but it does not establish that `512Mi` is the right number.

### How to test

`make test`. `internal/video/encoder_slots_test.go` covers the concurrency bound under 12 racing goroutines, context-aware waiting, slot release, and clamping of non-positive limits.

## Checklist

- [x] `make test` passes
- [x] `make build` succeeds
- [x] New code has tests where applicable
- [x] No unrelated changes included