### PR TITLE
fix: keep segment-removal expressions within ffmpeg's depth limit

### DIFF
--- a/internal/video/remove_segments.go
+++ b/internal/video/remove_segments.go
@@ -130,7 +130,22 @@ func buildSegmentFilter(segments []segmentRange) string {
 	for i, seg := range segments {
 		parts[i] = fmt.Sprintf("between(t,%.3f,%.3f)", seg.Start, seg.End)
 	}
-	return strings.Join(parts, "+")
+	return balancedSum(parts)
+}
+
+// balancedSum joins terms with '+' as a balanced tree. ffmpeg's expression
+// parser (libavutil/eval.c, MAX_DEPTH) rejects trees deeper than 100 levels,
+// and a flat a+b+c chain nests one level per term — so the 200 cuts the API
+// allows overflow it on ffmpeg 7+. Balanced, depth grows with log2(n).
+func balancedSum(parts []string) string {
+	switch len(parts) {
+	case 0:
+		return "0"
+	case 1:
+		return parts[0]
+	}
+	mid := len(parts) / 2
+	return "(" + balancedSum(parts[:mid]) + "+" + balancedSum(parts[mid:]) + ")"
 }
 
 // audioCodecForContentType pairs the audio codec with the container the output
@@ -181,7 +196,7 @@ func buildRemoveSegmentsArgs(inputPath, outputPath, contentType string, segments
 	// otherwise erase retained source frames. Bound frames before scaling/encoding.
 	// Shift by elapsed cut time, not retained frame count: rounding every cut to
 	// whole frames accumulates A/V drift when many boundaries fall between frames.
-	videoFilter := fmt.Sprintf("[0:v]setpts=PTS-STARTPTS,select='not(%s)',setpts='PTS-(%s)/TB',fps=60,scale='min(1920,iw)':'min(1080,ih)':force_original_aspect_ratio=decrease:force_divisible_by=2[v]", betweenExpr, strings.Join(removedTime, "+"))
+	videoFilter := fmt.Sprintf("[0:v]setpts=PTS-STARTPTS,select='not(%s)',setpts='PTS-%s/TB',fps=60,scale='min(1920,iw)':'min(1080,ih)':force_original_aspect_ratio=decrease:force_divisible_by=2[v]", betweenExpr, balancedSum(removedTime))
 
 	args := append(globalThreads(), inputThreads()...)
 	args = append(args, "-i", inputPath)

--- a/internal/video/remove_segments_depth_test.go
+++ b/internal/video/remove_segments_depth_test.go
@@ -1,0 +1,69 @@
+package video
+
+import (
+	"strings"
+	"testing"
+)
+
+// maxChainDepth mirrors how libavutil/eval.c measures an expression: every
+// binary operator adds one level over its deeper operand, and parentheses only
+// group. The parser rejects anything deeper than MAX_DEPTH (100).
+//
+// It walks the expression once, tracking for every open paren how many '+'
+// operands it has seen, and returns the deepest operator tree.
+func maxChainDepth(expr string) int {
+	type frame struct{ plus, childMax int }
+	stack := []frame{{}}
+	for _, c := range expr {
+		top := &stack[len(stack)-1]
+		switch c {
+		case '(':
+			stack = append(stack, frame{})
+		case ')':
+			done := stack[len(stack)-1]
+			stack = stack[:len(stack)-1]
+			d := done.plus + done.childMax
+			parent := &stack[len(stack)-1]
+			if d > parent.childMax {
+				parent.childMax = d
+			}
+		case '+':
+			top.plus++
+		}
+	}
+	root := stack[0]
+	return root.plus + root.childMax
+}
+
+func TestSegmentExpressionsStayWithinFFmpegDepthLimit(t *testing.T) {
+	segments := make([]segmentRange, maxSegments)
+	for i := range segments {
+		segments[i] = segmentRange{Start: float64(i), End: float64(i) + 0.5}
+	}
+	args := buildRemoveSegmentsArgs("in.mp4", "out.mp4", "video/mp4", segments, true)
+	var filter string
+	for i, a := range args {
+		if a == "-filter_complex" {
+			filter = args[i+1]
+		}
+	}
+	if filter == "" {
+		t.Fatal("no -filter_complex in args")
+	}
+	// Both the select and the setpts expressions carry one term per segment.
+	for _, expr := range []string{"select='", "setpts='PTS-"} {
+		start := strings.Index(filter, expr)
+		if start < 0 {
+			t.Fatalf("expression %q not found in filter", expr)
+		}
+		rest := filter[start+len(expr):]
+		end := strings.Index(rest, "'")
+		if expr == "setpts='PTS-" {
+			end = strings.Index(rest, "/TB")
+		}
+		body := rest[:end]
+		if d := maxChainDepth(body); d > 100 {
+			t.Errorf("%s expression nests %d deep for %d segments; ffmpeg rejects more than 100", expr, d, maxSegments)
+		}
+	}
+}


### PR DESCRIPTION
Latent production break, found while reviewing #219/#220: `TestRemoveSegmentsBoundsActualOutput/dense_cuts` and `/retained_frames_between_output_frames` fail on ffmpeg 8 — on `main`, unrelated to either PR.

## Root cause

ffmpeg's expression parser ([libavutil/eval.c](https://github.com/FFmpeg/FFmpeg/blob/master/libavutil/eval.c)) rejects expression trees deeper than `MAX_DEPTH = 100`. `buildRemoveSegmentsArgs` joins one `between()` term per cut with `+` for `select`, and one `gte()` term per cut for `setpts`. A flat `a+b+c` chain nests one level per term, so `maxSegments = 200` produces a 199-deep tree and ffmpeg fails with `Error while parsing expression … Out of memory`. The video stays in `processing`.

Today's production image is `alpine:3.21` → ffmpeg 6.1, which has no such limit, so this only bites self-hosters on a newer ffmpeg — and the next base-image bump.

## Fix

`balancedSum` joins the terms as a balanced tree, so depth grows with log2(n): 200 cuts nest 8 deep. Single-segment output is unchanged.

## Verification

| ffmpeg | before | after |
|---|---|---|
| 8.1.2 (`golang:1.26-alpine` + `apk add ffmpeg`) | `dense cuts`, `retained frames…` fail | full `internal/video` passes |
| 6.1.2 (`alpine:3.21`, production) | passes | passes |

`TestSegmentExpressionsStayWithinFFmpegDepthLimit` measures the depth of both generated expressions at `maxSegments` the way eval.c does, so the regression is caught in CI without ffmpeg (fails on `main` at 199, passes here). `golangci-lint` clean.