### PR TITLE
fix: bound edit output and correct container sizing

### DIFF
--- a/SELF-HOSTING.md
+++ b/SELF-HOSTING.md
@@ -23,7 +23,7 @@ SendRec includes a Helm chart at `helm/sendrec` for Kubernetes deployments.
 - Helm 3
 - PostgreSQL database
 - S3-compatible object storage
-- **At least 512 MB of memory for the app container**, whatever the deployment method. ffmpeg runs in the same process that serves HTTP, and a single 1080p encode peaks around 350 MB, so an under-provisioned container does not merely fail the edit — the OOM killer drops every in-flight request with it. Budget more for 4K sources, local transcription, or concurrent edits.
+- **Start with 1 GiB for the app container and measure your workload** using [Sizing the container](#sizing-the-container). ffmpeg is a child process in the HTTP server's container: memory pressure can take down live traffic as well as the edit. High-resolution sources, local transcription and concurrent jobs can require more.
 
 ### 1. Create a values file
 
@@ -223,35 +223,83 @@ Set `TRUSTED_PROXY=true` **only** when an edge proxy you control always sets `X-
 
 ## Sizing the container
 
-ffmpeg runs inside the process that serves HTTP, so an under-provisioned container does not just fail the edit — the OOM killer drops every in-flight request with it. A 1080p encode holds roughly 300 MB on top of the server itself.
+ffmpeg runs as a child process in the HTTP server's container. Encoder settings do not impose a container memory ceiling: decoders still hold full-resolution input frames, even when the output is scaled down.
 
-`MAX_CONCURRENT_ENCODES` (default `1`) caps how many encodes run at once, so extra edits queue rather than multiplying that figure. Raise it and the memory allowance together, never on its own.
+`MAX_CONCURRENT_ENCODES` (default `1`) caps simultaneous encodes per app process. Extra edits queue. It does not cover local transcription, probes, thumbnails, or downloads/uploads. Raise concurrency and the memory allowance together.
+
+The chart now requests **1Gi**, without a default memory limit. This replaces the 512Mi estimate from a synthetic 1080p encode. On 2026-09-05, staging image `6219d0a` (after #208) held **837.3 MiB of anon** while removing 200 ranges from a 3242×2626, 1000 fps recording; idle was **6.64 MiB**, shmem was zero, and only one encode ran. With N=1 and 20% headroom, that requires **1004.8 MiB**, exceeding 512Mi by **492.8 MiB**. The job timed out after ten minutes, so this is a measured lower bound, not a completed-job ceiling. Remove-segments now scales its output to fit 1920×1080 at 60 fps; remeasure after upgrading. The 1Gi default is a starting reservation, not a guarantee for every source.
+
+With these fixes, the same 200-cut edit on a copy completed in **367.3 seconds**. A disposable container using staging's FFmpeg 6.1.2 runtime and the patched binary (SHA-256 `534ea9aaeec27bd31464f1ca0c7c2473a761648dea84f70c71640bfc2400c5b8`, image created 2026-09-05 21:36 UTC) measured:
+
+| Measurement | Result |
+| --- | --- |
+| Idle anon | 5,836,800 bytes (5.57 MiB) |
+| Peak anon | 381,378,560 bytes (363.71 MiB) |
+| Within 5% of peak | 362.0 seconds, 363 one-second samples |
+| Shmem / swap / OOMs / restarts | Zero |
+| N=1 reservation: `(idle + (peak − idle)) × 1.2` | 457,654,272 bytes (436.45 MiB) |
+| Margin below 512Mi / 1Gi | 75.55 MiB / 587.55 MiB |
+
+This was the largest-resolution staging recording: 3242×2626, 43.167 seconds, 43,167 video frames, with audio. The completed output was 1334×1080 at 60 fps; video lasted 37.183 seconds and audio 37.172 seconds. The host exposed four CPUs, `/tmp` was disk-backed, and neither the container nor its ancestors imposed a memory limit. Only the app, its one edit subprocess at a time, and short-lived sampler commands ran in the measured cgroup; transcription was disabled and no other edit was active. The source and final-output probes ran separately, outside the measured container. The copied recording, container and sampler resources were removed; the original recording was unchanged.
+
+**512Mi covers this completed single-job run, not every accepted input or worker combination.** The 1Gi default remains a conservative starting reservation; reducing it requires a measurement on the image and workload you actually deploy. Decoding larger sources and enabling other workers can still exceed it.
+
+**Image matters:** the chart still defaults to `v1.90.5`, which predates #208, the concurrency gate and these edit fixes. That image ignores `MAX_CONCURRENT_ENCODES`; do not assume N=1 just because the chart sets it. Updating the chart alone does not install the fixed application. Select a reviewed image containing these fixes once released, then measure it; neither measurement certifies the older default image.
 
 ### Measuring your own floor
 
-Numbers from someone else's recordings are a starting point. Measure yours — a few minutes, no tooling beyond Docker:
+Use staging or a disposable copy of a recording. Confirm the container serves the intended hostname and its image contains the changes being tested; a later image creation date alone does not prove which code it contains. Wait for unrelated work to finish. These commands require Bash on the host and cgroup v2 in the container:
 
 ```bash
-C=sendrec   # your container name, from: docker ps
+C=$(docker inspect --format '{{.Id}}' sendrec)  # replace sendrec with your container
+docker inspect --format 'name={{.Name}} image={{.Image}} restarts={{.RestartCount}}' "$C"
+docker image inspect --format 'created={{.Created}} labels={{json .Config.Labels}}' \
+  "$(docker inspect --format '{{.Image}}' "$C")"
+docker exec "$C" sh -c 'cat /proc/1/cgroup /proc/self/cgroup; cat /sys/fs/cgroup/memory.max /sys/fs/cgroup/memory.swap.current /sys/fs/cgroup/memory.events; df -T /tmp'
 
-# 1. Idle baseline: the Go server and nothing else.
-docker exec "$C" awk '/^anon /{printf "%.0f MB\n", $2/1048576}' /sys/fs/cgroup/memory.stat
+# Require a private cgroup namespace with its root mounted here. Matching
+# /proc paths alone can still mean memory.stat belongs to the host root.
+# Do not certify a run with swapping, OOMs, or a restart.
+sample() {
+  docker exec "$C" sh -c '
+    test "$(cat /proc/1/cgroup)" = "0::/" &&
+    test "$(cat /proc/self/cgroup)" = "0::/" &&
+    awk '\''$4=="/" && $5=="/sys/fs/cgroup" && / - cgroup2 / {ok=1}
+      END{exit !ok}'\'' /proc/self/mountinfo || {
+      echo "Unsupported cgroup scope: resolve the app cgroup before sampling" >&2
+      exit 1
+    }
+    awk '\''$1=="anon"{a=$2} $1=="shmem"{s=$2}
+      END{printf "bytes %.0f %.0f %.0f\n", a, s, a+s}'\'' /sys/fs/cgroup/memory.stat &&
+    ps -o pid,ppid,comm'
+}
+sample  # idle baseline: bytes anon shmem sum; check the process list
 
-# 2. Start this sampler, then trigger the heaviest edit you expect: largest
-#    resolution, longest recording, remove-segments with many cuts.
-#    Stop it when the edit finishes; the last line printed is your figure.
-docker exec "$C" sh -c \
-  'while :; do awk "/^anon /{print \$2}" /sys/fs/cgroup/memory.stat; sleep 1; done' \
-  | awk '{ if ($1>m) { m=$1; printf "peak anon %.0f MB\n", m/1048576 } }'
+# Trigger the heaviest edit on a COPY in another terminal. Record whether it
+# completes. The loop is on the HOST, bounded to 900 samples, with no remote
+# sleep/loop to survive Ctrl-C. Every exec is a single short-lived snapshot.
+for ((i=0; i<900; i++)); do
+  date -u +%FT%TZ
+  sample || { echo "Sampling failed; discard this run" >&2; break; }
+  sleep 1
+done | awk '$1=="bytes" {if ($4>m) m=$4;
+  printf "anon=%.2f MiB shmem=%.2f MiB total=%.2f MiB peak=%.2f MiB\n", $2/1048576, $3/1048576, $4/1048576, m/1048576;
+  next} {print} {fflush()}'
+
+# After stopping: verify no sampler or edit remains inside the container.
+docker exec "$C" sh -c 'ps -o pid,ppid,comm; ls -la /tmp; cat /sys/fs/cgroup/memory.events'
+docker inspect --format 'restarts={{.RestartCount}}' "$C"
 ```
 
-Then set `mem_limit` (Compose) or `--memory` to **step 1 + N × (step 2 − step 1)**, plus about 20% headroom, where N is `MAX_CONCURRENT_ENCODES`. Step 2 already includes one encode, so at the default `N = 1` that is just step 2 plus headroom.
+If the scope check fails, stop: on a host-cgroup-namespace container, resolve the app's exact cgroup path and mount before adapting the sampler. Do not remove the guard and read the host root instead. Also check ancestor limits from the host; they may not be visible inside a private namespace.
 
-**Read `anon`, not `docker stats` or `memory.current`.** Both include page cache, and this app writes multi-hundred-megabyte temp files for every edit, so cache dominates the total. Cache is reclaimable — the kernel evicts it under pressure instead of OOM-killing — so sizing from it over-provisions substantially. A production instance of this app reported 1757 MB of `memory.peak` while holding 8 MB of `anon` and 122 MB of cache.
+The samples must rise when ffmpeg starts and fall when it exits. Keep timestamps and PIDs: a second job taking the slot, another process, or an unexpected shared cgroup changes what the peak means. Report the peak and time held within 5% of it. A failed/timed-out encode supplies only a lower bound; repeat through successful completion before certifying a size. Compare each stream's output duration as well as the job status.
 
-`anon` is the non-reclaimable working set, and what the OOM killer acts on. Memory-backed volumes are the exception: they are charged as `shmem` rather than `anon` and are *not* reclaimable, so add their contents by hand if you mount `/tmp` as tmpfs.
+Use **(idle + N × (peak − idle)) × 1.2** as a starting memory reservation, with idle and peak both measured as anon + shmem, and N taken from the running app's `MAX_CONCURRENT_ENCODES` setting/startup log. At N=1 this is peak × 1.2. Test actual concurrency before relying on the extrapolation; queued downloads, thumbnails and transcription need their own allowance.
 
-Needs cgroup v2. On cgroup v1, read the `rss` line of `/sys/fs/cgroup/memory/memory.stat` the same way.
+**This is not a formula for a hard limit.** `mem_limit` (Compose) and `--memory` include kernel memory and page cache too. Measure their behavior under the proposed limit with headroom for larger inputs; a request/reservation does not enforce a limit. Docker/Coolify does not perform Kubernetes request-based scheduling.
+
+Read **anon + shmem**, not `docker stats`, `memory.current` or `memory.peak`, for this resident working-set estimate. Those totals include reclaimable disk page cache from temporary files, and a constrained total can merely report the limit. Anonymous memory and tmpfs/shmem cannot be reclaimed without swapping; the sampler includes shmem automatically. They are not the whole charged footprint: kernel memory and actively used file-backed pages can also matter. One-second snapshots can miss brief spikes. If the container or an ancestor has a tight limit, or `memory.swap.current` is nonzero, do not treat its resident peak as unconstrained demand.
 
 Re-measure when you change resolution limits, enable transcription or noise reduction, or raise the concurrency limit — each moves the floor.
 

--- a/helm/sendrec/Chart.yaml
+++ b/helm/sendrec/Chart.yaml
@@ -20,5 +20,5 @@ maintainers:
 - name: mark24slides
 - name: alexneamtu 
 
-version: "1.4.0"
+version: "1.5.0"
 appVersion: "1.90.5"

--- a/helm/sendrec/README.md
+++ b/helm/sendrec/README.md
@@ -115,7 +115,7 @@ Set any of these to `"0"` for unlimited. The chart ships `"0"` for all three, so
 | `env.maxVideosPerMonth` | `MAX_VIDEOS_PER_MONTH` | Videos a user may create per month | `0` (app: free plan, `25`) |
 | `env.maxVideoDurationSeconds` | `MAX_VIDEO_DURATION_SECONDS` | Max recording length | `0` (app: free plan, `300`) |
 | `env.maxPlaylists` | `MAX_PLAYLISTS` | Playlists a free-tier user may create | `0` (app: free plan, `3`) |
-| `env.maxConcurrentEncodes` | `MAX_CONCURRENT_ENCODES` | ffmpeg encodes allowed to run at once **per pod**. Extra edits queue, holding their downloaded source on disk while they wait. Each 1080p encode peaks near 300 MB, so raise this and the memory request together | `1` |
+| `env.maxConcurrentEncodes` | `MAX_CONCURRENT_ENCODES` | ffmpeg encodes allowed to run at once **per app process**. Extra edits queue, holding their downloaded source on disk while they wait. Raise this and the measured memory request together; other workers are outside the gate | `1` |
 
 ### Features
 
@@ -261,7 +261,7 @@ Rendered into `sendrec-secret` unless `existingSecret` is set: `DATABASE_URL`, `
 | `replicas` | Pod count. The app is stateless (state lives in Postgres and S3), but transcode/transcription jobs run in-process | `1` |
 | `image.repository` / `image.tag` / `image.pullPolicy` | Container image. An empty tag resolves to `v<appVersion>` from `Chart.yaml` | `ghcr.io/sendrec/sendrec` / `""` / `Always` |
 | `deploymentStrategy` | Passed through to the Deployment | `RollingUpdate` 25%/25% |
-| `resources` | Requests/limits. See [Sizing the pod](#sizing-the-pod) | `200m` / `512Mi` requests, no limit |
+| `resources` | Requests/limits. See [Sizing the pod](#sizing-the-pod) | `200m` / `1Gi` requests, no limit |
 | `livenessProbe` / `readinessProbe` | Passed through as-is; both hit `/api/health` | see `values.yaml` |
 | `deployment.extraInitContainers` | Extra init containers, appended after the model downloader | `[]` |
 | `deployment.extraContainers` | Sidecars | `[]` |
@@ -272,67 +272,56 @@ The Deployment carries `checksum/configmap` and `checksum/secret` annotations, s
 
 ### Sizing the pod
 
-**Editing has a memory floor, and it is well above what an HTTP server needs.** Transcode, normalize, trim, remove-segments and composite all run ffmpeg in this pod. Measured peak RSS for a single 1080p30 x264 encode, ffmpeg 7.1:
+The chart requests **1Gi** and sets no memory limit. The former 512Mi request was based on a synthetic 1080p ffmpeg process, not a real app-container edit. A post-#208 staging image held **837.3 MiB anon** on a high-DPI edit: with 20% headroom that is already **1004.8 MiB**. That edit timed out, so this establishes a lower bound, not a universal ceiling. See the [measurement and its scope](../../SELF-HOSTING.md#sizing-the-container).
 
-| | peak RSS |
-| --- | --- |
-| ffmpeg defaults | ~540 MB |
-| the bounded settings the app now passes | ~300 MB |
-| stream copy, no encode | ~35 MB |
+The patched remove-segments path completed that same edit at **363.71 MiB anon**: **436.45 MiB** with 20% headroom, leaving **75.55 MiB** below 512Mi. That supports 512Mi for this one measured job on the patched image, not every input or enabled worker. The 1Gi default is a conservative starting reservation, not a measured universal ceiling.
 
-Figures are approximate and move with the ffmpeg build, the input and the machine — run `hack/encoder-memory/run.sh` for numbers that describe your environment.
+The default application image is still `v1.90.5`, older than #208, the concurrency gate and the remove-segments resolution/frame-rate fix. It ignores `MAX_CONCURRENT_ENCODES`, even though the chart sets it. A chart upgrade alone does not upgrade to those fixes. Set `image.tag` to a reviewed release containing them when available and remeasure; the figures above do not certify the older default image.
 
-Two things that table does **not** say. It measures the ffmpeg process alone, not the pod: the Go server sits alongside it. And it measures one encode — nothing in the app bounds how many run at once, so two concurrent edits want roughly twice this.
+`env.maxConcurrentEncodes` defaults to `1` per app process; extra encodes queue. Transcription, probes, thumbnails, downloads and uploads are outside that gate. Decoders still hold source-resolution frames even when output is scaled down. Measure high-DPI sources and all enabled workers before reducing the reservation or raising concurrency.
 
-The chart requests `512Mi` and sets no memory limit. The request is what gets the pod scheduled somewhere it can actually finish an encode; the absent limit is deliberate, because the app does not bound how many encodes run at once, so any default limit would be a hard kill threshold guessed without knowing your inputs. Set `resources.limits.memory` once you have measured your own workload.
-
-`512Mi` is not enough for everything:
-
-- **4K or high-DPI sources** scale roughly with pixel count. The app scales down to 1080p during transcode, but the decode side still holds full-resolution frames.
-- **Local transcription** runs whisper.cpp in the same pod and is both CPU and memory hungry.
-- **Noise reduction** adds an ffmpeg filter to every transcode.
-- **Concurrent jobs.** `env.maxConcurrentEncodes` defaults to `1`, so extra edits queue instead of running alongside each other. `512Mi` is sized for that one encode. Raising the limit multiplies peak memory, so raise the request with it.
-
-Under-provisioning does not fail gracefully: the OOM killer takes the whole pod, so an edit triggered by one user drops every in-flight request. If you cannot give the pod headroom, keep `replicas: 1` and expect edits on large recordings to fail.
+**Upgrade impact:** the higher request can leave pods Pending if a small cluster lacks allocatable memory. Override `sendrec.resources.requests.memory` only from a measurement of your workload. Requests reserve scheduling capacity; they neither guarantee edit completion nor impose a hard cap. Leaving `limits: {}` preserves bursting. Choose a limit separately after testing it under load; exceeding one can interrupt live HTTP traffic as well as the edit.
 
 #### Measuring your own floor
 
-The figures above are one ffmpeg process on synthetic content. The number that matters is the app container on your recordings, and only you can measure that. Ten minutes, no tooling:
+Follow the checks and interpretation in [Sizing the container](../../SELF-HOSTING.md#sizing-the-container): identify the image/code, verify cgroup scope and limits, start idle, observe a completed edit on a copy, account for every process, and check cleanup. For Kubernetes use this Bash sampler on your workstation:
 
-```sh
+```bash
 POD=$(kubectl -n sendrec get pod -l app=sendrec -o jsonpath='{.items[0].metadata.name}')
-
-# 1. Idle baseline — the Go server and nothing else.
-kubectl -n sendrec exec "$POD" -c sendrec -- \
-  awk '/^anon /{printf "%.0f MB\n", $2/1048576}' /sys/fs/cgroup/memory.stat
-
-# 2. Start this sampler, then trigger the heaviest edit you expect: your
-#    largest resolution, longest recording, remove-segments with many cuts.
-#    Stop it when the edit finishes; the last line it printed is your figure.
+kubectl -n sendrec get pod "$POD" -o jsonpath='{.status.containerStatuses}'
 kubectl -n sendrec exec "$POD" -c sendrec -- sh -c \
-  'while :; do awk "/^anon /{print \$2}" /sys/fs/cgroup/memory.stat; sleep 1; done' \
-  | awk '{ if ($1>m) { m=$1; printf "peak anon %.0f MB\n", m/1048576 } }' 
+  'cat /proc/1/cgroup /proc/self/cgroup; cat /sys/fs/cgroup/memory.max /sys/fs/cgroup/memory.swap.current /sys/fs/cgroup/memory.events; df -T /tmp'
+sample() {
+  kubectl -n sendrec exec "$POD" -c sendrec -- sh -c '
+    test "$(cat /proc/1/cgroup)" = "0::/" &&
+    test "$(cat /proc/self/cgroup)" = "0::/" &&
+    awk '\''$4=="/" && $5=="/sys/fs/cgroup" && / - cgroup2 / {ok=1}
+      END{exit !ok}'\'' /proc/self/mountinfo || {
+      echo "Unsupported cgroup scope: resolve the app cgroup before sampling" >&2
+      exit 1
+    }
+    awk '\''$1=="anon"{a=$2} $1=="shmem"{s=$2}
+      END{printf "bytes %.0f %.0f %.0f\n", a, s, a+s}'\'' /sys/fs/cgroup/memory.stat &&
+    ps -o pid,ppid,comm'
+}
+sample  # idle baseline: bytes anon shmem sum
+# Trigger the edit in another terminal. Ctrl-C stops the LOCAL loop;
+# no loop or sleep is started in the app container.
+for ((i=0; i<900; i++)); do
+  date -u +%FT%TZ
+  sample || { echo "Sampling failed; discard this run" >&2; break; }
+  sleep 1
+done | awk '$1=="bytes" {if ($4>m) m=$4;
+  printf "anon=%.2f MiB shmem=%.2f MiB total=%.2f MiB peak=%.2f MiB\n", $2/1048576, $3/1048576, $4/1048576, m/1048576;
+  next} {print} {fflush()}'
+kubectl -n sendrec exec "$POD" -c sendrec -- sh -c \
+  'ps -o pid,ppid,comm; ls -la /tmp; cat /sys/fs/cgroup/memory.events'
+kubectl -n sendrec get pod "$POD" -o jsonpath='{.status.containerStatuses}'
 ```
 
-`-c sendrec` matters: the chart renders `deployment.extraContainers` *before* the app container, so without it `kubectl exec` lands in your first sidecar and reports that container's memory instead. The figure is per container, not per pod — for the default single-container pod the two are the same.
+Keep `-c sendrec`: sidecars have separate cgroups and separate requests. Verify the selected pod is the one executing the edit and that its container ID and restart count do not change. The scope guard requires a private cgroup namespace and a mount rooted at the app cgroup; if it rejects your runtime, resolve the app's exact cgroup path before adapting it. Check ancestor limits from the node too. The loop reports anon + shmem, includes tmpfs automatically, prints PIDs and timestamps, and creates no temporary files.
 
-**Sample `anon`, not `memory.peak`.** This is the easy thing to get wrong, and getting it wrong over-provisions badly. `memory.peak` and `memory.current` count page cache, and this app writes multi-hundred-megabyte temp files for every edit, so cache dominates the total. Page cache is *reclaimable* — under a limit the kernel evicts it rather than OOM-killing. Two consequences:
-
-- **With no limit set, `memory.peak` is inflated.** A production instance showed `memory.peak` of 1757 MB after three days while holding 8 MB of `anon` and 122 MB of cache. Sizing a request from that number reserves far more than the process needs.
-- **With a limit already set, `memory.peak` is circular** — it saturates at the limit. Writing 400 MB inside a 256 MB cgroup reports a peak of exactly 256 MB and zero OOM kills. Re-running the procedure after you set a limit hands you back the limit.
-
-`anon` is the non-reclaimable part — the encoder's real working set, and what the OOM killer acts on. cgroup v2 keeps no historical peak for it, hence the sampler. One-second polling is enough: an encode holds its allocation for the whole run rather than spiking.
-
-One caveat on `anon`: memory-backed volumes are charged as `shmem`, not `anon`, and unlike page cache they are *not* reclaimable. The chart's `emptyDir` volumes are disk-backed, so this does not apply as shipped — but if you mount `/tmp` or the transcription volume with `medium: Memory`, add their contents to the figure.
-
-Needs cgroup v2. On cgroup v1, read the `rss` line of `/sys/fs/cgroup/memory/memory.stat` the same way.
-
-Then size it:
-
-- **Request** = (step 1 + N × (step 2 − step 1)) with 20% headroom, where N is `env.maxConcurrentEncodes`. Step 2 already contains one encode, so with the default N = 1 this is just step 2 plus headroom; each further concurrent encode adds the step 2 − step 1 difference once more.
-- **Limit** = request plus whatever headroom you want for a recording bigger than the one you tested, plus room for page cache on top. Setting it below the step 2 figure means the OOM killer, not a slow edit; setting it only slightly above makes the kernel thrash reclaiming cache.
-
-Repeat when you change resolution limits, enable transcription or noise reduction, or raise the concurrency limit — each moves the floor.
+Starting **request = (idle + N × (peak − idle)) × 1.2**, where N is the running app's encoder concurrency. Validate the extrapolation with actual concurrent jobs and budget other workers separately. This resident estimate excludes disk page cache and kernel memory; it is not a hard-limit formula. One-second sampling can miss brief spikes, and a timed-out, swapping, or OOM-killed run cannot certify a completed-job ceiling. Remeasure after image, input-size or feature changes.
 
 ## Networking
 

--- a/helm/sendrec/values.yaml
+++ b/helm/sendrec/values.yaml
@@ -38,9 +38,8 @@ sendrec:
     maxVideoDurationSeconds: "0"  # per-recording length cap ("" = free plan, 300s)
     maxPlaylists: "0"             # per-user playlist cap ("" = free plan, 3)
 
-    # How many ffmpeg encodes may run at once in the pod. Each 1080p encode peaks
-    # around 300 MB, so this multiplies peak memory: raise it and resources.requests
-    # together. Extra edits queue rather than fail.
+    # Encodes per app process. Extra edits queue. Raise this and the measured
+    # memory request together; transcription and decode-only jobs are separate.
     maxConcurrentEncodes: "1"
 
     # Features
@@ -136,21 +135,17 @@ sendrec:
 
   port: 8080
 
-  # Sized for video work, not for an idle HTTP server. Transcode, trim,
-  # remove-segments and composite all run ffmpeg inside this pod, and a 1080p
-  # x264 encode peaks around 350 MB on its own. 128Mi was enough to serve
-  # requests and not enough to finish an edit, which OOM-killed the pod and took
-  # live traffic with it. Raise both numbers again for 4K sources or local
-  # transcription.
+  # Starting reservation for one encode, not a memory ceiling. A real high-DPI
+  # edit held 837.3 MiB anon before timing out; with 20% headroom that already
+  # exceeds the former 512Mi request. See README for scope and remeasurement.
+  # A 1Gi request may leave pods Pending on small clusters; size from recordings.
   resources:
-    # No memory limit by default. The app does not bound how many encodes run at
-    # once, so any limit picked here is a hard kill threshold guessed without
-    # knowing your input sizes or concurrency. Set one once you have measured
-    # your own workload.
+    # Concurrency is bounded, input memory is not. Keep bursting available;
+    # choose a hard limit only after testing inputs and all enabled workers.
     limits: {}
     requests:
       cpu: 200m
-      memory: 512Mi
+      memory: 1Gi
 
   livenessProbe:
     httpGet:

--- a/internal/video/composite.go
+++ b/internal/video/composite.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"strings"
+	"time"
 
 	"github.com/sendrec/sendrec/internal/database"
 )
@@ -108,8 +109,10 @@ func CompositeWithWebcam(ctx context.Context, db database.DBTX, storage ObjectSt
 	slog.Info("composite: starting webcam overlay", "video_id", videoID)
 
 	setReadyFallback := func() {
-		if _, err := db.Exec(ctx,
-			`UPDATE videos SET status = 'ready', webcam_key = NULL, processing_started_at = NULL, updated_at = now() WHERE id = $1`,
+		recoveryCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 5*time.Second)
+		defer cancel()
+		if _, err := db.Exec(recoveryCtx,
+			`UPDATE videos SET status = 'ready', webcam_key = NULL, processing_started_at = NULL, updated_at = now() WHERE id = $1 AND status = 'processing'`,
 			videoID,
 		); err != nil {
 			slog.Error("composite: failed to set fallback ready status", "video_id", videoID, "error", err)

--- a/internal/video/edit_recovery_test.go
+++ b/internal/video/edit_recovery_test.go
@@ -1,0 +1,56 @@
+package video
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/sendrec/sendrec/internal/database"
+)
+
+// pgxmock accepts cancelled contexts, unlike the database driver.
+type recoveryDB struct {
+	database.DBTX
+	updated  bool
+	deadline time.Time
+}
+
+func (db *recoveryDB) Exec(ctx context.Context, _ string, _ ...any) (pgconn.CommandTag, error) {
+	if err := ctx.Err(); err != nil {
+		return pgconn.CommandTag{}, err
+	}
+	db.updated = true
+	db.deadline, _ = ctx.Deadline()
+	return pgconn.NewCommandTag("UPDATE 1"), nil
+}
+
+func TestFailedEditsRecoverAfterCancellation(t *testing.T) {
+	for _, edit := range []struct {
+		name string
+		run  func(context.Context, database.DBTX, ObjectStorage)
+	}{
+		{"trim", func(ctx context.Context, db database.DBTX, storage ObjectStorage) {
+			TrimVideoAsync(ctx, db, storage, "video", "input", "thumbnail", "video/mp4", 0, 2)
+		}},
+		{"composite", func(ctx context.Context, db database.DBTX, storage ObjectStorage) {
+			CompositeWithWebcam(ctx, db, storage, "video", "input", "webcam", "thumbnail", "video/mp4")
+		}},
+		{"remove-segments", func(ctx context.Context, db database.DBTX, storage ObjectStorage) {
+			RemoveSegmentsAsync(ctx, db, storage, "video", "input", "thumbnail", "video/mp4", []segmentRange{{Start: 1, End: 2}}, 3)
+		}},
+	} {
+		t.Run(edit.name, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			cancel()
+			db := &recoveryDB{}
+			edit.run(ctx, db, &mockStorage{downloadToFileErr: context.Canceled})
+			if !db.updated {
+				t.Fatal("cancelled edit left its processing status stuck")
+			}
+			if remaining := time.Until(db.deadline); remaining <= 0 || remaining > 10*time.Second {
+				t.Errorf("recovery must have a fresh bounded deadline, got %v", db.deadline)
+			}
+		})
+	}
+}

--- a/internal/video/encoder_slots.go
+++ b/internal/video/encoder_slots.go
@@ -10,18 +10,15 @@ import (
 // DefaultEncoderConcurrency is how many ffmpeg encodes may run at once when
 // MAX_CONCURRENT_ENCODES is unset.
 //
-// One, because the deployment is sized for one. A 1080p encode peaks around
-// 300 MB and the chart requests 512Mi, so a second concurrent encode wants
-// memory the pod never reserved. Raise it together with the memory request,
-// not on its own.
+// Raise it together with the measured memory reservation, not on its own.
 const DefaultEncoderConcurrency = 1
 
 // encoderSlots bounds how many ffmpeg encodes run concurrently in this process.
 //
-// Every encode runs in the process that serves HTTP, so concurrency multiplies
+// Every encode runs in the container that serves HTTP, so concurrency multiplies
 // peak memory directly: two 1080p edits at once want roughly twice what one
 // does, and the pod is sized for one. Without this the memory bounds in
-// x264MemoryParams and ffmpegPipelineThreads cap a single encode while nothing
+// x264MemoryParams and the thread helpers bound a single encode while nothing
 // caps how many there are — a per-encode ceiling with no process-wide one.
 //
 // Queueing is the intended behaviour. An edit that waits is slower; an edit that

--- a/internal/video/remove_segments.go
+++ b/internal/video/remove_segments.go
@@ -146,26 +146,53 @@ func audioCodecForContentType(ct string) string {
 	}
 }
 
+// Split audio once at sample-accurate boundaries. aselect drops whole decoded
+// packets: a two-millisecond cut can otherwise remove 1024 samples. asegment
+// routes successive samples to successive outputs without duplicating input.
+func buildSegmentAudioFilter(segments []segmentRange) string {
+	timestamps := make([]string, 0, 2*len(segments))
+	for _, seg := range segments {
+		timestamps = append(timestamps, fmt.Sprintf("%.3f", seg.Start), fmt.Sprintf("%.3f", seg.End))
+	}
+	outputs := make([]string, 2*len(segments)+1)
+	filters := make([]string, len(outputs))
+	kept := make([]string, 0, len(segments)+1)
+	for i := range outputs {
+		outputs[i] = fmt.Sprintf("[aseg%d]", i)
+		if i%2 == 0 {
+			label := fmt.Sprintf("[akeep%d]", i)
+			filters[i] = outputs[i] + "asetpts=PTS-STARTPTS" + label
+			kept = append(kept, label)
+		} else {
+			filters[i] = outputs[i] + "anullsink"
+		}
+	}
+	return "[0:a]asettb=1/sr,asetpts=N,asegment=timestamps='" + strings.Join(timestamps, "|") + "'" + strings.Join(outputs, "") + ";" +
+		strings.Join(filters, ";") + ";" + strings.Join(kept, "") + fmt.Sprintf("concat=n=%d:v=0:a=1[a]", len(kept))
+}
+
 func buildRemoveSegmentsArgs(inputPath, outputPath, contentType string, segments []segmentRange, audioPresent bool) []string {
 	betweenExpr := buildSegmentFilter(segments)
+	removedTime := make([]string, len(segments))
+	for i, seg := range segments {
+		removedTime[i] = fmt.Sprintf("gte(T,%.3f)*(%.3f-%.3f)", seg.End, seg.End, seg.Start)
+	}
+	// Cut before reducing frame rate: cuts aimed at the reduced frame grid could
+	// otherwise erase retained source frames. Bound frames before scaling/encoding.
+	// Shift by elapsed cut time, not retained frame count: rounding every cut to
+	// whole frames accumulates A/V drift when many boundaries fall between frames.
+	videoFilter := fmt.Sprintf("[0:v]setpts=PTS-STARTPTS,select='not(%s)',setpts='PTS-(%s)/TB',fps=60,scale='min(1920,iw)':'min(1080,ih)':force_original_aspect_ratio=decrease:force_divisible_by=2[v]", betweenExpr, strings.Join(removedTime, "+"))
 
 	args := append(globalThreads(), inputThreads()...)
 	args = append(args, "-i", inputPath)
 
 	if audioPresent {
-		filterComplex := fmt.Sprintf(
-			"[0:v]select='not(%s)',setpts=N/FRAME_RATE/TB[v];[0:a]aselect='not(%s)',asetpts=N/SR/TB[a]",
-			betweenExpr, betweenExpr,
-		)
+		filterComplex := videoFilter + ";" + buildSegmentAudioFilter(segments)
 		args = append(args, "-filter_complex", filterComplex)
 		args = append(args, "-map", "[v]", "-map", "[a]")
 		args = append(args, "-c:v", videoCodecForContentType(contentType), "-c:a", audioCodecForContentType(contentType))
 	} else {
-		filterComplex := fmt.Sprintf(
-			"[0:v]select='not(%s)',setpts=N/FRAME_RATE/TB[v]",
-			betweenExpr,
-		)
-		args = append(args, "-filter_complex", filterComplex)
+		args = append(args, "-filter_complex", videoFilter)
 		args = append(args, "-map", "[v]")
 		args = append(args, "-c:v", videoCodecForContentType(contentType), "-an")
 	}
@@ -191,6 +218,9 @@ func removeSegmentsFromVideo(ctx context.Context, inputPath, outputPath, content
 	if err != nil {
 		return fmt.Errorf("ffmpeg remove segments: %w: %s", err, string(output))
 	}
+	if _, err := probeVideoProperties(ctx, outputPath); err != nil {
+		return fmt.Errorf("invalid edited video: %w", err)
+	}
 	return nil
 }
 
@@ -198,8 +228,10 @@ func RemoveSegmentsAsync(ctx context.Context, db database.DBTX, storage ObjectSt
 	slog.Info("remove-segments: starting", "video_id", videoID, "segments", len(segments))
 
 	setReadyFallback := func() {
-		if _, err := db.Exec(ctx,
-			`UPDATE videos SET status = 'ready', processing_started_at = NULL, updated_at = now() WHERE id = $1`,
+		recoveryCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 5*time.Second)
+		defer cancel()
+		if _, err := db.Exec(recoveryCtx,
+			`UPDATE videos SET status = 'ready', processing_started_at = NULL, updated_at = now() WHERE id = $1 AND status = 'processing'`,
 			videoID,
 		); err != nil {
 			slog.Error("remove-segments: failed to set fallback ready status", "video_id", videoID, "error", err)

--- a/internal/video/remove_segments_execution_test.go
+++ b/internal/video/remove_segments_execution_test.go
@@ -1,0 +1,147 @@
+package video
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"math"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"testing"
+	"time"
+)
+
+// Inspect encoded output, not the presence or position of an ffmpeg option.
+func TestRemoveSegmentsBoundsActualOutput(t *testing.T) {
+	for _, tool := range []string{"ffmpeg", "ffprobe"} {
+		if _, err := exec.LookPath(tool); err != nil {
+			if os.Getenv("CI") != "" {
+				t.Fatal(err)
+			}
+			t.Skip(tool + " not installed")
+		}
+	}
+	cut := []segmentRange{{Start: 0.5, End: 1}}
+	denseCuts := make([]segmentRange, 200)
+	for i := range denseCuts {
+		denseCuts[i] = segmentRange{Start: float64(1+i*9) / 1000, End: float64(4+i*9) / 1000}
+	}
+	packetCuts := make([]segmentRange, 40)
+	for i := range packetCuts {
+		at := float64(2+i*2) * 1024 / 48000
+		packetCuts[i] = segmentRange{Start: at - 0.001, End: at + 0.001}
+	}
+	frameCuts := make([]segmentRange, 120)
+	for i := range frameCuts {
+		at := float64(i) / 60
+		frameCuts[i] = segmentRange{Start: math.Max(0, at-0.002), End: at + 0.002}
+	}
+	for _, tc := range []struct {
+		name, size, contentType  string
+		fps, maxWidth, maxHeight int
+		audio                    bool
+		segments                 []segmentRange
+		wantFrames               int
+	}{
+		{"high fps mp4", "320x240", "video/mp4", 1000, 320, 240, true, cut, 90},
+		{"high fps quicktime", "320x240", "video/quicktime", 1000, 320, 240, true, cut, 90},
+		{"high fps webm", "320x240", "video/webm", 1000, 320, 240, true, cut, 90},
+		{"high DPI", "2304x1296", "video/mp4", 5, 1920, 1080, false, cut, 90},
+		{"ordinary recording", "320x240", "video/mp4", 30, 320, 240, false, cut, 90},
+		{"dense cuts", "320x240", "video/mp4", 1000, 320, 240, true, denseCuts, 84},
+		{"audio packet boundaries", "320x240", "video/mp4", 60, 320, 240, true, packetCuts, 115},
+		{"retained frames between output frames", "320x240", "video/mp4", 1000, 320, 240, false, frameCuts, 91},
+		{"reject empty video", "320x240", "video/mp4", 60, 320, 240, false, frameCuts, 0},
+		{"cut from start", "320x240", "video/mp4", 1000, 320, 240, true, []segmentRange{{Start: 0, End: 0.5}}, 90},
+		{"cut at end", "320x240", "video/mp4", 1000, 320, 240, true, []segmentRange{{Start: 1.5, End: 2}}, 90},
+		{"adjacent cuts", "320x240", "video/mp4", 1000, 320, 240, true, []segmentRange{{Start: 0.5, End: 0.75}, {Start: 0.75, End: 1}}, 90},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+			defer cancel()
+			dir := t.TempDir()
+			input := filepath.Join(dir, "input.mp4")
+			args := []string{"-v", "error", "-f", "lavfi", "-i", fmt.Sprintf("color=size=%s:rate=%d:duration=2", tc.size, tc.fps)}
+			if tc.audio {
+				args = append(args, "-f", "lavfi", "-i", "sine=frequency=440:sample_rate=48000:duration=2", "-c:a", "aac")
+			}
+			args = append(args, "-c:v", "libx264", "-threads", "1", "-preset", "ultrafast", "-pix_fmt", "yuv420p", input)
+			if out, err := exec.CommandContext(ctx, "ffmpeg", args...).CombinedOutput(); err != nil {
+				t.Fatalf("fixture: %v: %s", err, out)
+			}
+			output := filepath.Join(dir, "output"+extensionForContentType(tc.contentType))
+			err := removeSegmentsFromVideo(ctx, input, output, tc.contentType, tc.segments, tc.audio)
+			if tc.wantFrames == 0 {
+				if err == nil {
+					t.Fatal("an empty edit must fail before it can replace the original")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			out, err := exec.CommandContext(ctx, "ffprobe", "-v", "error", "-count_frames", "-show_entries", "stream=codec_type,width,height,r_frame_rate,nb_read_frames,duration:format=duration", "-of", "json", output).Output()
+			if err != nil {
+				t.Fatal(err)
+			}
+			var probe struct {
+				Streams []struct {
+					CodecType     string `json:"codec_type"`
+					Width, Height int
+					Rate          string `json:"r_frame_rate"`
+					Frames        string `json:"nb_read_frames"`
+					Duration      string
+				}
+				Format struct{ Duration string }
+			}
+			if err := json.Unmarshal(out, &probe); err != nil {
+				t.Fatal(err)
+			}
+			duration, err := strconv.ParseFloat(probe.Format.Duration, 64)
+			wantDuration := float64(tc.wantFrames) / 60
+			if err != nil || math.Abs(duration-wantDuration) > 0.05 {
+				t.Errorf("retained duration = %q, want about %g seconds", probe.Format.Duration, wantDuration)
+			}
+			var videoSeen, audioSeen bool
+			for _, stream := range probe.Streams {
+				if stream.CodecType == "audio" {
+					audioSeen = true
+					// MP4/MOV expose per-stream duration; format.duration alone
+					// hides an audio stream shortened by packet-sized cuts.
+					if stream.Duration != "" {
+						audioDuration, err := strconv.ParseFloat(stream.Duration, 64)
+						if err != nil || math.Abs(audioDuration-wantDuration) > 0.025 {
+							t.Errorf("audio duration = %q, want about %g seconds", stream.Duration, wantDuration)
+						}
+					}
+				}
+				if stream.CodecType != "video" {
+					continue
+				}
+				videoSeen = true
+				if stream.Width != tc.maxWidth || stream.Height != tc.maxHeight {
+					t.Errorf("output dimensions = %dx%d, want %dx%d", stream.Width, stream.Height, tc.maxWidth, tc.maxHeight)
+				}
+				var numerator, denominator float64
+				if _, err := fmt.Sscanf(stream.Rate, "%f/%f", &numerator, &denominator); err != nil || denominator == 0 {
+					t.Fatalf("invalid frame rate %q", stream.Rate)
+				}
+				rate := numerator / denominator
+				if rate != 60 {
+					t.Errorf("encoded frame rate = %g, want 60", rate)
+				}
+				frames, err := strconv.Atoi(stream.Frames)
+				// Allow one frame of timestamp quantization for the whole output,
+				// not one frame per cut (the dense fixture caught that drift).
+				if err != nil || math.Abs(float64(frames-tc.wantFrames)) > 1 {
+					t.Errorf("decoded %s frames, want %d ± 1 (cut rounding must not accumulate)", stream.Frames, tc.wantFrames)
+				}
+			}
+			if !videoSeen || audioSeen != tc.audio {
+				t.Errorf("output streams: video=%t audio=%t, want video=true audio=%t", videoSeen, audioSeen, tc.audio)
+			}
+		})
+	}
+}

--- a/internal/video/trim.go
+++ b/internal/video/trim.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"os"
 	"os/exec"
+	"time"
 
 	"github.com/sendrec/sendrec/internal/database"
 )
@@ -78,8 +79,10 @@ func TrimVideoAsync(ctx context.Context, db database.DBTX, storage ObjectStorage
 	slog.Info("trim: starting", "video_id", videoID, "start_seconds", startSeconds, "end_seconds", endSeconds)
 
 	setReadyFallback := func() {
-		if _, err := db.Exec(ctx,
-			`UPDATE videos SET status = 'ready', processing_started_at = NULL, updated_at = now() WHERE id = $1`,
+		recoveryCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 5*time.Second)
+		defer cancel()
+		if _, err := db.Exec(recoveryCtx,
+			`UPDATE videos SET status = 'ready', processing_started_at = NULL, updated_at = now() WHERE id = $1 AND status = 'processing'`,
 			videoID,
 		); err != nil {
 			slog.Error("trim: failed to set fallback ready status", "video_id", videoID, "error", err)


### PR DESCRIPTION
## What changed

- Bound remove-segments output to fit 1920×1080 at 60 fps, matching the app's existing output envelope. Apply cuts before frame-rate conversion so retained frames cannot disappear, and retime by elapsed cut duration rather than retained frame count.
- Split audio at sample-accurate boundaries with FFmpeg's native `asegment`, instead of dropping whole AAC packets with `aselect`. Reject an output with no video stream before it can replace the original.
- Give trim, composite and remove-segments failure recovery a fresh five-second database context. A timed-out job must not try to clear its processing state through its expired context; the update also leaves deleted rows alone.
- Raise the chart's starting request from 512Mi to 1Gi, retain `limits: {}`, and document the Pending/bursting tradeoff. Replace unsupported universal memory-floor claims with scoped measurements.
- Replace container-resident sampler loops with bounded host/workstation loops. Include shmem, reject ambiguous cgroup scope, retain timestamps/PIDs, check cleanup, and distinguish a reservation estimate from a hard-limit setting.

## Real staging measurement

The largest-resolution ready staging recording was 3242×2626, 1000 fps, 43.167 seconds, with audio. Both runs removed the same 200 ranges from disposable copies through the actual API. No production edit or deployment was performed.

| | Existing post-#208 image (`6219d0a`) | Patched binary |
| --- | --- | --- |
| Idle anon | 6.64 MiB | 5.57 MiB (5,836,800 bytes) |
| Peak anon | 837.30 MiB | 363.71 MiB (381,378,560 bytes) |
| Outcome | Ten-minute timeout; lower bound only | Completed in 367.3 seconds |
| N=1 estimate with 20% headroom | 1004.76 MiB | 436.45 MiB (457,654,272 bytes) |
| Margin against 512Mi | −492.76 MiB | +75.55 MiB |

Patched peak was held within 5% for 362.0 seconds (363 one-second samples). FFmpeg 6.1.2, four visible CPUs, private cgroup v2, disk-backed `/tmp`, no container/ancestor memory limit, zero shmem/swap/OOMs/restarts. Only the app, its one edit subprocess at a time and short-lived sampler commands were in the measured cgroup; transcription was disabled and no unrelated edit was active. Source/output probes ran separately outside that cgroup.

The finished output contains 2,231 video frames at 1334×1080/60 fps: video 37.183333 seconds, audio 37.172000 seconds. The patched binary SHA-256 was `534ea9aaeec27bd31464f1ca0c7c2473a761648dea84f70c71640bfc2400c5b8`; its disposable image was created at 2026-09-05 21:36 UTC from the staging runtime.

512Mi covers this completed single-job run, not every source or enabled worker. 1Gi is a conservative starting reservation, not a proven universal ceiling. The pinned chart image is still `v1.90.5`, which predates the bounds and ignores `MAX_CONCURRENT_ENCODES`; the docs call this out. A reviewed application release and explicit image upgrade are still needed—this PR does not publish a release or deploy production.

## Verification

- `go test ./...`, `go test -race ./...`, `go vet ./...`, and Go binary build passed with FFmpeg 7.1 available.
- Twelve execution regressions inspect actual encoded dimensions, frame rate, frame count, video/audio duration and empty-output rejection. They cover MP4, QuickTime, WebM, high DPI, 1000 fps, 200 dense cuts, AAC packet boundaries, first/last/adjacent cuts and cuts aimed at the output frame grid. All also passed against staging's FFmpeg 6.1.2.
- Cancellation-sensitive database regression tests cover all three edit recovery paths; the old implementation fails them.
- `pnpm typecheck` and `pnpm build` passed; only the existing bundle-size warning remained.
- Helm lint/render passed: request `1Gi`, `limits: {}`. Both Bash snippets passed syntax checks. The Docker snippet measured a deliberate 4 MiB tmpfs allocation and rejected a host-cgroup-namespace container without printing a bogus peak.
- Cleanup verified inside both app containers: no surviving edit/sampler and empty `/tmp`. All copied recordings, disposable containers/images and remote measurement files were removed. Original staging image, recording and database counts were unchanged; no unrelated work remained.

Related: #202.
