### PR TITLE
docs(helm): correct the memory runbook where it was wrong

### DIFF
--- a/helm/sendrec/README.md
+++ b/helm/sendrec/README.md
@@ -297,26 +297,28 @@ Under-provisioning does not fail gracefully: the OOM killer takes the whole pod,
 
 #### Measuring your own floor
 
-The figures above are one ffmpeg process on synthetic content. The number that matters is the whole pod on your recordings, and only you can measure that. Ten minutes, no tooling:
+The figures above are one ffmpeg process on synthetic content. The number that matters is the app container on your recordings, and only you can measure that. Ten minutes, no tooling:
 
 ```sh
 POD=$(kubectl -n sendrec get pod -l app=sendrec -o jsonpath='{.items[0].metadata.name}')
 
 # 1. Idle baseline — the Go server and nothing else.
-kubectl -n sendrec exec "$POD" -- cat /sys/fs/cgroup/memory.peak
+kubectl -n sendrec exec "$POD" -c sendrec -- cat /sys/fs/cgroup/memory.peak
 
 # 2. Trigger the heaviest edit you expect: your largest resolution, your
 #    longest recording, remove-segments with many cuts. Wait for it to finish.
 
-# 3. Peak for the pod, including that encode.
-kubectl -n sendrec exec "$POD" -- cat /sys/fs/cgroup/memory.peak
+# 3. Peak for the app container, including that encode.
+kubectl -n sendrec exec "$POD" -c sendrec -- cat /sys/fs/cgroup/memory.peak
 ```
 
-`memory.peak` is cgroup v2 and is the high-water mark since the container started, so run step 2 on a freshly started pod or accept that earlier work is included. On cgroup v1 read `/sys/fs/cgroup/memory/memory.max_usage_in_bytes` instead.
+`-c sendrec` matters: the chart renders `deployment.extraContainers` *before* the app container, so without it `kubectl exec` lands in your first sidecar and reports that container's memory instead. The figure is per container, not per pod — for the default single-container pod the two are the same.
+
+`memory.peak` is cgroup v2 on Linux 5.19 or newer, and is the high-water mark since the container started, so run step 2 on a freshly started pod or accept that earlier work is included. On an older cgroup v2 kernel the file does not exist; sample `/sys/fs/cgroup/memory.current` every second during step 2 and keep the largest value. On cgroup v1 read `/sys/fs/cgroup/memory/memory.max_usage_in_bytes` instead.
 
 Then size it:
 
-- **Request** = the step 3 figure with 20% headroom, and if you raise `env.maxConcurrentEncodes` to N, add roughly N times the difference between steps 3 and 1.
+- **Request** = (step 1 + N × (step 3 − step 1)) with 20% headroom, where N is `env.maxConcurrentEncodes`. Step 3 already contains one encode, so with the default N = 1 this is just step 3 plus headroom; each further concurrent encode adds the step 3 − step 1 difference once more.
 - **Limit** = request plus whatever headroom you want for a recording bigger than the one you tested. Setting it below the step 3 figure means the OOM killer, not a slow edit.
 
 Repeat when you change resolution limits, enable transcription or noise reduction, or raise the concurrency limit — each moves the floor.


### PR DESCRIPTION
Follow-up to #210. I tested the runbook's claims with disposable harnesses instead of re-reading it: `helm template` for the chart-dependent claims, a real cgroup v2 container for the kernel-dependent ones, and the sizing formula against the model it exists to predict. Two claims failed.

### What was wrong

**The sizing rule counted N+1 encodes.** Step 3 already contains one encode; the text said to add *N times* the difference on top. Across 200 random baselines it over-provisioned for N < 6, under-provisioned for N > 6, and was exactly right at N = 6 by coincidence. Now `(step 1 + N × (step 3 − step 1)) × 1.2`, with the N = 1 case spelled out.

**`kubectl exec` without `-c` reads the wrong container once a sidecar exists.** The chart renders `deployment.extraContainers` *before* the app container — confirmed by rendering with one sidecar: order is `[log-shipper, sendrec]`. `exec` lands in the sidecar and reports its cgroup, silently. Both commands now carry `-c sendrec`, the text says why, and "peak for the pod" is corrected to per-container.

### What could not be verified here

`memory.peak` requires Linux ≥ 5.19; the test host was 6.8. On an older cgroup v2 kernel the file is absent and the runbook offered nothing. Added: sample `memory.current` during the edit and keep the maximum.

### What held

- `-l app=sendrec` matches the rendered pod label; namespace follows `-n`.
- `/sys/fs/cgroup/memory.peak` exists in the container, rose 4 → 49 MB on a 48 MB allocation, and **stayed at 49 while `memory.current` fell to 1** — the high-water-mark claim is true.
- The documented v1 path is absent on a v2 host, so the fallback is exclusive as written.

All harnesses deleted; nothing promoted, since none of this is exercisable by `go test`.

Docs only.

## Checklist

- [x] `make test` passes
- [x] `make build` succeeds
- [x] New code has tests where applicable — n/a
- [x] No unrelated changes included