### PR TITLE
feat: show the SendRec version on the settings page

### DIFF
--- a/cmd/sendrec/main.go
+++ b/cmd/sendrec/main.go
@@ -155,6 +155,7 @@ func main() {
 		WebFS:                     webFS,
 		JWTSecret:                 jwtSecret,
 		BaseURL:                   baseURL,
+		Version:                   version,
 		RegistrationEnabled:       registrationEnabled,
 		PlanBadgeEnabled:          planBadgeEnabled,
 		MaxUploadBytes:            getEnvInt64("MAX_UPLOAD_BYTES", 500*1024*1024),

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -47,6 +47,7 @@ type Config struct {
 	NoiseReductionFilter      string
 	AllowedFrameAncestors     string
 	AnalyticsScript           string
+	Version                   string
 	EmailSender               auth.EmailSender
 	CommentNotifier           video.CommentNotifier
 	ViewNotifier              video.ViewNotifier
@@ -86,6 +87,7 @@ type Server struct {
 	registrationEnabled bool
 	planBadgeEnabled    bool
 	analyticsScript     string
+	version             string
 }
 
 func New(cfg Config) *Server {
@@ -98,7 +100,7 @@ func New(cfg Config) *Server {
 		AllowedFrameAncestors: cfg.AllowedFrameAncestors,
 	}))
 
-	s := &Server{router: r, pinger: cfg.Pinger, db: cfg.DB, webFS: cfg.WebFS, enableDocs: cfg.EnableDocs, registrationEnabled: cfg.RegistrationEnabled, planBadgeEnabled: cfg.PlanBadgeEnabled, analyticsScript: cfg.AnalyticsScript}
+	s := &Server{router: r, pinger: cfg.Pinger, db: cfg.DB, webFS: cfg.WebFS, enableDocs: cfg.EnableDocs, registrationEnabled: cfg.RegistrationEnabled, planBadgeEnabled: cfg.PlanBadgeEnabled, analyticsScript: cfg.AnalyticsScript, version: cfg.Version}
 
 	if cfg.DB != nil {
 		jwtSecret := cfg.JWTSecret
@@ -544,9 +546,10 @@ func (s *Server) routes() {
 
 func (s *Server) handleHealth(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
-	// The exact build version is only useful to someone matching the deployment
-	// against known CVEs, and nothing consumes it here (SR-15). The feature flags
-	// stay: the SPA reads them to decide what to render.
+	// The SPA reads these to decide what to render: the feature flags gate UI,
+	// and the version is shown on the settings page so self-hosters can tell
+	// which build they are running (#218). Reversing SR-15: the build string is
+	// visible to anyone, which does make CVE-matching a deployment easier.
 	if s.pinger != nil {
 		if err := s.pinger.Ping(r.Context()); err != nil {
 			w.WriteHeader(http.StatusServiceUnavailable)
@@ -554,7 +557,7 @@ func (s *Server) handleHealth(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	}
-	_, _ = fmt.Fprintf(w, `{"status":"ok","registrationEnabled":%t,"planBadgeEnabled":%t}`, s.registrationEnabled, s.planBadgeEnabled)
+	_, _ = fmt.Fprintf(w, `{"status":"ok","registrationEnabled":%t,"planBadgeEnabled":%t,"version":%q}`, s.registrationEnabled, s.planBadgeEnabled, s.version)
 }
 
 func (s *Server) handleRobotsTxt(w http.ResponseWriter, r *http.Request) {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io/fs"
 	"log"
@@ -557,7 +558,13 @@ func (s *Server) handleHealth(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	}
-	_, _ = fmt.Fprintf(w, `{"status":"ok","registrationEnabled":%t,"planBadgeEnabled":%t,"version":%q}`, s.registrationEnabled, s.planBadgeEnabled, s.version)
+	// fmt %q is Go-syntax escaping, not JSON: a tag that is not valid UTF-8
+	// would emit \xff and break every caller parsing this payload.
+	version, err := json.Marshal(s.version)
+	if err != nil {
+		version = []byte(`""`)
+	}
+	_, _ = fmt.Fprintf(w, `{"status":"ok","registrationEnabled":%t,"planBadgeEnabled":%t,"version":%s}`, s.registrationEnabled, s.planBadgeEnabled, version)
 }
 
 func (s *Server) handleRobotsTxt(w http.ResponseWriter, r *http.Request) {

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -3,6 +3,7 @@ package server_test
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"crypto/sha256"
 	"encoding/hex"
 	"errors"
@@ -132,6 +133,29 @@ func TestHealthEndpointReportsVersion(t *testing.T) {
 	expected := `{"status":"ok","registrationEnabled":false,"planBadgeEnabled":false,"version":"v1.90.6"}`
 	if rec.Body.String() != expected {
 		t.Errorf("expected body %q, got %q", expected, rec.Body.String())
+	}
+}
+
+func TestHealthEndpointVersionIsAlwaysValidJSON(t *testing.T) {
+	// `git describe` returns the tag bytes verbatim, and Git accepts a tag that
+	// is not valid UTF-8. Go-syntax escaping would emit `\xff` here, which no
+	// JSON parser accepts — and every SPA page parses this payload.
+	srv := server.New(server.Config{Version: "v1.0-\xff"})
+	rec := executeRequest(srv, http.MethodGet, "/api/health")
+
+	if !json.Valid(rec.Body.Bytes()) {
+		t.Fatalf("health body is not valid JSON: %s", rec.Body.String())
+	}
+
+	var body struct {
+		Status  string `json:"status"`
+		Version string `json:"version"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("failed to decode health body: %v", err)
+	}
+	if body.Status != "ok" {
+		t.Errorf("expected status %q, got %q", "ok", body.Status)
 	}
 }
 

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -119,7 +119,17 @@ func TestHealthEndpointReturnsOK(t *testing.T) {
 		t.Errorf("expected status 200, got %d", rec.Code)
 	}
 
-	expected := `{"status":"ok","registrationEnabled":false,"planBadgeEnabled":false}`
+	expected := `{"status":"ok","registrationEnabled":false,"planBadgeEnabled":false,"version":""}`
+	if rec.Body.String() != expected {
+		t.Errorf("expected body %q, got %q", expected, rec.Body.String())
+	}
+}
+
+func TestHealthEndpointReportsVersion(t *testing.T) {
+	srv := server.New(server.Config{Version: "v1.90.6"})
+	rec := executeRequest(srv, http.MethodGet, "/api/health")
+
+	expected := `{"status":"ok","registrationEnabled":false,"planBadgeEnabled":false,"version":"v1.90.6"}`
 	if rec.Body.String() != expected {
 		t.Errorf("expected body %q, got %q", expected, rec.Body.String())
 	}
@@ -147,7 +157,7 @@ func TestHealthEndpointWithPingSuccess(t *testing.T) {
 		t.Errorf("expected status 200, got %d", rec.Code)
 	}
 
-	expected := `{"status":"ok","registrationEnabled":false,"planBadgeEnabled":false}`
+	expected := `{"status":"ok","registrationEnabled":false,"planBadgeEnabled":false,"version":""}`
 	if rec.Body.String() != expected {
 		t.Errorf("expected body %q, got %q", expected, rec.Body.String())
 	}
@@ -176,7 +186,7 @@ func TestHealthEndpointIncludesRegistrationEnabled(t *testing.T) {
 	})
 	rec := executeRequest(srv, http.MethodGet, "/api/health")
 
-	expected := `{"status":"ok","registrationEnabled":true,"planBadgeEnabled":false}`
+	expected := `{"status":"ok","registrationEnabled":true,"planBadgeEnabled":false,"version":""}`
 	if rec.Body.String() != expected {
 		t.Errorf("expected body %q, got %q", expected, rec.Body.String())
 	}
@@ -189,7 +199,7 @@ func TestHealthEndpointRegistrationDisabled(t *testing.T) {
 	})
 	rec := executeRequest(srv, http.MethodGet, "/api/health")
 
-	expected := `{"status":"ok","registrationEnabled":false,"planBadgeEnabled":false}`
+	expected := `{"status":"ok","registrationEnabled":false,"planBadgeEnabled":false,"version":""}`
 	if rec.Body.String() != expected {
 		t.Errorf("expected body %q, got %q", expected, rec.Body.String())
 	}
@@ -202,7 +212,7 @@ func TestHealthEndpointPlanBadgeEnabled(t *testing.T) {
 	})
 	rec := executeRequest(srv, http.MethodGet, "/api/health")
 
-	expected := `{"status":"ok","registrationEnabled":false,"planBadgeEnabled":true}`
+	expected := `{"status":"ok","registrationEnabled":false,"planBadgeEnabled":true,"version":""}`
 	if rec.Body.String() != expected {
 		t.Errorf("expected body %q, got %q", expected, rec.Body.String())
 	}
@@ -214,7 +224,7 @@ func TestHealthEndpointPlanBadgeDefaultDisabled(t *testing.T) {
 	})
 	rec := executeRequest(srv, http.MethodGet, "/api/health")
 
-	expected := `{"status":"ok","registrationEnabled":false,"planBadgeEnabled":false}`
+	expected := `{"status":"ok","registrationEnabled":false,"planBadgeEnabled":false,"version":""}`
 	if rec.Body.String() != expected {
 		t.Errorf("expected body %q, got %q", expected, rec.Body.String())
 	}
@@ -851,7 +861,7 @@ func TestSPADoesNotInterceptHealthEndpoint(t *testing.T) {
 		t.Errorf("expected status 200 for health endpoint with SPA, got %d", rec.Code)
 	}
 
-	expected := `{"status":"ok","registrationEnabled":false,"planBadgeEnabled":false}`
+	expected := `{"status":"ok","registrationEnabled":false,"planBadgeEnabled":false,"version":""}`
 	if rec.Body.String() != expected {
 		t.Errorf("expected health JSON, got %q", rec.Body.String())
 	}

--- a/web/src/pages/Settings.test.tsx
+++ b/web/src/pages/Settings.test.tsx
@@ -1463,4 +1463,38 @@ describe("Settings", () => {
 
     expect(screen.getByRole("button", { name: "Disconnect" })).toBeEnabled();
   });
+
+  it("shows the server version", async () => {
+    mockApiFetch
+      .mockResolvedValueOnce({ name: "Alice", email: "alice@example.com" })
+      .mockResolvedValueOnce({ notificationMode: "off" })
+      .mockResolvedValueOnce({ brandingEnabled: false })
+      .mockResolvedValueOnce([])
+      .mockRejectedValueOnce(new Error("Not Found"))
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce({ identities: [], hasPassword: false });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({ json: async () => ({ version: "v1.90.6" }) }),
+    );
+    renderSettings();
+
+    expect(await screen.findByText("SendRec v1.90.6")).toBeInTheDocument();
+  });
+
+  it("omits the version line when the server reports none", async () => {
+    mockApiFetch
+      .mockResolvedValueOnce({ name: "Alice", email: "alice@example.com" })
+      .mockResolvedValueOnce({ notificationMode: "off" })
+      .mockResolvedValueOnce({ brandingEnabled: false })
+      .mockResolvedValueOnce([])
+      .mockRejectedValueOnce(new Error("Not Found"))
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce({ identities: [], hasPassword: false });
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ json: async () => ({}) }));
+    renderSettings();
+
+    await screen.findByText("Settings");
+    expect(screen.queryByTestId("server-version")).not.toBeInTheDocument();
+  });
 });

--- a/web/src/pages/Settings/index.tsx
+++ b/web/src/pages/Settings/index.tsx
@@ -51,6 +51,14 @@ interface LoadedState {
 
 export function Settings() {
   const [loaded, setLoaded] = useState<LoadedState | null>(null);
+  const [version, setVersion] = useState("");
+
+  useEffect(() => {
+    fetch("/api/health")
+      .then((res) => res.json())
+      .then((data: { version?: string }) => setVersion(data.version ?? ""))
+      .catch(() => setVersion(""));
+  }, []);
 
   useEffect(() => {
     async function fetchProfile() {
@@ -244,6 +252,12 @@ export function Settings() {
           initialBranding={loaded.branding}
           limits={loaded.limits}
         />
+      )}
+
+      {version && (
+        <p className="settings-version" data-testid="server-version">
+          SendRec {version}
+        </p>
       )}
     </div>
   );

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -126,6 +126,12 @@ input:focus-visible {
   margin-bottom: var(--space-6);
 }
 
+.settings-version {
+  font-size: 13px;
+  color: var(--color-text-secondary);
+  text-align: center;
+}
+
 .settings-section h2 {
   font-size: 18px;
   font-weight: 700;


### PR DESCRIPTION
Fixes #218.

Adds `version` back to the `/api/health` payload (sourced from the existing `main.version` ldflag) and renders it under the settings sections as `SendRec <version>`. The line is hidden only when the server reports an empty version — a `go run` build reports the `dev` default and renders `SendRec dev`.

## Security trade-off, stated explicitly

`version` was deliberately removed from `/api/health` under SR-15:

> The exact build version is only useful to someone matching the deployment against known CVEs, and nothing consumes it here.

This PR reverses that. `/api/health` is unauthenticated, so the build string is public to anyone who curls it. The alternative — serving it from an authenticated endpoint and gating the Settings line on login — keeps that property, and I flagged it before implementing; the decision was to put it back on `/api/health`. Worth a second look at review time if the exposure isn't wanted.

The OpenAPI `HealthResponse` schema already declared `version`; only the handler had dropped it, so docs and behaviour now agree again.

## Review fix: JSON encoding

The first revision formatted the version with `fmt` `%q`, which is Go-syntax escaping, not JSON. Git accepts an annotated tag whose bytes are not valid UTF-8, and `git describe` passes them through to the ldflag, so such a build served `"version":"v1.0-\xff"` — invalid JSON. Every SPA page parses `/api/health`, so that build would have silently lost registration and plan-badge state on Login, Register and Layout too, not just the version line. Now encoded with `encoding/json`.

## Tests

`TestHealthEndpointReportsVersion` covers the populated case, `TestHealthEndpointVersionIsAlwaysValidJSON` pins the invalid-UTF-8 tag, and every existing health-body assertion pins the empty-version default. Two Settings tests cover the rendered line and its absence.

Go: `go build ./...`, `go vet`, `internal/server` and `internal/docs` tests pass (run in a `golang:1.26-alpine` container — Go isn't installed on this machine, so the rest of the Go suite is on CI).
Frontend: 767 tests pass, `tsc --noEmit` clean.