### PR TITLE
docs: add the Docker sizing procedure, which is how sendrec actually runs

### DIFF
--- a/SELF-HOSTING.md
+++ b/SELF-HOSTING.md
@@ -221,6 +221,40 @@ Per-IP rate limiting keys on the connection's source address. Behind a reverse p
 
 Set `TRUSTED_PROXY=true` **only** when an edge proxy you control always sets `X-Forwarded-For` (Caddy, nginx, and Traefik do by default). If the app is exposed to the internet directly, leave it `false`: otherwise clients forge the header and evade rate limiting entirely.
 
+## Sizing the container
+
+ffmpeg runs inside the process that serves HTTP, so an under-provisioned container does not just fail the edit — the OOM killer drops every in-flight request with it. A 1080p encode holds roughly 300 MB on top of the server itself.
+
+`MAX_CONCURRENT_ENCODES` (default `1`) caps how many encodes run at once, so extra edits queue rather than multiplying that figure. Raise it and the memory allowance together, never on its own.
+
+### Measuring your own floor
+
+Numbers from someone else's recordings are a starting point. Measure yours — a few minutes, no tooling beyond Docker:
+
+```bash
+C=sendrec   # your container name, from: docker ps
+
+# 1. Idle baseline: the Go server and nothing else.
+docker exec "$C" awk '/^anon /{printf "%.0f MB\n", $2/1048576}' /sys/fs/cgroup/memory.stat
+
+# 2. Start this sampler, then trigger the heaviest edit you expect: largest
+#    resolution, longest recording, remove-segments with many cuts.
+#    Stop it when the edit finishes; the last line printed is your figure.
+docker exec "$C" sh -c \
+  'while :; do awk "/^anon /{print \$2}" /sys/fs/cgroup/memory.stat; sleep 1; done' \
+  | awk '{ if ($1>m) { m=$1; printf "peak anon %.0f MB\n", m/1048576 } }'
+```
+
+Then set `mem_limit` (Compose) or `--memory` to **step 1 + N × (step 2 − step 1)**, plus about 20% headroom, where N is `MAX_CONCURRENT_ENCODES`. Step 2 already includes one encode, so at the default `N = 1` that is just step 2 plus headroom.
+
+**Read `anon`, not `docker stats` or `memory.current`.** Both include page cache, and this app writes multi-hundred-megabyte temp files for every edit, so cache dominates the total. Cache is reclaimable — the kernel evicts it under pressure instead of OOM-killing — so sizing from it over-provisions substantially. A production instance of this app reported 1757 MB of `memory.peak` while holding 8 MB of `anon` and 122 MB of cache.
+
+`anon` is the non-reclaimable working set, and what the OOM killer acts on. Memory-backed volumes are the exception: they are charged as `shmem` rather than `anon` and are *not* reclaimable, so add their contents by hand if you mount `/tmp` as tmpfs.
+
+Needs cgroup v2. On cgroup v1, read the `rss` line of `/sys/fs/cgroup/memory/memory.stat` the same way.
+
+Re-measure when you change resolution limits, enable transcription or noise reduction, or raise the concurrency limit — each moves the floor.
+
 ## Environment variables
 
 ### Required

--- a/helm/sendrec/README.md
+++ b/helm/sendrec/README.md
@@ -384,5 +384,5 @@ This deletes everything the release owns, including the whisper model PVC - add 
 
 ## See also
 
-- [SELF-HOSTING.md](../../SELF-HOSTING.md) - provider notes and Docker Compose setup. It predates several of the variables above (`RATE_LIMIT_ENABLED`, `WEBHOOK_ALLOW_PRIVATE_TARGETS`, `NOISE_REDUCTION_FILTER`, `DEVELOPER_EMAIL`, the workspace Creem product IDs), so treat this page as the current reference for anything under `sendrec.env`
+- [SELF-HOSTING.md](../../SELF-HOSTING.md) - provider notes and Docker Compose setup, including the Docker equivalent of the sizing procedure above. It predates several of the variables above (`RATE_LIMIT_ENABLED`, `WEBHOOK_ALLOW_PRIVATE_TARGETS`, `NOISE_REDUCTION_FILTER`, `DEVELOPER_EMAIL`, the workspace Creem product IDs), so treat this page as the current reference for anything under `sendrec.env`
 - [Releases](https://github.com/sendrec/sendrec/releases) - changelog


### PR DESCRIPTION
**Stacked on #213** — review that first; it carries the reasoning for measuring `anon` instead of `memory.peak`.

The sizing runbook lives in the chart README and is written entirely in `kubectl`. But sendrec's own production runs Docker under Coolify, and so does every deployment following SELF-HOSTING.md — so the operators most likely to hit the memory floor had no procedure at all.

This adds the Docker equivalent to SELF-HOSTING.md under a new **Sizing the container** section: same `anon` sampling, same formula, sized with `mem_limit` / `--memory` rather than resource requests. Cross-linked from the chart README.

### Verified against the live container

Both commands were executed on production before being written down:

- `awk` is present in the image
- the cgroup is namespaced, so the container reads its own figures rather than the host's
- step 1 returns `8 MB`
- `docker stats` reports `109.5MiB` for the same container against `memory.current` of `131.5MB` — it subtracts inactive cache but still counts active cache, which is why the text points at `anon` instead

### Note

Verifying step 2 left a sampler loop running inside the production container. I noticed it in the follow-up check and killed it; container is `running`, `restarts=0`, `anon` back to 8 MB. Nothing else on that host was touched, and no edit was triggered.

Docs only.

## Checklist

- [x] `make test` passes
- [x] `make build` succeeds
- [x] New code has tests where applicable — n/a
- [x] No unrelated changes included