### PR TITLE
test: fix four data races in video mocks and run CI under -race

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,7 +87,7 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y ffmpeg
 
       - name: Run Go tests
-        run: go clean -cache && go test ./... -coverprofile=coverage.out -covermode=atomic | tee test-output.txt
+        run: go clean -cache && go test ./... -race -coverprofile=coverage.out -covermode=atomic | tee test-output.txt
 
       - name: Coverage summary
         run: |

--- a/internal/video/cleanup_test.go
+++ b/internal/video/cleanup_test.go
@@ -37,8 +37,8 @@ func TestPurgeOrphanedFiles_DeletesUnpurgedFiles(t *testing.T) {
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Errorf("unmet expectations: %v", err)
 	}
-	if storage.deleteCallCount != 2 {
-		t.Errorf("expected 2 delete calls, got %d", storage.deleteCallCount)
+	if storage.deleteCalls() != 2 {
+		t.Errorf("expected 2 delete calls, got %d", storage.deleteCalls())
 	}
 }
 
@@ -59,8 +59,8 @@ func TestPurgeOrphanedFiles_SkipsWhenNoOrphans(t *testing.T) {
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Errorf("unmet expectations: %v", err)
 	}
-	if storage.deleteCallCount != 0 {
-		t.Errorf("expected 0 delete calls, got %d", storage.deleteCallCount)
+	if storage.deleteCalls() != 0 {
+		t.Errorf("expected 0 delete calls, got %d", storage.deleteCalls())
 	}
 }
 
@@ -132,8 +132,8 @@ func TestPurgeOrphanedFiles_DeletesTranscriptFile(t *testing.T) {
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Errorf("unmet expectations: %v", err)
 	}
-	if storage.deleteCallCount != 2 {
-		t.Errorf("expected 2 delete calls (video + transcript), got %d", storage.deleteCallCount)
+	if storage.deleteCalls() != 2 {
+		t.Errorf("expected 2 delete calls (video + transcript), got %d", storage.deleteCalls())
 	}
 }
 

--- a/internal/video/comment_test.go
+++ b/internal/video/comment_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -145,6 +146,7 @@ func TestSetCommentMode_AllValidModes(t *testing.T) {
 // --- mockCommentNotifier ---
 
 type mockCommentNotifier struct {
+	mu            sync.Mutex
 	called        bool
 	toEmail       string
 	videoTitle    string
@@ -152,11 +154,36 @@ type mockCommentNotifier struct {
 }
 
 func (m *mockCommentNotifier) SendCommentNotification(_ context.Context, toEmail, toName, videoTitle, commentAuthor, commentBody, watchURL string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	m.called = true
 	m.toEmail = toEmail
 	m.videoTitle = videoTitle
 	m.commentAuthor = commentAuthor
 	return nil
+}
+
+func (m *mockCommentNotifier) wasCalled() bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.called
+}
+
+// waitCalled reports whether the notifier fired within d. PostWatchComment
+// notifies from a goroutine after responding, so a test cannot assert straight
+// after ServeHTTP; this replaces a fixed sleep that raced the write. For a
+// negative assertion, d is how long the test is willing to wait for nothing.
+func (m *mockCommentNotifier) waitCalled(d time.Duration) bool {
+	deadline := time.Now().Add(d)
+	for {
+		if m.wasCalled() {
+			return true
+		}
+		if time.Now().After(deadline) {
+			return false
+		}
+		time.Sleep(time.Millisecond)
+	}
 }
 
 // --- PostWatchComment Tests ---
@@ -559,8 +586,7 @@ func TestPostWatchComment_QuickReaction_DoesNotSendCommentNotification(t *testin
 	}
 
 	// Notification is sent asynchronously for non-reaction comments.
-	time.Sleep(50 * time.Millisecond)
-	if notifier.called {
+	if notifier.waitCalled(50 * time.Millisecond) {
 		t.Fatal("expected no comment notification for quick reactions")
 	}
 }
@@ -611,8 +637,7 @@ func TestPostWatchComment_NotificationModeViewsOnly_DoesNotSendCommentNotificati
 		t.Fatalf("expected status %d, got %d: %s", http.StatusCreated, rec.Code, rec.Body.String())
 	}
 
-	time.Sleep(50 * time.Millisecond)
-	if notifier.called {
+	if notifier.waitCalled(50 * time.Millisecond) {
 		t.Fatal("expected no comment notification when account mode is views_only")
 	}
 
@@ -671,8 +696,7 @@ func TestPostWatchComment_NotificationModeCommentsOnly_SendsCommentNotification(
 		t.Fatalf("expected status %d, got %d: %s", http.StatusCreated, rec.Code, rec.Body.String())
 	}
 
-	time.Sleep(50 * time.Millisecond)
-	if !notifier.called {
+	if !notifier.waitCalled(time.Second) {
 		t.Fatal("expected comment notification when account mode is comments_only")
 	}
 

--- a/internal/video/transcode_test.go
+++ b/internal/video/transcode_test.go
@@ -286,8 +286,8 @@ func TestTranscodeWebMAsync_StopsWhenBudgetExhausted(t *testing.T) {
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Errorf("unmet expectations: %v", err)
 	}
-	if s.downloadToFileCount != 0 {
-		t.Errorf("expected no download, got %d", s.downloadToFileCount)
+	if s.downloadCalls() != 0 {
+		t.Errorf("expected no download, got %d", s.downloadCalls())
 	}
 }
 
@@ -314,8 +314,8 @@ func TestTranscodeWebMAsync_ProceedsBelowBudget(t *testing.T) {
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Errorf("unmet expectations: %v", err)
 	}
-	if s.downloadToFileCount != 1 {
-		t.Errorf("expected 1 download attempt, got %d", s.downloadToFileCount)
+	if s.downloadCalls() != 1 {
+		t.Errorf("expected 1 download attempt, got %d", s.downloadCalls())
 	}
 }
 
@@ -338,8 +338,8 @@ func TestNormalizeVideoAsync_StopsWhenBudgetExhausted(t *testing.T) {
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Errorf("unmet expectations: %v", err)
 	}
-	if s.downloadToFileCount != 0 {
-		t.Errorf("expected no download, got %d", s.downloadToFileCount)
+	if s.downloadCalls() != 0 {
+		t.Errorf("expected no download, got %d", s.downloadCalls())
 	}
 }
 

--- a/internal/video/video_test.go
+++ b/internal/video/video_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -21,6 +22,11 @@ import (
 )
 
 type mockStorage struct {
+	// Handlers hand work to goroutines that outlive the request, so several of
+	// them can hit one mock at once. Every mutation and every read goes
+	// through mu; the race detector found four places where they did not.
+	mu sync.Mutex
+
 	uploadURL              string
 	webcamUploadURL        string
 	uploadErr              error
@@ -62,6 +68,8 @@ func (m *mockStorage) GenerateDownloadURLWithDisposition(_ context.Context, _ st
 }
 
 func (m *mockStorage) DeleteObject(_ context.Context, key string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	m.deleteCallCount++
 	if m.deleteCalled != nil {
 		m.deleteCalled <- key
@@ -83,15 +91,41 @@ func (m *mockStorage) HeadObject(_ context.Context, _ string) (int64, string, er
 }
 
 func (m *mockStorage) DownloadToFile(_ context.Context, _ string, _ string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	m.downloadToFileCount++
 	return m.downloadToFileErr
 }
 
 func (m *mockStorage) UploadFile(_ context.Context, key string, _ string, contentType string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	m.uploadFileCallCount++
 	m.uploadFileKeys = append(m.uploadFileKeys, key)
 	m.uploadFileContentTypes = append(m.uploadFileContentTypes, contentType)
 	return m.uploadFileErr
+}
+
+func (m *mockStorage) deleteCalls() int { m.mu.Lock(); defer m.mu.Unlock(); return m.deleteCallCount }
+func (m *mockStorage) downloadCalls() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.downloadToFileCount
+}
+func (m *mockStorage) uploadCalls() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.uploadFileCallCount
+}
+func (m *mockStorage) uploadedKeys() []string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return append([]string(nil), m.uploadFileKeys...)
+}
+func (m *mockStorage) uploadedContentTypes() []string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return append([]string(nil), m.uploadFileContentTypes...)
 }
 
 const testJWTSecret = "test-secret-for-video-tests"
@@ -3400,8 +3434,8 @@ func TestDeleteWithRetry_SucceedsFirstAttempt(t *testing.T) {
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
-	if s.deleteCallCount != 1 {
-		t.Errorf("expected 1 call, got %d", s.deleteCallCount)
+	if s.deleteCalls() != 1 {
+		t.Errorf("expected 1 call, got %d", s.deleteCalls())
 	}
 }
 
@@ -3414,8 +3448,8 @@ func TestDeleteWithRetry_SucceedsOnSecondAttempt(t *testing.T) {
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
-	if s.deleteCallCount != 2 {
-		t.Errorf("expected 2 calls, got %d", s.deleteCallCount)
+	if s.deleteCalls() != 2 {
+		t.Errorf("expected 2 calls, got %d", s.deleteCalls())
 	}
 }
 
@@ -3427,8 +3461,8 @@ func TestDeleteWithRetry_FailsAfterAllAttempts(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
-	if s.deleteCallCount != 3 {
-		t.Errorf("expected 3 calls, got %d", s.deleteCallCount)
+	if s.deleteCalls() != 3 {
+		t.Errorf("expected 3 calls, got %d", s.deleteCalls())
 	}
 }
 
@@ -3444,8 +3478,8 @@ func TestDeleteWithRetry_RespectsContextCancellation(t *testing.T) {
 		t.Fatal("expected error, got nil")
 	}
 	// Should stop early due to cancelled context
-	if s.deleteCallCount > 2 {
-		t.Errorf("expected early stop, got %d calls", s.deleteCallCount)
+	if s.deleteCalls() > 2 {
+		t.Errorf("expected early stop, got %d calls", s.deleteCalls())
 	}
 }
 
@@ -6931,14 +6965,14 @@ func TestUploadTranscript_HappyPath(t *testing.T) {
 		t.Errorf("expected text %q, got %q", "hi", resp.Segments[0].Text)
 	}
 
-	if storage.uploadFileCallCount != 1 {
-		t.Errorf("expected storage.UploadFile called once, got %d", storage.uploadFileCallCount)
+	if storage.uploadCalls() != 1 {
+		t.Errorf("expected storage.UploadFile called once, got %d", storage.uploadCalls())
 	}
-	if len(storage.uploadFileKeys) == 1 && storage.uploadFileKeys[0] != "recordings/"+testUserID+"/"+shareToken+".vtt" {
-		t.Errorf("unexpected upload key: %s", storage.uploadFileKeys[0])
+	if len(storage.uploadedKeys()) == 1 && storage.uploadedKeys()[0] != "recordings/"+testUserID+"/"+shareToken+".vtt" {
+		t.Errorf("unexpected upload key: %s", storage.uploadedKeys()[0])
 	}
-	if len(storage.uploadFileContentTypes) == 1 && storage.uploadFileContentTypes[0] != "text/vtt" {
-		t.Errorf("unexpected content type: %s", storage.uploadFileContentTypes[0])
+	if len(storage.uploadedContentTypes()) == 1 && storage.uploadedContentTypes()[0] != "text/vtt" {
+		t.Errorf("unexpected content type: %s", storage.uploadedContentTypes()[0])
 	}
 
 	if err := mock.ExpectationsWereMet(); err != nil {
@@ -6974,8 +7008,8 @@ func TestUploadTranscript_RejectsNonVTT(t *testing.T) {
 		t.Fatalf("expected status %d, got %d: %s", http.StatusBadRequest, rec.Code, rec.Body.String())
 	}
 
-	if storage.uploadFileCallCount != 0 {
-		t.Errorf("expected storage.UploadFile not called, got %d calls", storage.uploadFileCallCount)
+	if storage.uploadCalls() != 0 {
+		t.Errorf("expected storage.UploadFile not called, got %d calls", storage.uploadCalls())
 	}
 
 	if err := mock.ExpectationsWereMet(); err != nil {
@@ -7023,8 +7057,8 @@ func TestUploadTranscript_RejectsOversized(t *testing.T) {
 		t.Fatalf("expected size-specific error message, got: %s", rec.Body.String())
 	}
 
-	if storage.uploadFileCallCount != 0 {
-		t.Errorf("expected storage.UploadFile not called, got %d calls", storage.uploadFileCallCount)
+	if storage.uploadCalls() != 0 {
+		t.Errorf("expected storage.UploadFile not called, got %d calls", storage.uploadCalls())
 	}
 
 	if err := mock.ExpectationsWereMet(); err != nil {
@@ -7074,8 +7108,8 @@ func TestUploadTranscript_RejectsOversized_OverRouteCeiling(t *testing.T) {
 		t.Fatalf("expected size-specific error message, got: %s", rec.Body.String())
 	}
 
-	if storage.uploadFileCallCount != 0 {
-		t.Errorf("expected storage.UploadFile not called, got %d calls", storage.uploadFileCallCount)
+	if storage.uploadCalls() != 0 {
+		t.Errorf("expected storage.UploadFile not called, got %d calls", storage.uploadCalls())
 	}
 
 	if err := mock.ExpectationsWereMet(); err != nil {


### PR DESCRIPTION
Fixes #209.

`go test ./internal/video/ -race` failed on `main` with four data races, all in test doubles. Handlers respond and then hand work to goroutines that outlive the request; those goroutines kept writing to mocks that the test body — or a sibling goroutine — was reading unsynchronised. CI never ran `-race`, so nobody saw them.

| Race | Writer | Reader |
| --- | --- | --- |
| `mockStorage.DeleteObject` counter | `BatchDelete` goroutines | each other |
| `mockStorage.DownloadToFile` counter (×2) | `EnqueueJob` goroutines | each other |
| `mockCommentNotifier` fields | `PostWatchComment` goroutine | the test body after a 50ms sleep |

### The change

- `mockStorage` and `mockCommentNotifier` guard every mutation and read with a mutex. The 34 direct reads of mock counters across `cleanup_test.go`, `transcode_test.go` and `video_test.go` go through accessors; slice accessors return copies.
- The three comment tests that slept 50ms and then read a bool now wait on the notifier under the lock, with a bound — a second for a positive assertion, 50ms for a negative one. Same semantics, no unsynchronised read, and no longer flaky on a slow runner.
- **CI runs the Go suite under `-race`.** Verified across the whole repository first: 22 packages, zero reports. `internal/video` goes from ~15s to ~36s; everything else is seconds.

### Why now

This package spawns goroutines from handlers by design. #208 reached for an `atomic.Pointer` on the encoder gate specifically because nothing in CI would have caught a plain-variable race. With `-race` on, that class goes red instead of landing.

### Worth a look during review

`waitCalled` polls every millisecond under the lock rather than using a channel, because the mock is constructed as a zero-value literal in many tests and a nil channel would need every site touched. Polling is fine at this scale; say if you would rather have the channel.

## Checklist

- [x] `make test` passes — including under `-race`
- [x] `make build` succeeds
- [x] New code has tests where applicable — the race detector is the test
- [x] No unrelated changes included