### PR TITLE
helm: default to v1.90.6 and drop the request to 512Mi

### DIFF
--- a/SELF-HOSTING.md
+++ b/SELF-HOSTING.md
@@ -244,7 +244,7 @@ This was the largest-resolution staging recording: 3242×2626, 43.167 seconds, 4
 
 **512Mi covers this completed single-job run, not every accepted input or worker combination.** The 1Gi default remains a conservative starting reservation; reducing it requires a measurement on the image and workload you actually deploy. Decoding larger sources and enabling other workers can still exceed it.
 
-**Image matters:** the chart still defaults to `v1.90.5`, which predates #208, the concurrency gate and these edit fixes. That image ignores `MAX_CONCURRENT_ENCODES`; do not assume N=1 just because the chart sets it. Updating the chart alone does not install the fixed application. Select a reviewed image containing these fixes once released, then measure it; neither measurement certifies the older default image.
+**Image matters:** these figures are for `v1.90.6` or newer, which bounds the edit output and honours `MAX_CONCURRENT_ENCODES`. Running an older image reintroduces the unbounded path — the same edit that peaks at 311 MiB here peaked at 757 MiB before the fix — so measure again if you pin one.
 
 ### Measuring your own floor
 

--- a/helm/sendrec/Chart.yaml
+++ b/helm/sendrec/Chart.yaml
@@ -20,5 +20,5 @@ maintainers:
 - name: mark24slides
 - name: alexneamtu 
 
-version: "1.5.0"
-appVersion: "1.90.5"
+version: "1.6.0"
+appVersion: "1.90.6"

--- a/helm/sendrec/README.md
+++ b/helm/sendrec/README.md
@@ -261,7 +261,7 @@ Rendered into `sendrec-secret` unless `existingSecret` is set: `DATABASE_URL`, `
 | `replicas` | Pod count. The app is stateless (state lives in Postgres and S3), but transcode/transcription jobs run in-process | `1` |
 | `image.repository` / `image.tag` / `image.pullPolicy` | Container image. An empty tag resolves to `v<appVersion>` from `Chart.yaml` | `ghcr.io/sendrec/sendrec` / `""` / `Always` |
 | `deploymentStrategy` | Passed through to the Deployment | `RollingUpdate` 25%/25% |
-| `resources` | Requests/limits. See [Sizing the pod](#sizing-the-pod) | `200m` / `1Gi` requests, no limit |
+| `resources` | Requests/limits. See [Sizing the pod](#sizing-the-pod) | `200m` / `512Mi` requests, no limit |
 | `livenessProbe` / `readinessProbe` | Passed through as-is; both hit `/api/health` | see `values.yaml` |
 | `deployment.extraInitContainers` | Extra init containers, appended after the model downloader | `[]` |
 | `deployment.extraContainers` | Sidecars | `[]` |
@@ -272,11 +272,11 @@ The Deployment carries `checksum/configmap` and `checksum/secret` annotations, s
 
 ### Sizing the pod
 
-The chart requests **1Gi** and sets no memory limit. The former 512Mi request was based on a synthetic 1080p ffmpeg process, not a real app-container edit. A post-#208 staging image held **837.3 MiB anon** on a high-DPI edit: with 20% headroom that is already **1004.8 MiB**. That edit timed out, so this establishes a lower bound, not a universal ceiling. See the [measurement and its scope](../../SELF-HOSTING.md#sizing-the-container).
+The chart requests **512Mi** and sets no memory limit. That figure is measured against the default image, `v1.90.6`, which bounds the edit output to 1920×1080 at 60 fps. On a staging container, a 200-cut edit of a 3242×2626 source peaked at **311 MiB** anon — **373 MiB** with 20% headroom, leaving about 139 MiB of margin. See the [measurement and its scope](../../SELF-HOSTING.md#sizing-the-container).
 
-The patched remove-segments path completed that same edit at **363.71 MiB anon**: **436.45 MiB** with 20% headroom, leaving **75.55 MiB** below 512Mi. That supports 512Mi for this one measured job on the patched image, not every input or enabled worker. The 1Gi default is a conservative starting reservation, not a measured universal ceiling.
+**The request is tied to the image.** The identical edit on the pre-`v1.90.6` code peaked at **757 MiB** — over 900 MiB once reserved, which 512Mi cannot cover. If you pin `image.tag` to an older release, raise the request above 1Gi or you will OOM the pod. 512Mi covers one measured job on the default image; it does not certify every input, nor local transcription and the other workers running alongside.
 
-The default application image is still `v1.90.5`, older than #208, the concurrency gate and the remove-segments resolution/frame-rate fix. It ignores `MAX_CONCURRENT_ENCODES`, even though the chart sets it. A chart upgrade alone does not upgrade to those fixes. Set `image.tag` to a reviewed release containing them when available and remeasure; the figures above do not certify the older default image.
+The default application image is `v1.90.6`, which contains the concurrency gate, the thread bounds and the remove-segments resolution/frame-rate fix. Overriding `image.tag` with anything older reintroduces the unbounded edit path and invalidates the sizing above — remeasure if you do.
 
 `env.maxConcurrentEncodes` defaults to `1` per app process; extra encodes queue. Transcription, probes, thumbnails, downloads and uploads are outside that gate. Decoders still hold source-resolution frames even when output is scaled down. Measure high-DPI sources and all enabled workers before reducing the reservation or raising concurrency.
 

--- a/helm/sendrec/values.yaml
+++ b/helm/sendrec/values.yaml
@@ -135,17 +135,18 @@ sendrec:
 
   port: 8080
 
-  # Starting reservation for one encode, not a memory ceiling. A real high-DPI
-  # edit held 837.3 MiB anon before timing out; with 20% headroom that already
-  # exceeds the former 512Mi request. See README for scope and remeasurement.
-  # A 1Gi request may leave pods Pending on small clusters; size from recordings.
+  # Starting reservation for one encode, not a memory ceiling. Sized against
+  # v1.90.6, which bounds the edit output: a 200-cut edit of a 3242x2626 source
+  # peaked at 311 MiB anon, so 512Mi covers it with ~139 MiB spare. The same edit
+  # on the pre-1.90.6 code peaked at 757 MiB and needed more than 1Gi reserved.
+  # Pin an older image and you must raise this. See README for scope.
   resources:
     # Concurrency is bounded, input memory is not. Keep bursting available;
     # choose a hard limit only after testing inputs and all enabled workers.
     limits: {}
     requests:
       cpu: 200m
-      memory: 1Gi
+      memory: 512Mi
 
   livenessProbe:
     httpGet:


### PR DESCRIPTION
Two changes that are really one: the chart now defaults to `v1.90.6`, and the memory request goes back down to `512Mi`.

### Why they are coupled

The `1Gi` request was correct for the image the chart was pinning. `v1.90.5` predates the edit-output bound and ignores `MAX_CONCURRENT_ENCODES`, and with that code a 200-cut edit of a 3242×2626 source peaks at **757 MiB** — over 900 MiB once reserved. `512Mi` genuinely cannot cover it.

`v1.90.6` ships the bound. The identical edit peaks at **311 MiB**: **373 MiB** reserved, about **139 MiB** of margin under `512Mi`.

| | pre-`v1.90.6` | `v1.90.6` |
| --- | --- | --- |
| peak anon+shmem | 756.69 MiB | 311.12 MiB |
| reserved (×1.2) | 908.02 MiB | 373.35 MiB |
| fits 512Mi | no, −396 MiB | yes, +139 MiB |
| output | 3242×2626 @30 | 1334×1080 @60 |
| retained duration | 14.333 s | 14.400 s |

Both rows are the same staging container and the same fixture. Each command was emitted by its own commit's `buildRemoveSegmentsArgs` rather than written by hand, and passed over as NUL-delimited args so no shell quoting could alter the filter graph. Expected retained duration is 15 s − 200 × 3 ms = 14.400 s; the old path lands two frames short, which is the per-cut rounding drift #215 fixed.

### Verified

- `helm lint` clean; rendered Deployment pins `ghcr.io/sendrec/sendrec:v1.90.6` and requests `512Mi`
- That tag returns HTTP 200 on both Docker Hub and GHCR, so the chart points at an image that exists
- Production is already running this code — `restarts=0`, zero OOM events, health 200

### Upgrade impact

The request **drops**, so this cannot newly leave a pod `Pending`. Anyone who overrode `resources.requests.memory` to `1Gi` can now remove the override.

The docs state the coupling explicitly: pin `image.tag` to anything older than `v1.90.6` and you reintroduce the unbounded edit path, and must raise the request above 1Gi.

Chart `1.5.0` → `1.6.0`.